### PR TITLE
feat: Add Sorbet language server

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -51,6 +51,7 @@ that config.
 - [rust_analyzer](#rust_analyzer)
 - [scry](#scry)
 - [solargraph](#solargraph)
+- [sorbet](#sorbet)
 - [sourcekit](#sourcekit)
 - [sqlls](#sqlls)
 - [sumneko_lua](#sumneko_lua)
@@ -4586,6 +4587,31 @@ require'lspconfig'.solargraph.setup{}
   
   Default Values:
     cmd = { "solargraph", "stdio" }
+    filetypes = { "ruby" }
+    root_dir = root_pattern("Gemfile", ".git")
+```
+
+## sorbet
+
+https://sorbet.org
+
+Sorbet is a fast, powerful type checker designed for Ruby.
+
+You can install Sorbet via gem install. You might also be interested in how to set
+Sorbet up for new projects: https://sorbet.org/docs/adopting.
+
+```sh
+gem install sorbet
+```
+    
+
+```lua
+require'lspconfig'.sorbet.setup{}
+
+  Commands:
+  
+  Default Values:
+    cmd = { "srb", "tc", "--lsp" }
     filetypes = { "ruby" }
     root_dir = root_pattern("Gemfile", ".git")
 ```

--- a/lua/lspconfig/sorbet.lua
+++ b/lua/lspconfig/sorbet.lua
@@ -1,0 +1,30 @@
+local configs = require 'lspconfig/configs'
+local util = require 'lspconfig/util'
+
+local server_name = "sorbet"
+local bin_name = "srb"
+
+configs[server_name] = {
+  default_config = {
+    cmd = {bin_name, "tc", "--lsp"};
+    filetypes = {"ruby"};
+    root_dir = util.root_pattern("Gemfile", ".git");
+  };
+  docs = {
+    description = [[
+https://sorbet.org
+
+Sorbet is a fast, powerful type checker designed for Ruby.
+
+You can install Sorbet via gem install. You might also be interested in how to set
+Sorbet up for new projects: https://sorbet.org/docs/adopting.
+
+```sh
+gem install sorbet
+```
+    ]];
+    default_config = {
+      root_dir = [[root_pattern("Gemfile", ".git")]];
+    };
+  };
+};


### PR DESCRIPTION
Adds support for [Sorbet](https://sorbet.org), a Ruby type-checker with [LSP support as of 0.5](https://sorbet.org/blog/2019/12/20/announcing-sorbet-0.5).

Most of this I copied from the solargraph integration. 