### PR TITLE
lspconfig: use vim.notify to warn of absent LSP executable

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -245,7 +245,7 @@ function M.server_per_root_dir_manager(_make_config)
               .."See server documentation.", new_config.name))
           return
       elseif vim.fn.executable(new_config.cmd[1]) == 0 then
-        print(string.format("Error, cmd [%q] is not executable.", new_config.cmd[1]))
+        vim.notify(string.format("cmd [%q] is not executable.", new_config.cmd[1]), vim.log.levels.Error)
         return
       end
       new_config.on_exit = M.add_hook_before(new_config.on_exit, function()


### PR DESCRIPTION
has been driving me nuts for some time. This way I can use system level notifications and it's less disturbing (to me at least).