### PR TITLE
bashls: Set root_dir to nil when editing file in ~

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -2118,6 +2118,12 @@ This server accepts configuration via the `settings` key.
   
   Display plots within VS Code\. Might require a restart of the Julia process\.
 
+- **`julia.useProgressFrontend`**: `boolean`
+
+  Default: `true`
+  
+  null
+
 - **`julia.useRevise`**: `boolean`
 
   Default: `true`
@@ -2326,6 +2332,12 @@ This server accepts configuration via the `settings` key.
   Default: `vim.empty_dict()`
   
   Array items: `{description = "Unicode character to translate to",type = "string"}`
+  
+  null
+
+- **`lean.input.eagerReplacementEnabled`**: `boolean`
+
+  Default: `true`
   
   null
 

--- a/lua/lspconfig/bashls.lua
+++ b/lua/lspconfig/bashls.lua
@@ -1,3 +1,4 @@
+local log = require('vim/lsp/log')
 local configs = require 'lspconfig/configs'
 local util = require 'lspconfig/util'
 
@@ -7,7 +8,17 @@ configs[server_name] = {
   default_config = {
     cmd = {"bash-language-server", "start"};
     filetypes = {"sh"};
-    root_dir = util.path.dirname;
+    root_dir = function(fname)
+      local dirname = util.path.dirname(fname)
+
+      -- Prevent the bash-language-server from scanning the entire home folder.
+      if dirname == vim.loop.os_homedir() then
+        log.info('Not setting root_dir to prevent scanning everything in $HOME')
+        return nil
+      end
+
+      return dirname
+    end
   };
   docs = {
     description = [[


### PR DESCRIPTION
A problem with bash-language-server is that it has a bad habit of trying to recursively scan the entire home folder if you for example tried to edit a shell script directly in `~` (e.g. `~/foo.sh`).

This causes a bunch of weird behaviour and causes the server to take forever to start.

To prevent this we set `root_dir` to `nil` when the resolved `root_dir` happened to be `~`. This solution is kind of hinted towards if you look at their own [README](https://github.com/bash-lsp/bash-language-server/blob/master/README.md) for how you should configure it with coc.nvim (note the `ignoredRootPaths`):

    "languageserver": {
      "bash": {
        "command": "bash-language-server",
        "args": ["start"],
        "filetypes": ["sh"],
        "ignoredRootPaths": ["~"]
      }
    }