### PR TITLE
Switch to Lua on_exit callback in util.sh

### DIFF
--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -415,24 +415,12 @@ function M.sh(script, cwd)
   -- and makes it easy and intuitive to cancel the operation with Ctrl-C
   api.nvim_command("10new | startinsert")
   local bufnr = api.nvim_get_current_buf()
-
-  -- TODO: The on_exit callback needs to be a VimL function, so here's a quick
-  -- and dirty way of creating one with a hopefully unique name, so that
-  -- different runs of M.sh don't stomp on each other's callbacks (or some
-  -- other VimL functions for that matter). If it ever becomes possible to pass
-  -- Lua callbacks to termopen/jobstart, switch to a local Lua function closing
-  -- over bufnr as a much cleaner alternative.
-  -- See https://github.com/neovim/neovim/issues/7607
-  local viml_on_exit = "Nvim_lspUtilShOn_exit"..bufnr
-  api.nvim_command([[
-    function! ]]..viml_on_exit..[[(job_id, code, event_type)
-      if !a:code
-        silent bwipeout! ]]..bufnr..[[|
-      endif
-    endfunction
-  ]])
-
-  fn.termopen({"sh", "-c", script}, {cwd = cwd, on_exit = viml_on_exit})
+  local function on_exit(job_id, code, event_type)
+    if code == 0 then
+      api.nvim_command("silent bwipeout! "..bufnr)
+    end
+  end
+  fn.termopen({"sh", "-c", script}, {cwd = cwd, on_exit = on_exit})
 end
 
 function M.format_vspackage_url(extension_name)


### PR DESCRIPTION
With neovim/neovim#12507 merged, we can get rid of the hacky global VimL callback :tada: