### PR TITLE
Disable rust-analyzer checkOnSave by default

### DIFF
--- a/lua/nvim_lsp/rust_analyzer.lua
+++ b/lua/nvim_lsp/rust_analyzer.lua
@@ -7,7 +7,11 @@ configs.rust_analyzer = {
     filetypes = {"rust"};
     root_dir = util.root_pattern("Cargo.toml", "rust-project.json");
     settings = {
-      ["rust-analyzer"] = {}
+      ["rust-analyzer"] = {
+        checkOnSave = {
+          enable = false
+        }
+      }
     }
   };
   docs = {


### PR DESCRIPTION
As recently, rust-analyzer has just make checkOnSave as default behavior https://github.com/rust-analyzer/rust-analyzer/commit/24805d1d80af251a124f7e1085bd59dfc93b764f on server side, this behavior is not good for nvim-lsp as it will block save. I think the better default would be off for nvim.