### PR TITLE
vscode-html-languageserver: document reason completion is not on by default 

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1647,9 +1647,22 @@ require'lspconfig'.hls.setup{}
 
 https://github.com/vscode-langservers/vscode-html-languageserver-bin
 
-`html-languageserver` can be installed via `npm`:
+`vscode-html-languageserver` can be installed via `npm`:
 ```sh
 npm install -g vscode-html-languageserver-bin
+```
+
+Neovim does not currently include built-in snippets. `vscode-html-languageserver` only provides completions when snippet support is enabled.
+To enable completion, install a snippet plugin and add the following override to your language client capabilities during setup.
+
+```lua
+--Enable (broadcasting) snippet capability for completion
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+capabilities.textDocument.completion.completionItem.snippetSupport = true
+
+require'lspconfig'.html.setup {
+  capabilities = capabilities,
+}
 ```
 
 
@@ -1871,6 +1884,12 @@ This server accepts configuration via the `settings` key.
 - **`julia.execution.codeInREPL`**: `boolean`
 
   Print executed code in REPL and append it to the REPL history\.
+
+- **`julia.execution.inlineResults.colors`**: `object`
+
+  Default: `vim.empty_dict()`
+  
+  null
 
 - **`julia.execution.resultType`**: `enum { "REPL", "inline", "both" }`
 
@@ -4022,6 +4041,12 @@ This server accepts configuration via the `settings` key.
 
 - **`rust-analyzer.procMacro.enable`**: `boolean`
 
+  null
+
+- **`rust-analyzer.procMacro.server`**: `null|string`
+
+  Default: `vim.NIL`
+  
   null
 
 - **`rust-analyzer.runnableEnv`**

--- a/lua/lspconfig/html.lua
+++ b/lua/lspconfig/html.lua
@@ -24,9 +24,22 @@ configs[server_name] = {
     description = [[
 https://github.com/vscode-langservers/vscode-html-languageserver-bin
 
-`html-languageserver` can be installed via `npm`:
+`vscode-html-languageserver` can be installed via `npm`:
 ```sh
 npm install -g vscode-html-languageserver-bin
+```
+
+Neovim does not currently include built-in snippets. `vscode-html-languageserver` only provides completions when snippet support is enabled.
+To enable completion, install a snippet plugin and add the following override to your language client capabilities during setup.
+
+```lua
+--Enable (broadcasting) snippet capability for completion
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+capabilities.textDocument.completion.completionItem.snippetSupport = true
+
+require'lspconfig'.html.setup {
+  capabilities = capabilities,
+}
 ```
 ]];
   };


### PR DESCRIPTION
Closes  #490

Can't do anything about this (by default) unless snippets are added to core. 

See also https://github.com/emacs-lsp/lsp-mode/issues/1449

