### PR TITLE
Check flutter path for dart sdk before checking dart path

### DIFF
--- a/lua/nvim_lsp/dartls.lua
+++ b/lua/nvim_lsp/dartls.lua
@@ -5,12 +5,12 @@ local server_name = "dartls"
 local bin_name = "dart"
 
 local find_dart_sdk_root_path = function()
-  if vim.fn["executable"]("dart") == 1 then
-    return vim.fn["resolve"](vim.fn["exepath"]("dart"))
-  elseif vim.fn["executable"]("flutter") == 1 then
+  if vim.fn["executable"]("flutter") == 1 then
     local flutter_path = vim.fn["resolve"](vim.fn["exepath"]("flutter"))
     local flutter_bin = vim.fn["fnamemodify"](flutter_path, ":h")
     return flutter_bin.."/cache/dart-sdk/bin/dart"
+  elseif vim.fn["executable"]("dart") == 1 then
+    return vim.fn["resolve"](vim.fn["exepath"]("dart"))
   else
     return ''
   end


### PR DESCRIPTION
Since most of the time user just install the flutter sdk and the dart path is present in `~/flutter/bin/dart` it would be better to check first for the flutter path since even if a user has flutter path set the elseif part will be ignored every time.