### PR TITLE
feat(javascript/typescript) add javascript-typescript-langserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ that config.
 - [hie](#hie)
 - [html](#html)
 - [intelephense](#intelephense)
+- [javascript_typescript_langserver](#javascript_typescript_langserver)
 - [jsonls](#jsonls)
 - [julials](#julials)
 - [kotlin_language_server](#kotlin_language_server)
@@ -2081,6 +2082,25 @@ require'nvim_lsp'.intelephense.setup{}
     cmd = { "intelephense", "--stdio" }
     filetypes = { "php" }
     root_dir = root_pattern("composer.json", ".git")
+```
+
+## javascript_typescript_langserver
+
+https://github.com/sourcegraph/javascript-typescript-langserver
+
+`javascript_typescript_langserver` can be installed via `:LspInstall javascript_typescript_langserver` or by yourself with `npm`:
+```sh
+npm install -g javascript-typescript-langserver
+```
+
+Can be installed in Nvim with `:LspInstall javascript_typescript_langserver`
+
+```lua
+require'nvim_lsp'.javascript_typescript_langserver.setup{}
+  Default Values:
+    cmd = { "javascript-typescript-stdio" }
+    filetypes = {"javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx"};
+    root_dir = root_pattern("package.json", "tsconfig.json", ".git");
 ```
 
 ## jsonls

--- a/lua/nvim_lsp/javascript_typescript_langserver.lua
+++ b/lua/nvim_lsp/javascript_typescript_langserver.lua
@@ -1,0 +1,47 @@
+local configs = require 'nvim_lsp/configs'
+local util = require 'nvim_lsp/util'
+
+local server_name = "javascript_typescript_langserver"
+local bin_name = "javascript-typescript-stdio"
+
+local installer = util.npm_installer {
+  server_name = server_name;
+  packages = { "javascript-typescript-langserver" };
+  binaries = {bin_name};
+}
+
+configs[server_name] = {
+  default_config = {
+    cmd = { bin_name };
+    filetypes = {"javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx"};
+    root_dir = util.root_pattern("package.json", "tsconfig.json", ".git");
+  };
+  on_new_config = function(new_config)
+    local install_info = installer.info()
+    if install_info.is_installed then
+      if type(new_config.cmd) == 'table' then
+        -- Try to preserve any additional args from upstream changes.
+        new_config.cmd[1] = install_info.binaries[bin_name]
+      else
+        new_config.cmd = {install_info.binaries[bin_name]}
+      end
+    end
+  end;
+  docs = {
+    description = [[
+https://github.com/sourcegraph/javascript-typescript-langserver
+
+`javascript-typescript-langserver` can be installed via `:LspInstall javascript-typescript-langserver` or by yourself with `npm`:
+```sh
+npm install -g javascript-typescript-langserver
+```
+]];
+    default_config = {
+      root_dir = [[root_pattern("package.json", "tsconfig.json", ".git")]];
+    };
+  };
+}
+
+configs[server_name].install = installer.install
+configs[server_name].install_info = installer.info
+-- vim:et ts=2 sw=2


### PR DESCRIPTION
The current typescript / javascript language server ([typescript-language-server](https://github.com/theia-ide/typescript-language-server)) is no longer actively maintained ([source](https://github.com/theia-ide/typescript-language-server/issues/141)).

This PR adds support for [javascript-typescript-langserver](https://github.com/sourcegraph/javascript-typescript-langserver), which is the most active js / ts language server I could find.

Fixes #250.