### PR TITLE
nimls: root_dir improvements

### DIFF
--- a/lua/lspconfig/nimls.lua
+++ b/lua/lspconfig/nimls.lua
@@ -8,7 +8,7 @@ configs.nimls = {
     root_dir = function(fname)
       return util.root_pattern("*.nimble")(fname) or
         util.find_git_ancestor(fname) or
-        vim.loop.os_homedir()
+        util.path.dirname(fname)
     end;
   };
   docs = {

--- a/lua/lspconfig/nimls.lua
+++ b/lua/lspconfig/nimls.lua
@@ -6,7 +6,9 @@ configs.nimls = {
     cmd = {"nimlsp",};
     filetypes = {'nim'};
     root_dir = function(fname)
-      return util.find_git_ancestor(fname) or vim.loop.os_homedir()
+      return util.root_pattern("*.nimble")(fname) or
+        util.find_git_ancestor(fname) or
+        vim.loop.os_homedir()
     end;
   };
   docs = {


### PR DESCRIPTION
Added support for .nimble[1] files and replaced the fallback with buffer directory instead of home.

[1] https://github.com/nim-lang/nimble