### PR TITLE
Kotlin: Fix order of root files

### DIFF
--- a/lua/lspconfig/kotlin_language_server.lua
+++ b/lua/lspconfig/kotlin_language_server.lua
@@ -23,10 +23,10 @@ end
 local root_files = {
   'build.xml',             -- Ant
   'pom.xml',               -- Maven
+  'settings.gradle',       -- Gradle (mutli-project)
+  'settings.gradle.kts',   -- Gradle (mutli-project)
   'build.gradle',          -- Gradle
   'build.gradle.kts',      -- Gradle
-  'settings.gradle',       -- Gradle
-  'settings.gradle.kts',   -- Gradle
 }
 
 configs.kotlin_language_server = {


### PR DESCRIPTION
Using `build.gradle[.kts]` as a root marker is a problem in multi-project setups. The plugin would find the first file relative to the source file, which is would belong to the sub-project. Instead we first have to search for a global `settings.gradle[.kts]` file.

If no global settings file exist, then we have a single project; in that case using `build.gradle[.kts]` is exactly what we want.

A multi-project setup without a global settings file is broken anyway, so no need to check for that scenario.