### PR TITLE
Add forward search command for Texlab

### DIFF
--- a/lua/lspconfig/texlab.lua
+++ b/lua/lspconfig/texlab.lua
@@ -32,7 +32,7 @@ local function buf_search(bufnr)
   lsp.buf_request(bufnr, 'textDocument/forwardSearch', params,
       function(err, _, result, _)
         if err then error(tostring(err)) end
-        print("Search "..texlab_build_status[result.status])
+        print("Search "..texlab_forward_status[result.status])
       end)
 end
 

--- a/lua/lspconfig/texlab.lua
+++ b/lua/lspconfig/texlab.lua
@@ -28,7 +28,7 @@ end
 
 local function buf_search(bufnr)
   bufnr = util.validate_bufnr(bufnr)
-  local params = { textDocument = { uri = vim.uri_from_bufnr(bufnr) }, position = { line = 10, character = 10  }
+  local params = { textDocument = { uri = vim.uri_from_bufnr(bufnr) }, position = { line = vim.fn.line('.')-1, character = vim.fn.col('.')  }}
   lsp.buf_request(bufnr, 'textDocument/forwardSearch', params,
       function(err, _, result, _)
         if err then error(tostring(err)) end
@@ -87,7 +87,7 @@ configs.texlab = {
       function()
           buf_search(0)
       end;
-      description = "Forward search current position";
+      description = "Forward search from current position";
     }
   };
   docs = {

--- a/lua/lspconfig/texlab.lua
+++ b/lua/lspconfig/texlab.lua
@@ -9,6 +9,13 @@ local texlab_build_status = vim.tbl_add_reverse_lookup {
   Cancelled = 3;
 }
 
+local texlab_forward_status = vim.tbl_add_reverse_lookup {
+  Success = 0;
+  Error = 1;
+  Failure = 2;
+  Unconfigured = 3;
+}
+
 local function buf_build(bufnr)
   bufnr = util.validate_bufnr(bufnr)
   local params = { textDocument = { uri = vim.uri_from_bufnr(bufnr) }  }
@@ -16,6 +23,16 @@ local function buf_build(bufnr)
       function(err, _, result, _)
         if err then error(tostring(err)) end
         print("Build "..texlab_build_status[result.status])
+      end)
+end
+
+local function buf_search(bufnr)
+  bufnr = util.validate_bufnr(bufnr)
+  local params = { textDocument = { uri = vim.uri_from_bufnr(bufnr) }, position = { line = 10, character = 10  }
+  lsp.buf_request(bufnr, 'textDocument/forwardSearch', params,
+      function(err, _, result, _)
+        if err then error(tostring(err)) end
+        print("Search "..texlab_build_status[result.status])
       end)
 end
 
@@ -66,6 +83,12 @@ configs.texlab = {
       end;
       description = "Build the current buffer";
     };
+    TexlabForward = {
+      function()
+          buf_search(0)
+      end;
+      description = "Forward search current position";
+    }
   };
   docs = {
     description = [[

--- a/lua/lspconfig/texlab.lua
+++ b/lua/lspconfig/texlab.lua
@@ -105,4 +105,5 @@ See https://texlab.netlify.com/docs/reference/configuration for configuration op
 }
 
 configs.texlab.buf_build = buf_build
+configs.texlab.buf_search = buf_search
 -- vim:et ts=2 sw=2


### PR DESCRIPTION
I made a simple command for supporting Texlab forward search on current cursor position
According to [Position especification](https://microsoft.github.io/language-server-protocol/specification#position) contains a zero-based line and character number, vim.fn.line/col give a one-based number, that's why it is substracting one.