### PR TITLE
Set terraformls to also operate on `hcl` files

### DIFF
--- a/lua/lspconfig/terraformls.lua
+++ b/lua/lspconfig/terraformls.lua
@@ -4,7 +4,7 @@ local util = require 'lspconfig/util'
 configs.terraformls = {
   default_config = {
     cmd = {"terraform-ls", "serve"};
-    filetypes = {"terraform"};
+    filetypes = {"terraform", "hcl"};
     root_dir = util.root_pattern(".terraform", ".git");
   };
   docs = {


### PR DESCRIPTION
The file format that terraformls checks is HCL (Hashicorp Configuration
Language). Tools like `vim-hcl` actually set this `filetype` correctly.

Make the LSP pick up these files correctly too.