### PR TITLE
Make actual root_dir available to on_new_config hooks

### DIFF
--- a/lua/nvim_lsp/configs.lua
+++ b/lua/nvim_lsp/configs.lua
@@ -125,6 +125,7 @@ function configs.__newindex(t, config_name, config_def)
       })
 
       add_callbacks(new_config)
+      new_config.root_dir = _root_dir
       if config_def.on_new_config then
         pcall(config_def.on_new_config, new_config)
       end
@@ -162,7 +163,6 @@ function configs.__newindex(t, config_name, config_def)
         end
       end)
 
-      new_config.root_dir = _root_dir
       return new_config
     end
 


### PR DESCRIPTION
This allows to customize the client depending on the directory for which it is started.