### PR TITLE
Fix the Terraform-ls default config

### DIFF
--- a/lua/nvim_lsp/terraformls.lua
+++ b/lua/nvim_lsp/terraformls.lua
@@ -3,7 +3,7 @@ local util = require 'nvim_lsp/util'
 
 configs.terraformls = {
   default_config = {
-    cmd = {"terraform-ls"};
+    cmd = {"terraform-ls", "serve"};
     filetypes = {"terraform"};
     root_dir = util.root_pattern(".terraform", ".git");
   };


### PR DESCRIPTION
The Terraform-ls default config is just calling terraform-ls. This is
resulting in the language server just outputting it's help as the
command needs to be:

```
terraform-ls serve
```

to actually start the language server.