### PR TITLE
Check if language server is executable before trying to start it

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -255,10 +255,15 @@ function M.server_per_root_dir_manager(_make_config)
     local client_id = clients[root_dir]
     if not client_id then
       local new_config = _make_config(root_dir)
-      --TODO:mjlbach -- this current isn't printing
+      --TODO:mjlbach -- these prints only show up with nvim_error_writeln()
       if not new_config.cmd then
-          print(string.format("Error, cmd not defined for [%q]. You must manually define a cmd for the default config for this server. See server documentation.", new_config.name))
+          print(string.format("Error, cmd not defined for [%q]."..
+              "You must manually define a cmd for the default config for this server."
+              .."See server documentation.", new_config.name))
           return
+      elseif vim.fn.executable(new_config.cmd[1]) == 0 then
+        print(string.format("Error, cmd [%q] is not executable.", new_config.cmd[1]))
+        return
       end
       new_config.on_exit = M.add_hook_before(new_config.on_exit, function()
         clients[root_dir] = nil


### PR DESCRIPTION
Closes #106

@teto it has arrived.

I like this solution best, because it allows you to modify your path to fix the issue with the server without restarting neovim.