### PR TITLE
Add pyright.organizeimports command

### DIFF
--- a/lua/lspconfig/pyright.lua
+++ b/lua/lspconfig/pyright.lua
@@ -13,6 +13,14 @@ local installer = util.npm_installer {
   binaries = {bin_name};
 }
 
+local function organize_imports()
+  local params = {
+    command = 'pyright.organizeimports',
+    arguments = { vim.uri_from_bufnr(0) },
+  }
+  vim.lsp.buf.execute_command(params)
+end
+
 configs[server_name] = {
   default_config = {
     cmd = {bin_name, "--stdio"};
@@ -26,7 +34,13 @@ configs[server_name] = {
         };
       };
     };
-   };
+  };
+  commands = {
+    PyrightOrganizeImports = {
+      organize_imports;
+      description = "Organize Imports";
+    };
+  };
   docs = {
     description = [[
 https://github.com/microsoft/pyright


### PR DESCRIPTION
`pyright` allows you to organize imports through `workspace/executeCommand`, so I added a command that does this.

I tried adding a command to generate typestubs but that seems to rely on `window/showMessage`, which is not yet supported (https://github.com/neovim/neovim/issues/11710)