### PR TITLE
rust_analyzer: Fix the root_dir shell command

### DIFF
--- a/lua/lspconfig/rust_analyzer.lua
+++ b/lua/lspconfig/rust_analyzer.lua
@@ -8,7 +8,7 @@ configs.rust_analyzer = {
     root_dir = function(fname)
       local cargo_metadata = vim.fn.system("cargo metadata --format-version 1")
       local cargo_root = nil
-      if vim.v.shell_handler == 0 then
+      if vim.v.shell_error == 0 then
         cargo_root = vim.fn.json_decode(cargo_metadata)["workspace_root"]
       end
       return cargo_root or


### PR DESCRIPTION
The shell function was added in #657. Searching google and [the neovim repository](https://github.com/neovim/neovim/search?q=shell_handler&type=commits) yields no reference to a `v:shell_handler` special variable. I believe that `v:shell_error` was intended to be used. [The docs for v:shell_error](https://neovim.io/doc/user/eval.html#v:shell_error) certainly sounds like what we want, and testing it with this change produces the correct results.