### PR TITLE
Show correct lua syntax for configuring rust-analyzer

### DIFF
--- a/lua/nvim_lsp/rust_analyzer.lua
+++ b/lua/nvim_lsp/rust_analyzer.lua
@@ -6,6 +6,9 @@ configs.rust_analyzer = {
     cmd = {"rust-analyzer"};
     filetypes = {"rust"};
     root_dir = util.root_pattern("Cargo.toml", "rust-project.json");
+    settings = {
+      ["rust-analyzer"] = {}
+    }
   };
   docs = {
     package_json = "https://raw.githubusercontent.com/rust-analyzer/rust-analyzer/master/editors/code/package.json";


### PR DESCRIPTION
Hi! It took me a while (knowing neither lua not vimscript) to figure out how to pass settings to rust-analyzer, so I thought it would be nice to document it. 

I am not sure if this change will actually be reflected in readme. Running `nvim -R -Es +'set rtp+=$PWD' +'luafile scripts/docgen.lua'` did nothing for me, so I am not sure...