### PR TITLE
Add support for Lua language server alloyed_lua

### DIFF
--- a/lua/lspconfig/alloyed_lua.lua
+++ b/lua/lspconfig/alloyed_lua.lua
@@ -1,0 +1,33 @@
+local configs = require 'lspconfig/configs'
+local util = require 'lspconfig/util'
+
+configs.alloyed_lua = {
+  default_config = {
+    cmd = {'lua-lsp'};
+    filetypes = {'lua'};
+    root_dir = function(fname)
+      return util.root_pattern('.luacheckrc', '.luacompleterc', '.git') or
+        util.path.dirname(fname)
+    end;
+  };
+  docs = {
+    description = [[
+https://github.com/Alloyed/lua-lsp
+
+`lua-lsp` is a language server for Lua written in Lua. It can be installed
+using *luarocks*:
+```sh
+luarocks install --server=http://luarocks.org/dev lua-lsp
+```
+
+`lua-lsp` automatically integrates with common lua packages when they are
+installed. For linting, install `luacheck`:
+```sh
+luarocks install luacheck
+```
+    ]];
+    default_config = {
+      root_dir = [[root_pattern('.luacheckrc', '.luacompleterc', '.git') or dirname]];
+    };
+  };
+};


### PR DESCRIPTION
Add a new language server for Lua: [here's the repo](https://github.com/Alloyed/lua-lsp). I find `sumneko_lua` way too complicated to install so I figured I'd use this one instead.