### PR TITLE
LspInfo: disable transparency for terminal emulator compatibility

### DIFF
--- a/lua/lspconfig/_lspui.lua
+++ b/lua/lspconfig/_lspui.lua
@@ -96,7 +96,6 @@ function win_float.percentage_range_window(col_range, row_range, options)
   vim.api.nvim_win_set_buf(win_id, bufnr)
 
   vim.cmd('setlocal nocursorcolumn')
-  vim.fn.nvim_win_set_option(win_id, 'winblend', options.winblend)
 
   return {
     bufnr = bufnr,


### PR DESCRIPTION
For the non-iTerm apple user(s) out there