### PR TITLE
Fix terraformls link

### DIFF
--- a/lua/nvim_lsp/terraformls.lua
+++ b/lua/nvim_lsp/terraformls.lua
@@ -10,7 +10,7 @@ configs.terraformls = {
   docs = {
     package_json = "https://raw.githubusercontent.com/hashicorp/vscode-terraform/master/package.json";
     description = [[
-https://github.com/juliosueiras/terraform-lsp
+https://github.com/hashicorp/terraform-ls
 
 Terraform language server
 Download a released binary from https://github.com/hashicorp/terraform-ls/releases.


### PR DESCRIPTION
Fix url.

[Switch to Hashicorp's official Terraform language server by lithammer · Pull Request \#345 · neovim/nvim\-lspconfig](https://github.com/neovim/nvim-lspconfig/pull/345)