### PR TITLE
Added optional extra parameter to on_new_config method for the root directory

### DIFF
--- a/lua/nvim_lsp/configs.lua
+++ b/lua/nvim_lsp/configs.lua
@@ -126,10 +126,10 @@ function configs.__newindex(t, config_name, config_def)
 
       add_callbacks(new_config)
       if config_def.on_new_config then
-        pcall(config_def.on_new_config, new_config)
+        pcall(config_def.on_new_config, new_config, _root_dir)
       end
       if config.on_new_config then
-        pcall(config.on_new_config, new_config)
+        pcall(config.on_new_config, new_config, _root_dir)
       end
 
       new_config.on_init = util.add_hook_after(new_config.on_init, function(client, _result)


### PR DESCRIPTION
For some lsp configs, it's helpful to have access to the root directory that was chosen for the new config.  For example, it is common for python to use a `.venv` directory at the root of the project that includes the python interpreter that should be used for the project, which needs to be specified to the server at initialization time.