### PR TITLE
rust-analyzer: fix root pattern for multi-crate projects

### DIFF
--- a/lua/lspconfig/rust_analyzer.lua
+++ b/lua/lspconfig/rust_analyzer.lua
@@ -5,7 +5,11 @@ configs.rust_analyzer = {
   default_config = {
     cmd = {"rust-analyzer"};
     filetypes = {"rust"};
-    root_dir = util.root_pattern("Cargo.toml", "rust-project.json");
+    root_dir = function(fname)
+      return util.find_git_ancestor(fname) or
+      util.root_pattern("rust-project.json")(fname) or
+      util.root_pattern("Cargo.toml")(fname)
+    end;
     settings = {
       ["rust-analyzer"] = {}
     };


### PR DESCRIPTION
Closes  #310

This will prefer git directory > rust-project.json > cargo.toml