### PR TITLE
bashls: Set GLOB_PATTERN to prevent recursive scanning

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -146,6 +146,9 @@ require'lspconfig'.bashls.setup{}
   
   Default Values:
     cmd = { "bash-language-server", "start" }
+    cmd_env = {
+      GLOB_PATTERN = "*@(.sh|.inc|.bash|.command)"
+    }
     filetypes = { "sh" }
     root_dir = vim's starting directory
 ```

--- a/lua/lspconfig/bashls.lua
+++ b/lua/lspconfig/bashls.lua
@@ -6,6 +6,13 @@ local server_name = "bashls"
 configs[server_name] = {
   default_config = {
     cmd = {"bash-language-server", "start"};
+    cmd_env = {
+      -- Prevent recursive scanning which will cause issues when opening a file
+      -- directly in the home directory (e.g. ~/foo.sh).
+      --
+      -- Default upstream pattern is "**/*@(.sh|.inc|.bash|.command)".
+      GLOB_PATTERN = vim.env.GLOB_PATTERN or "*@(.sh|.inc|.bash|.command)"
+    },
     filetypes = {"sh"};
     root_dir = util.path.dirname;
   };


### PR DESCRIPTION
Alternative solution to GH-685. Personally I prefer this approach since it means editing files in `~` will work just fine.