### PR TITLE
rust_analyzer: don't fetch deps in root_dir

### DIFF
--- a/lua/lspconfig/rust_analyzer.lua
+++ b/lua/lspconfig/rust_analyzer.lua
@@ -6,7 +6,7 @@ configs.rust_analyzer = {
     cmd = {"rust-analyzer"};
     filetypes = {"rust"};
     root_dir = function(fname)
-      local cargo_metadata = vim.fn.system("cargo metadata --format-version 1")
+      local cargo_metadata = vim.fn.system("cargo metadata --no-deps --format-version 1")
       local cargo_root = nil
       if vim.v.shell_error == 0 then
         cargo_root = vim.fn.json_decode(cargo_metadata)["workspace_root"]


### PR DESCRIPTION
Use `cargo metadata --no-deps` to avoid fetching dependencies that haven't been downloaded yet when getting the cargo workspace directory to avoid hangs.