### PR TITLE
Attempt at server setting validation

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -250,15 +250,40 @@ local function read_package_json(package_json)
   return settings
 end
 
+local function deep_equal(tbl_a, tbl_b)
+  for k,v in pairs(tbl_b) do
+    if tbl_a[k] == nil then
+      return false
+    elseif type(v) == "table"  and tbl_a[k]['type'] == nil then
+      if not deep_equal(tbl_a[k], v) then
+        return false
+      end
+    else
+      local v_type = type(v)
+      local tbl_v_type = type(tbl_a[k]['default'])
+
+      if tbl_a[k]['type'] ~= nil and tbl_v_type == "nil" then
+        tbl_v_type = tbl_a[k]['type']
+        tbl_v_type = string.gsub(tbl_v_type, "object", "table")
+        tbl_v_type = string.gsub(tbl_v_type, "array", "table")
+        tbl_v_type = string.gsub(tbl_v_type, "integer", "number")
+      end
+
+      if v_type ~= tbl_v_type then
+        return false
+      end
+    end
+  end
+  return true
+end
+
 function M.validate_server_settings(server_settings, package_json)
   -- TODO (saad parwaiz) improve validation
   local default_server_settings = read_package_json(package_json)
-  for k,_ in pairs(server_settings) do
-    if default_server_settings[k] == nil then
-      return {}
-    end
+  if deep_equal(default_server_settings, server_settings) then
+    return server_settings
   end
-  return server_settings
+  return {}
 end
 
 -- Returns a function(root_dir), which, when called with a root_dir it hasn't

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -108,7 +108,6 @@ function M.has_bins(...)
   return true
 end
 
-
 -- Some path utilities
 M.path = (function()
   local function exists(filename)
@@ -254,7 +253,7 @@ end
 function M.validate_server_settings(server_settings, package_json)
   -- TODO (saad parwaiz) improve validation
   local default_server_settings = read_package_json(package_json)
-  for k,v in pairs(server_settings) do
+  for k,_ in pairs(server_settings) do
     if default_server_settings[k] == nil then
       return {}
     end


### PR DESCRIPTION
<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->

The PR will add validate_server_settings to utils, letting users validate server specific settings. 

- [x] Create Lua Table For Default Settings From Package.json
- [x] Create Basic Implementation for validate_server_settings
- [x]  Improve validate_server_settings to check nested tables