### PR TITLE
pyright: add current file directory as fallback for root

### DIFF
--- a/lua/lspconfig/pyright.lua
+++ b/lua/lspconfig/pyright.lua
@@ -7,11 +7,22 @@ if vim.fn.has('win32') == 1 then
   bin_name = bin_name..".cmd"
 end
 
+local root_files = {
+  'setup.py',
+  'pyproject.toml',
+  'setup.cfg',
+  'requirements.txt',
+  '.git',
+}
+
 configs[server_name] = {
   default_config = {
     cmd = {bin_name, "--stdio"};
     filetypes = {"python"};
-    root_dir = util.root_pattern(".git", "setup.py",  "setup.cfg", "pyproject.toml", "requirements.txt");
+    root_dir = function(filename)
+      return util.root_pattern(unpack(root_files))(filename) or
+             util.path.dirname(filename)
+    end;
     settings = {
       python = {
         analysis = {


### PR DESCRIPTION
This is probably the most reported issue on Gitter/IRC/reddit. It's a bad idea to rely on this fallback behavior for a variety of reasons, but I think this will cut the time I spent troubleshooting people's configurations in half 😆 

@lithammer You raised this point before. What do you thing? I also think that falling back to the parent directory of the file is probably more defined than using getcwd.