### PR TITLE
npm_installer: Skip creating package.json

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -392,8 +392,7 @@ function M.npm_installer(config)
     set -e
     mkdir -p "{{install_dir}}"
     cd "{{install_dir}}"
-    [ ! -f package.json ] && npm init -y
-    npm install {{packages}} --no-package-lock --no-save --production
+    npm install {{packages}} --no-package-lock --no-save --no-color --no-progress
     {{post_install_script}}
     ]]):gsub("{{(%S+)}}", install_params)
     cmd:write(install_script)


### PR DESCRIPTION
If the name in the `package.json` file generated by `npm init`
matched the name of one of the packages to be installed, npm would
error out. It turns out that npm will happily install packages without
the current directory containing a `package.json`, so just do that
instead of any gymnastics to avoid name the name collision.

fixes #409
