### PR TITLE
Return all settings when configuration has no section

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -66,6 +66,8 @@ function configs.__newindex(t, config_name, config_def)
             value = config.settings or vim.NIL
           end
           table.insert(result, value)
+        else
+          table.insert(result, config.settings)
         end
       end
       return result


### PR DESCRIPTION
For `workspace/configuration` requests that have no `section` all settings data should be returned.
