### PR TITLE
Fix root_pattern for wildcards and file in wildignore

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -535,6 +535,12 @@ This server accepts configuration via the `settings` key.
   
   Whether to include symbols that have not been imported in the code completion list and automatically insert the required import when selecting them \(requires restart\)\.
 
+- **`dart.automaticCommentSlashes`**: `enum { "none", "tripleSlash", "all" }`
+
+  Default: `"tripleSlash"`
+  
+  null
+
 - **`dart.buildRunnerAdditionalArgs`**: `array`
 
   Default: `{}`
@@ -5568,6 +5574,12 @@ This server accepts configuration via the `settings` key.
   Default: `true`
   
   Whether to enable codeActions
+
+- **`vetur.languageFeatures.semanticTokens`**: `boolean`
+
+  Default: `true`
+  
+  Whether to enable semantic highlighting\. Currently only works for typescript
 
 - **`vetur.languageFeatures.updateImportOnFileMove`**: `boolean`
 

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -249,8 +249,10 @@ function M.root_pattern(...)
   local patterns = vim.tbl_flatten {...}
   local function matcher(path)
     for _, pattern in ipairs(patterns) do
-      if M.path.exists(vim.fn.glob(M.path.join(path, pattern))) then
-        return path
+      for _, p in ipairs(vim.fn.glob(M.path.join(path, pattern), true, true)) do
+        if M.path.exists(p) then
+          return path
+        end
       end
     end
   end


### PR DESCRIPTION
This PR fixes `root_pattern` to find directories that are included in wildignore. I think it is pretty common that people have `.git` in their wildignore, but would like to use it as a root directory marker.

I've also fixed `root_pattern` to work correctly with globs so things like `build_*` will work.