### PR TITLE
texlab.lua incorrect default latex.build.args

### DIFF
--- a/lua/lspconfig/texlab.lua
+++ b/lua/lspconfig/texlab.lua
@@ -60,7 +60,7 @@ configs.texlab = {
     settings = {
       latex = {
         build = {
-          args = {"-pdf", "-interaction=nonstopmode", "-synctex=1"};
+          args = {"-pdf", "-interaction=nonstopmode", "-synctex=1", "%f"};
           executable = "latexmk";
           onSave = false;
         };


### PR DESCRIPTION
Updated build.args with "%f" as shown [here](https://texlab.netlify.app/docs/reference/configuration)