### PR TITLE
[elixirls] change root dir for umbrella project

### DIFF
--- a/lua/nvim_lsp/elixirls.lua
+++ b/lua/nvim_lsp/elixirls.lua
@@ -73,7 +73,7 @@ configs[server_name] = {
     cmd = { cmd };
     filetypes = {"elixir", "eelixir"};
     root_dir = function(fname)
-        return util.root_pattern("mix.exs", ".git")(fname) or vim.loop.os_homedir()
+        return util.root_pattern("mix.lock", ".git")(fname) or vim.loop.os_homedir()
     end;
     };
     on_new_config = function(config)
@@ -100,7 +100,7 @@ require'nvim_lsp'.elixirls.setup{
 ```
 ]];
             default_config = {
-                root_dir = [[root_pattern("mix.exs", ".git") or vim.loop.os_homedir()]];
+                root_dir = [[root_pattern("mix.lock", ".git") or vim.loop.os_homedir()]];
             };
     };
 }


### PR DESCRIPTION
@mortepau 
What do you think about it?
This code fix "go to definition"
before
```
find . -name '*elixir_ls*'
./.elixir_ls
./apps/app_name1/.elixir_ls
./apps/app_name2/.elixir_ls
./apps/app_name3/.elixir_ls
./apps/app_name4/.elixir_ls
```
after
```
find . -name '*elixir_ls*'
./.elixir_ls
```