### PR TITLE
Remove package_json link from Metals docs.

### DIFF
--- a/lua/lspconfig/metals.lua
+++ b/lua/lspconfig/metals.lua
@@ -18,7 +18,6 @@ configs[server_name] = {
       };
   };
   docs = {
-    package_json = "https://raw.githubusercontent.com/scalameta/metals-vscode/master/package.json";
     description  = [[
 https://scalameta.org/metals/
 


### PR DESCRIPTION
Many of the settings that this link shows are reliant on
specific things like code lenses working. I think it's a better
idea to not show these as there are a handful of them that if a
user would use them, they won't work at all, and in the worst
case they actual may cause errors due to unsupported handlers
or LSP extensions.