### PR TITLE
Have leanls use util.find_git_ancestor.

### DIFF
--- a/lua/lspconfig/leanls.lua
+++ b/lua/lspconfig/leanls.lua
@@ -5,7 +5,9 @@ configs.leanls = {
   default_config = {
     cmd = {"lean-language-server", "--stdio"};
     filetypes = {"lean"};
-    root_dir = util.root_pattern(".git");
+    root_dir = function(fname)
+      return util.find_git_ancestor(fname) or vim.loop.os_homedir()
+    end;
   };
   docs = {
     package_json = "https://raw.githubusercontent.com/leanprover/vscode-lean/master/package.json";
@@ -15,7 +17,7 @@ https://github.com/leanprover/lean-client-js/tree/master/lean-language-server
 Lean language server.
     ]];
     default_config = {
-      root_dir = [[util.root_pattern(".git")]];
+      root_dir = [[root_pattern(".git") or os_homedir]];
     };
   };
 }


### PR DESCRIPTION
Otherwise, the existing root_dir won't enable leanls for the normal style of lean package.