### PR TITLE
Fix missing argument to cmd for terraform-ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3150,7 +3150,7 @@ require'lspconfig'.omnisharp.setup{}
   Commands:
   
   Default Values:
-    cmd = { "/home/runner/.cache/nvim/lspconfig/omnisharp/run", "--languageserver", "--hostPID", "2543" }
+    cmd = { "/home/runner/.cache/nvim/lspconfig/omnisharp/run", "--languageserver", "--hostPID", "2551" }
     filetypes = { "cs", "vb" }
     init_options = {}
     on_new_config = <function 1>
@@ -4947,7 +4947,7 @@ require'lspconfig'.terraformls.setup{}
   Commands:
   
   Default Values:
-    cmd = { "terraform-ls" }
+    cmd = { "terraform-ls", "serve" }
     filetypes = { "terraform" }
     root_dir = root_pattern(".terraform", ".git")
 ```

--- a/lua/lspconfig/terraformls.lua
+++ b/lua/lspconfig/terraformls.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig/util'
 
 configs.terraformls = {
   default_config = {
-    cmd = {"terraform-ls"};
+    cmd = {"terraform-ls", "serve"};
     filetypes = {"terraform"};
     root_dir = util.root_pattern(".terraform", ".git");
   };


### PR DESCRIPTION
```console
$ terraform-ls
Usage: terraform-ls [--version] [--help] <command> [<args>]

Available commands are:
    completion        Lists available completion items
    inspect-module    Lists available debug items
    serve             Starts the Language Server
```

```console
$ terraform-ls serve
2020/09/14 13:34:28 serve_command.go:137: Starting terraform-ls 0.0.0-dev
2020/09/14 13:34:28 service.go:60: Preparing new session ...
2020/09/14 13:34:28 service.go:77: Worker pool size set to 12
2020/09/14 13:34:28 watcher.go:118: watching for changes ...
2020/09/14 13:34:28 langserver.go:69: Starting server (pid 83736) ...
```

Ref #345