### PR TITLE
Add js-langserver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ that config.
 - [gopls](#gopls)
 - [hie](#hie)
 - [intelephense](#intelephense)
+- [js_langserver](#js_langserver)
 - [jsonls](#jsonls)
 - [julials](#julials)
 - [leanls](#leanls)
@@ -1225,6 +1226,30 @@ require'nvim_lsp'.intelephense.setup{}
     log_level = 2
     on_init = function to handle changing offsetEncoding
     root_dir = root_pattern("composer.json", ".git")
+```
+
+## js_langserver
+
+https://github.com/tbodt/js-langserver
+
+`js-langserver` can be installed via `:LspInstall js-langserver` or by yourself with `npm`:
+```sh
+npm install -g js-langserver
+```
+
+Can be installed in Nvim with `:LspInstall js_langserver`
+
+```lua
+require'nvim_lsp'.js_langserver.setup{}
+
+  Default Values:
+    capabilities = default capabilities, with offsetEncoding utf-8
+    cmd = { "js-langserver", "--stdio" }
+    filetypes = { "javascript", "javascriptreact", "javascript.jsx" }
+    log_level = 2
+    on_init = function to handle changing offsetEncoding
+    root_dir = root_pattern("package.json")
+    settings = {}
 ```
 
 ## jsonls

--- a/lua/nvim_lsp/js_langserver.lua
+++ b/lua/nvim_lsp/js_langserver.lua
@@ -1,0 +1,56 @@
+vim.cmd('packadd nvim-lsp')
+
+local configs = require 'nvim_lsp/configs'
+local util = require 'nvim_lsp/util'
+local lsp = vim.lsp
+
+local server_name = "js_langserver"
+local package_name = "js-langserver"
+local bin_name = package_name
+
+local installer = util.npm_installer {
+  server_name = server_name;
+  packages = {package_name};
+  binaries = {bin_name};
+}
+
+configs[server_name] = {
+  default_config = util.utf8_config {
+    cmd = {bin_name, "--stdio"};
+    filetypes = {"javascript", "javascriptreact", "javascript.jsx"};
+    root_dir = util.root_pattern("package.json");
+    log_level = lsp.protocol.MessageType.Warning;
+    settings = {};
+  };
+  on_new_config = function(new_config)
+    local install_info = installer.info()
+    if install_info.is_installed then
+      if type(new_config.cmd) == 'table' then
+        -- Try to preserve any additional args from upstream changes.
+        new_config.cmd[1] = install_info.binaries[bin_name]
+      else
+        new_config.cmd = {install_info.binaries[bin_name]}
+      end
+    end
+  end;
+  docs = {
+    description = [[
+https://github.com/tbodt/js-langserver
+
+`js-langserver` can be installed via `:LspInstall js-langserver` or by yourself with `npm`:
+```sh
+npm install -g js-langserver
+```
+]];
+    default_config = {
+      root_dir = [[root_pattern("package.json")]];
+      on_init = [[function to handle changing offsetEncoding]];
+      capabilities = [[default capabilities, with offsetEncoding utf-8]];
+    };
+  };
+}
+
+configs[server_name].install = installer.install
+configs[server_name].install_info = installer.info
+
+-- vim:et ts=2 sw=2


### PR DESCRIPTION
For a minimal test:

1. Make sure you have a `lua require'nvim_lsp'.js_langserver.setup{}` or similar in your `init.vim`
1.  `mkdir test && cd test`
1.  Create a `package.json`:
    ```json
    {
      "name": "test",
      "version": "0.0.1",
      "description": "test lsp",
      "main": "index.js",
      "keywords": [],
      "author": "",
      "license": "ISC",
      "devDependencies": {
        "eslint": "^6.8.0"
      },
      "eslintConfig": {
        "env": {
          "browser": true,
          "commonjs": true,
          "es6": true
        },
        "extends": "eslint:recommended",
        "globals": {
          "Atomics": "readonly",
          "SharedArrayBuffer": "readonly"
        },
        "parserOptions": {
          "ecmaVersion": 2018
        },
        "rules": {}
      }
    }
    ```
1.  `npm i` (You might be able to use a globally installed version of `eslint`?)
1.  install `js-langserver`:
    ```
    npm i -g https://github.com/tbodt/js-langserver/tarball/d59d7d8
    ```
    or run `:LspInstall js_langserver` and (most likely) you will need to add a `.tern-project` that looks something like:
    ```json
    {
      "plugins": {
        "node": {}
      }
    }
    ```
1.  Create an `index.js`:
    ```javascript
    console.log(x);
    ```

You should see an error: `'x' is not defined`
