### PR TITLE
Update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,6 +13,7 @@ labels: bug
 - `:checkhealth` result
 - What language server(If the problem is related to a specific language server):
 - Can you reproduce this behavior on other language server clients (vscode, languageclient-neovim, coc.nvim, etc.):
+- Can you reproduce this behavior on other language servers offer by the nvim-lspconfig repo? (pyls -> pyright):
 - Is this problem isolated to this particular language server:
 - Operating system/version:
 - Terminal name/version:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ labels: bug
 - nvim-lsp version(commit hash):
 - `:checkhealth` result
 - What language server(If the problem is related to a specific language server):
-- Can you reproduce this beahvior on other language server clients (vscode, languageclient-neovim, coc.nvim, etc.):
+- Can you reproduce this behavior on other language server clients (vscode, languageclient-neovim, coc.nvim, etc.):
 - Is this problem isolated to this particular language server:
 - Operating system/version:
 - Terminal name/version:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: bug
 
 ---
 
-<!-- Before reporting: search existing issues. Note that this repository implements configuration and initialization of language servers. Implementaiton of the language server spec itself is located in the neovim core repository-->
+<!-- Before reporting: search existing issues. Note that this repository implements configuration and initialization of language servers. Implementation of the language server spec itself is located in the neovim core repository-->
 
 - `nvim --version`:
 - nvim-lsp version(commit hash):

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,4 +25,4 @@ labels: bug
 ### Expected behaviour
 
 ### LSP log
-<!-- Please add vim.lsp.log.set_level("info") to your lua block in init.vim and paste a link to your log file, located at $HOME/.local/share/nvim/lsp.log -->
+<!-- Please add vim.lsp.set_log_level("debug") to your lua block in init.vim and paste a link to your log file, located at $HOME/.local/share/nvim/lsp.log -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,12 +6,14 @@ labels: bug
 
 ---
 
-<!-- Before reporting: search existing issues. -->
+<!-- Before reporting: search existing issues. Note that this repository implements configuration and initialization of language servers. Implementaiton of the language server spec itself is located in the neovim core repository-->
 
 - `nvim --version`:
 - nvim-lsp version(commit hash):
 - `:checkhealth` result
 - What language server(If the problem is related to a specific language server):
+- Can you reproduce this beahvior on other language server clients (vscode, languageclient-neovim, coc.nvim, etc.):
+- Is this problem isolated to this particular language server:
 - Operating system/version:
 - Terminal name/version:
 - `$TERM`:
@@ -21,3 +23,6 @@ labels: bug
 ### Actual behaviour
 
 ### Expected behaviour
+
+### LSP log
+<!-- Please add vim.lsp.log.set_level("info") to your lua block in init.vim and paste a link to your log file, located at $HOME/.local/share/nvim/lsp.log -->


### PR DESCRIPTION
A lot of issues are filed here that are really issues in upstream language servers, or are issues with the neovim client implementation which is located in core. Furthermore, most issue templates don't have the LSP log attached to them, which makes debugging hard.