### PR TITLE
readme: Fix lsp_document_highlight augroup to work for buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ local on_attach = function(client, bufnr)
       hi LspReferenceText cterm=bold ctermbg=red guibg=LightYellow
       hi LspReferenceWrite cterm=bold ctermbg=red guibg=LightYellow
       augroup lsp_document_highlight
-        autocmd!
+        autocmd! * <buffer>
         autocmd CursorHold <buffer> lua vim.lsp.buf.document_highlight()
         autocmd CursorMoved <buffer> lua vim.lsp.buf.clear_references()
       augroup END


### PR DESCRIPTION
Without this the `augroup` will be removed from old buffers when a new language server is attached. Found the solution here: https://stackoverflow.com/a/31822230/1862923