### PR TITLE
change Julia LS to use the new dedicated neovim LS wrapper LSPNeovim.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -2274,14 +2274,10 @@ require'nvim_lsp'.jsonls.setup{}
 ## julials
 
 https://github.com/julia-vscode/julia-vscode
-`LanguageServer.jl` can be installed via `:LspInstall julials` or by yourself the `julia` and `Pkg`:
-```sh
-julia --project=/home/runner/.cache/nvim/nvim_lsp/julials -e 'using Pkg; Pkg.add("LanguageServer"); Pkg.add("SymbolServer")'
-```
-If you want to install the LanguageServer manually, you will have to ensure that the Julia environment is stored in this location:
-```vim
-:lua print(require'nvim_lsp'.util.path.join(require'nvim_lsp'.util.base_install_dir, "julials"))
-```
+One can install [LSPNeovim](https://github.com/ExpandingMan/LSPNeovim.jl) by doing
+`:LSPInstall julials`.  `LSPNeovim` is a wrapper to
+[LanguageServer.jl](https://github.com/julia-vscode/LanguageServer.jl) for improved
+compatibility with `nvim-lsp`.
     
 Can be installed in Nvim with `:LspInstall julials`
 This server accepts configuration via the `settings` key.
@@ -2495,7 +2491,10 @@ require'nvim_lsp'.julials.setup{}
   Commands:
   
   Default Values:
-    cmd = { "julia", "--project=/home/runner/.cache/nvim/nvim_lsp/julials", "--startup-file=no", "--history-file=no", "-e", '        using Pkg;\n        Pkg.instantiate()\n        using LanguageServer; using SymbolServer;\n        depot_path = get(ENV, "JULIA_DEPOT_PATH", "")\n        project_path = pwd()\n        # Make sure that we only load packages from this environment specifically.\n        empty!(LOAD_PATH)\n        push!(LOAD_PATH, "@")\n        @info "Running language server" env=Base.load_path()[1] pwd() project_path depot_path\n        server = LanguageServer.LanguageServerInstance(stdin, stdout, project_path, depot_path);\n        server.runlinter = true;\n        run(server);\n        ' }
+    cmd = {
+        "julia", "--project=$HOME/.cache/nvim/nvim_lsp/julials", "--startup-file=no", "--history-file=no",
+        "$HOME/.cache/nvim/nvim_lsp/LSPNeovim/bin/run.jl"
+    };
     filetypes = { "julia" }
     root_dir = <function 1>
 ```

--- a/lua/nvim_lsp/julials.lua
+++ b/lua/nvim_lsp/julials.lua
@@ -1,25 +1,15 @@
 local configs = require 'nvim_lsp/configs'
 local util = require 'nvim_lsp/util'
 
-local environment_directory = util.path.join(util.base_install_dir, "LSPNeovim")
+local envdir = util.path.join(util.base_install_dir, "LSPNeovim")
 
--- determine appropriate project argument
--- TODO not entirely sure when this is evaluated, so it may not be safe
-local function envdirstring()
-  dir = util.path.join(util.base_install_dir, "LSPNeovim")
-  if util.path.is_dir(dir) then
-    return "--project=" .. dir
-  else
-    return nil
-  end
-end
+local runscript = util.path.join(envdir, "bin", "run.jl")
 
--- TODO project string
 configs.julials = {
   default_config = {
     cmd = {
-        "julia", envdirstring(), "--startup-file=no", "--history-file=no",
-        "-e", "using LSPNeovim; LSPNeovim.run()"
+        "julia", "--project=" .. envdir, "--startup-file=no", "--history-file=no",
+        runscript
     };
     filetypes = {'julia'};
     root_dir = function(fname)
@@ -38,13 +28,13 @@ environment by doing `Pkg.add("LSPNeovim")`.
 configs.julials.install = function()
 
   local script = [[julia --startup-file=no -e 'using LibGit2; LibGit2.clone("https://github.com/ExpandingMan/LSPNeovim.jl", "]] ..
-    environment_directory .. [[")']]
+    envdir .. [[")']]
 
   util.sh(script, vim.loop.os_homedir())
 end
 
 configs.julials.install_info = function()
-  local script = [[julia --startup-file=no --project=]] .. (envdirstring() or "") .. [[ -e 'using LSPNeovim']]
+  local script = [[julia --startup-file=no --project=]] .. envdir .. [[ -e 'using LSPNeovim']]
 
   local status = pcall(vim.fn.system, script)
 

--- a/lua/nvim_lsp/julials.lua
+++ b/lua/nvim_lsp/julials.lua
@@ -34,13 +34,7 @@ configs.julials.install = function()
 end
 
 configs.julials.install_info = function()
-  local script = [[julia --startup-file=no --project=]] .. envdir .. [[ -e 'using LSPNeovim']]
-
-  local status = pcall(vim.fn.system, script)
-
-  return {
-    is_installed = status and vim.v.shell_error == 0;
-  }
+  return {is_installed=util.path.is_file(util.path.join(envdir,"Project.toml"))}
 end
 
 --- vim:et ts=2 sw=2


### PR DESCRIPTION
This change is to make nvim-lsp use the package [LSPNeovim.jl](https://github.com/ExpandingMan/LSPNeovim.jl) by default.  This simplifies the interface and resolves some issues, see discussion [here](https://github.com/ExpandingMan/LSPNeovim.jl/issues/1).

From conversations with others from the Julia community involved with LanguageServer.jl (@kdheepak , @davidanthoff, @non-Jedi), it seems there is consensus we should do this.  If you are involved with LanguageServer.jl please thumbs up/down this PR.