### PR TITLE
add default for kotlin-language-server cmd

### DIFF
--- a/lua/nvim_lsp/kotlin_language_server.lua
+++ b/lua/nvim_lsp/kotlin_language_server.lua
@@ -13,6 +13,7 @@ configs.kotlin_language_server = {
   default_config = {
     filetypes = { "kotlin" };
     root_dir = util.root_pattern("settings.gradle");
+    cmd = {"kotlin-language-server"};
   };
   docs = {
     package_json = "https://raw.githubusercontent.com/fwcd/vscode-kotlin/master/package.json";
@@ -27,6 +28,7 @@ configs.kotlin_language_server = {
     ]];
     default_config = {
       root_dir = [[root_pattern("settings.gradle")]];
+      cmd = {"kotlin-language-server"};
       capabilities = [[
       smart code completion,
       diagnostics,


### PR DESCRIPTION
It is not that easy to find out what needs to happen for the language server command to be picked up. I think this can help a lot of newcomers to quickly get started with Kotlin and the language client.