### PR TITLE
lspconfig: allow accessing nil config with pcall

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,16 +102,19 @@ To configure a custom/private server, just
 ```lua
 local lspconfig = require'lspconfig'
 local configs = require'lspconfig/configs'
-configs.foo_lsp = {
-  default_config = {
-    cmd = {'/home/ashkan/works/3rd/lua-language-server/run.sh'};
-    filetypes = {'lua'};
-    root_dir = function(fname)
-      return lspconfig.util.find_git_ancestor(fname) or vim.loop.os_homedir()
-    end;
-    settings = {};
-  };
-}
+-- Check if it's already defined for when reloading this file.
+if not lspconfig.foo_lsp then
+  configs.foo_lsp = {
+    default_config = {
+      cmd = {'/home/ashkan/works/3rd/lua-language-server/run.sh'};
+      filetypes = {'lua'};
+      root_dir = function(fname)
+        return lspconfig.util.find_git_ancestor(fname) or vim.loop.os_homedir()
+      end;
+      settings = {};
+    };
+  }
+end
 lspconfig.foo_lsp.setup{}
 ```
 

--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -34,7 +34,7 @@ end
 local mt = {}
 function mt:__index(k)
   if configs[k] == nil then
-    require('lspconfig/'..k)
+    pcall(require, 'lspconfig/'..k)
   end
   return configs[k]
 end


### PR DESCRIPTION
Closes #191

The following example from the readme should now "just work"
```lua
local lspconfig = require'lspconfig'
local configs = require'lspconfig/configs'
-- Check if it's already defined for when I reload this file.
if not lspconfig.foo_lsp then
  configs.foo_lsp = {
    default_config = {
      cmd = {'/home/ashkan/works/3rd/lua-language-server/run.sh'};
      filetypes = {'lua'};
      root_dir = function(fname)
        return lspconfig.util.find_git_ancestor(fname) or vim.loop.os_homedir()
      end;
      settings = {};
    };
  }
end
lspconfig.foo_lsp.setup{}
```