### PR TITLE
Add workaround to make yamlls work with node v15.x

### DIFF
--- a/lua/lspconfig/yamlls.lua
+++ b/lua/lspconfig/yamlls.lua
@@ -14,6 +14,15 @@ configs[server_name] = {
   default_config = {
     cmd = {bin_name, "--stdio"};
     filetypes = {"yaml"};
+    handlers = {
+      -- yamlls tries to register for workspaceFolder changes, which does not have the dynamicRegistration indicator
+      ['client/registerCapability'] = function(_, _, _, _)
+        return {
+          result = nil;
+          error = nil;
+        }
+      end
+    };
     root_dir = util.root_pattern(".git", vim.fn.getcwd());
   };
   on_new_config = function(new_config)


### PR DESCRIPTION
See https://github.com/neovim/neovim/issues/13448 and https://github.com/redhat-developer/yaml-language-server/issues/370.

I don't see a good way how yamlls could find out that registerCapability is not working for workspaceFolder changes, so this workaround would solve that for the moment.