### PR TITLE
Allow to use filename patterns on root_pattern

### DIFF
--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -290,7 +290,7 @@ function M.root_pattern(...)
   local patterns = vim.tbl_flatten {...}
   local function matcher(path)
     for _, pattern in ipairs(patterns) do
-      if M.path.exists(M.path.join(path, pattern)) then
+      if M.path.exists(vim.fn.glob(M.path.join(path, pattern))) then
         return path
       end
     end


### PR DESCRIPTION
This pull request will allow to use filename patterns on `root_pattern` function. So will possible to use something like:

```lua
root_dir = util.root_pattern("*.sln");
```