### PR TITLE
lspinfo: add neovim log path in header

### DIFF
--- a/lua/lspconfig/lspinfo.lua
+++ b/lua/lspconfig/lspinfo.lua
@@ -21,6 +21,7 @@ return function ()
 
   local header = {
     "Configured servers: "..table.concat(vim.tbl_keys(configs), ', '),
+    "Neovim logs at: "..(vim.lsp.get_log_path()),
     "",
     tostring(#buf_clients).." client(s) attached to this buffer: "..table.concat(buf_client_names, ', '),
   }


### PR DESCRIPTION
I am usually against this type of overengineering but LSP configuration is so complex that it may be a good idea to parse the server commands and look for their logfile as well so we can display it when we see it.
For instance hls has:
```
	settings = {
			haskell = {
			completionSnippetsOn = false,
			formattingProvider = "stylish-haskell",
				logFile = "/tmp/nvim-hls.log",
				hlintOn = false
		}
	}
```
Or even more generic, a per server debug function.