### PR TITLE
Implement some denols functions

### DIFF
--- a/lua/lspconfig/denols.lua
+++ b/lua/lspconfig/denols.lua
@@ -1,7 +1,39 @@
 local configs = require 'lspconfig/configs'
 local util = require 'lspconfig/util'
+local lsp = vim.lsp
 
 local server_name = "denols"
+
+local function buf_cache(bufnr)
+  local params = {}
+  params["referrer"] = { textDocument = { uri = vim.uri_from_bufnr(bufnr) } }
+  params["uris"] = {}
+  lsp.buf_request(bufnr, "deno/cache", params)
+end
+
+local function virtual_text_document_handler(uri, result)
+  if not result or #result ~= 1 then return nil end
+
+  local lines = vim.split(result[1].result, "\n")
+  local bufnr = vim.uri_to_bufnr(uri)
+
+  local current_buf = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  if #current_buf ~= 0 then return nil end
+
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, nil, lines)
+  vim.api.nvim_buf_set_option(bufnr, "readonly", true)
+  vim.api.nvim_buf_set_option(bufnr, "modified", false)
+end
+
+local function virtual_text_document(uri)
+  local params = {
+    textDocument = {
+      uri = uri,
+    },
+  }
+  local result = lsp.buf_request_sync(0, "deno/virtualTextDocument", params)
+  virtual_text_document_handler(uri, result)
+end
 
 configs[server_name] = {
   default_config = {
@@ -12,6 +44,27 @@ configs[server_name] = {
       enable = true;
       lint = false;
       unstable = false;
+    };
+    handlers = {
+      ["textDocument/definition"] = function(err, method, result)
+        if not result or vim.tbl_isempty(result) then return nil end
+
+        for _, res in pairs(result) do
+          if string.sub(res.targetUri, 1, 7) == "deno://" then
+            virtual_text_document(res.targetUri)
+          end
+        end
+
+        lsp.handlers["textDocument/definition"](err, method, result)
+      end;
+    };
+  };
+  commands = {
+    DenolsCache = {
+      function()
+        buf_cache(0)
+      end;
+      description = "Cache a module and all of its dependencies."
     };
   };
   docs = {
@@ -26,4 +79,6 @@ Deno's built-in language server
   };
 }
 
+configs.denols.buf_cache = buf_cache
+configs.denols.virtual_text_document = virtual_text_document
 -- vim:et ts=2 sw=2


### PR DESCRIPTION
Thank you for the nice plugin.

I added some implementations for denols. https://github.com/denoland/deno/tree/master/cli/lsp#custom-requests

- deno/cache
- deno/virtualTextDocument

`deno/cache`: This command will instruct Deno to attempt to cache a module and all of its dependencies. 

`deno/virtualTextDocument`: Requests a virtual text document from the LSP, which is a read only document that can be displayed in the client. This allows clients to access documents in the Deno cache, like remote modules and TypeScript library files built into Deno. The Deno language server will encode all internal files under the custom schema `deno:`, so clients should route all requests for the `deno:` schema back to the `deno/virtualTextDocument` API.

Furthermore, I added `DenolsDefinition` command. This command wraps `vim.lsp.buf.definition` command, and
 resolve `deno:` schema of the definition result.

Thank you.