### PR TITLE
sumneko_lua: Use bufdir instead of homedir when resolving root_dir

### DIFF
--- a/lua/lspconfig/sumneko_lua.lua
+++ b/lua/lspconfig/sumneko_lua.lua
@@ -95,7 +95,7 @@ configs[name] = {
   default_config = {
     filetypes = {'lua'};
     root_dir = function(fname)
-      return util.find_git_ancestor(fname) or vim.loop.os_homedir()
+      return util.find_git_ancestor(fname) or util.path.dirname(fname)
     end;
     log_level = vim.lsp.protocol.MessageType.Warning;
   };
@@ -123,7 +123,7 @@ require'lspconfig'.sumneko_lua.setup{
 If you install via our installer, if you execute `:LspInstallInfo sumneko_lua`, you can know `cmd` value.
 ]];
     default_config = {
-      root_dir = [[root_pattern(".git") or os_homedir]];
+      root_dir = [[root_pattern(".git") or bufdir]];
     };
   };
 }


### PR DESCRIPTION
The problem is that if you open a Lua file outside of a git repository, it will use your home directory as root directory. This causes Sumneko to scan your entire home directory for Lua files. Which is bad from both a security and performance point of view.

Fixes GH-446