### PR TITLE
MessageType: add None to MessageType and rename MessageType to Severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ additional optional properties.
 local nvim_lsp = require'nvim_lsp'
 nvim_lsp.texlab.setup{
   name = 'texlab_fancy';
-  log_level = vim.lsp.protocol.MessageType.Log;
-  message_level = vim.lsp.protocol.MessageType.Log;
+  log_level = nvim_lsp.util.Severity.Log;
+  message_level = nvim_lsp.util.Severity.Log;
   settings = {
     latex = {
       build = {
@@ -168,14 +168,25 @@ nvim_lsp.SERVER.setup{config}
     Server may specify a default value.
 
   {log_level}
-    controls the level of logs to show from window/logMessage notifications. Defaults to
-    vim.lsp.protocol.MessageType.Warning instead of
-    vim.lsp.protocol.MessageType.Log.
+    controls the level of logs to show from window/logMessage notifications.
+    Defaults to nvim_lsp.util.Severity.Warning.
+    You can set
+      - nvim_lsp.util.Severity.None
+      - nvim_lsp.util.Severity.Error
+      - nvim_lsp.util.Severity.Warning
+      - nvim_lsp.util.Severity.Info
+      - nvim_lsp.util.Severity.Log
 
   {message_level}
-    controls the level of messages to show from window/showMessage notifications. Defaults to
-    vim.lsp.protocol.MessageType.Warning instead of
-    vim.lsp.protocol.MessageType.Log.
+    controls the level of messages to show from window/showMessage notifications.
+    Defaults to vim.lsp.protocol.Severity.Warning.
+    Defaults to nvim_lsp.util.Severity.Warning.
+    You can set
+      - nvim_lsp.util.Severity.None
+      - nvim_lsp.util.Severity.Error
+      - nvim_lsp.util.Severity.Warning
+      - nvim_lsp.util.Severity.Info
+      - nvim_lsp.util.Severity.Log
 
   {settings}
     Map with case-sensitive keys corresponding to `workspace/configuration`
@@ -3178,7 +3189,6 @@ require'nvim_lsp'.sumneko_lua.setup{}
 
   Default Values:
     filetypes = { "lua" }
-    log_level = 2
     root_dir = root_pattern(".git") or os_homedir
 ```
 

--- a/lua/nvim_lsp/configs.lua
+++ b/lua/nvim_lsp/configs.lua
@@ -24,8 +24,8 @@ function configs.__newindex(t, config_name, config_def)
   local M = {}
 
   local default_config = tbl_extend("keep", config_def.default_config, {
-    log_level = lsp.protocol.MessageType.Warning;
-    message_level = lsp.protocol.MessageType.Warning;
+    log_level = util.Severity.Warning;
+    message_level = util.Severity.Warning;
     settings = vim.empty_dict();
     init_options = vim.empty_dict();
     callbacks = {};

--- a/lua/nvim_lsp/sumneko_lua.lua
+++ b/lua/nvim_lsp/sumneko_lua.lua
@@ -97,7 +97,6 @@ configs[name] = {
     root_dir = function(fname)
       return util.find_git_ancestor(fname) or vim.loop.os_homedir()
     end;
-    log_level = vim.lsp.protocol.MessageType.Warning;
   };
   on_new_config = function(config)
     installer.configure(config)

--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -7,6 +7,8 @@ local fn = vim.fn
 
 local M = {}
 
+M.Severity = vim.tbl_extend("keep", lsp.protocol.MessageType, { None = 0 })
+
 function M.validate_bufnr(bufnr)
   validate {
     bufnr = { bufnr, 'n' }

--- a/scripts/README_template.md
+++ b/scripts/README_template.md
@@ -75,8 +75,8 @@ additional optional properties.
 local nvim_lsp = require'nvim_lsp'
 nvim_lsp.texlab.setup{
   name = 'texlab_fancy';
-  log_level = vim.lsp.protocol.MessageType.Log;
-  message_level = vim.lsp.protocol.MessageType.Log;
+  log_level = nvim_lsp.util.Severity.Log;
+  message_level = nvim_lsp.util.Severity.Log;
   settings = {
     latex = {
       build = {
@@ -168,14 +168,25 @@ nvim_lsp.SERVER.setup{config}
     Server may specify a default value.
 
   {log_level}
-    controls the level of logs to show from window/logMessage notifications. Defaults to
-    vim.lsp.protocol.MessageType.Warning instead of
-    vim.lsp.protocol.MessageType.Log.
+    controls the level of logs to show from window/logMessage notifications.
+    Defaults to nvim_lsp.util.Severity.Warning.
+    You can set
+      - nvim_lsp.util.Severity.None
+      - nvim_lsp.util.Severity.Error
+      - nvim_lsp.util.Severity.Warning
+      - nvim_lsp.util.Severity.Info
+      - nvim_lsp.util.Severity.Log
 
   {message_level}
-    controls the level of messages to show from window/showMessage notifications. Defaults to
-    vim.lsp.protocol.MessageType.Warning instead of
-    vim.lsp.protocol.MessageType.Log.
+    controls the level of messages to show from window/showMessage notifications.
+    Defaults to vim.lsp.protocol.Severity.Warning.
+    Defaults to nvim_lsp.util.Severity.Warning.
+    You can set
+      - nvim_lsp.util.Severity.None
+      - nvim_lsp.util.Severity.Error
+      - nvim_lsp.util.Severity.Warning
+      - nvim_lsp.util.Severity.Info
+      - nvim_lsp.util.Severity.Log
 
   {settings}
     Map with case-sensitive keys corresponding to `workspace/configuration`


### PR DESCRIPTION
Add None because the user has no way to hide logMessage and showMessage.
ref: #127