### PR TITLE
[dartls] Change init_options to booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -1562,11 +1562,11 @@ require'lspconfig'.dartls.setup{}
     cmd = { "dart", "./snapshots/analysis_server.dart.snapshot", "--lsp" }
     filetypes = { "dart" }
     init_options = {
-      closingLabels = "true",
-      flutterOutline = "false",
-      onlyAnalyzeProjectsWithOpenFiles = "false",
-      outline = "true",
-      suggestFromUnimportedLibraries = "true"
+      closingLabels = false,
+      flutterOutline = false,
+      onlyAnalyzeProjectsWithOpenFiles = false,
+      outline = false,
+      suggestFromUnimportedLibraries = true
     }
     root_dir = root_pattern("pubspec.yaml")
 ```

--- a/lua/lspconfig/dartls.lua
+++ b/lua/lspconfig/dartls.lua
@@ -33,11 +33,11 @@ configs[server_name] = {
     filetypes = {"dart"};
     root_dir = util.root_pattern("pubspec.yaml");
     init_options = {
-      onlyAnalyzeProjectsWithOpenFiles = "false",
-      suggestFromUnimportedLibraries = "true",
-      closingLabels = "true",
-      outline = "true",
-      flutterOutline= "false"
+      onlyAnalyzeProjectsWithOpenFiles = false,
+      suggestFromUnimportedLibraries = true,
+      closingLabels = false,
+      outline = false,
+      flutterOutline = false
     };
   };
   docs = {


### PR DESCRIPTION
This PR is meant to change the default type in the init_options for the dart language server because it seems like passing stringified booleans doesn't affect the behavior. This can be demonstrated if you include a small callback for [dart/textDocument/publishClosingLabels](https://github.com/dart-lang/sdk/blob/61e0098c9241261b73210b869af55577583de287/pkg/analysis_server/tool/lsp_spec/README.md#darttextdocumentpublishclosinglabels-notification).
```lua
local dart_callbacks = {}
dart_callbacks['dart/textDocument/publishClosingLabels'] = function(_, _, result, _, _) print(result) end
              
nvim_lsp.dartls.setup({
  on_attach = dart_attach;
  init_options = {
    onlyAnalyzeProjectsWithOpenFiles = "true";
    suggestFromUnimportedLibraries = "false";
    closingLabels = "true";
  };
  callbacks = dart_callbacks;
})
```
Using this setup call, a table of the result will never arrive because the language server will fall back to its default value. If you change all the init_options to booleans you will see the notification on startup of the language server.

I also turned off the init_options for additional features by default because there aren't callbacks defined to handle them as far as I could tell.

[dartls init_options for reference](https://github.com/dart-lang/sdk/blob/61e0098c9241261b73210b869af55577583de287/pkg/analysis_server/tool/lsp_spec/README.md#initialization-options)

Thank you for taking the time to review :smile: 