### PR TITLE
Add handling for nil filetypes

### DIFF
--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -63,7 +63,7 @@ function M._root._setup()
             "Client: "..tostring(client.id),
             "\tname: "..client.name,
             "\troot: "..client.workspaceFolders[1].name,
-            "\tfiletypes: "..table.concat(client.config.filetypes, ', '),
+            "\tfiletypes: "..table.concat(client.config.filetypes or {}, ', '),
             "\tcmd: "..remove_newlines(client.config.cmd),
           }
         end


### PR DESCRIPTION
@weilbith

This will make LspInfo work for servers that were not started via the workspace launcher (which requires filetypes to be set).