### PR TITLE
Fix clangd when default_config not set

### DIFF
--- a/lua/lspconfig/clangd.lua
+++ b/lua/lspconfig/clangd.lua
@@ -14,7 +14,9 @@ end
 
 local root_pattern = util.root_pattern("compile_commands.json", "compile_flags.txt", ".git")
 
-local default_capabilities = vim.tbl_deep_extend('force', util.default_config.capabilities, {
+local default_capabilities = vim.tbl_deep_extend(
+  'force',
+  util.default_config.capabilities or vim.lsp.protocol.make_client_capabilities(), {
   textDocument = {
     completion = {
       editsNearCursor = true


### PR DESCRIPTION
@runiq Can you test this?

From CI from your last PR:

```
Run :checkhealth for more info
26
Error detected while processing command line:
27
E5113: Error while calling lua chunk: vim/shared.lua:219: after the second argument: expected table, got nil
28
stack traceback:
29
	vim/shared.lua:219: in function 'tbl_deep_extend'
30
	...k/nvim-lspconfig/nvim-lspconfig/lua/lspconfig/clangd.lua:17: in main chunk
31
	[C]: in function 'require'
32
	scripts/docgen.lua:81: in function 'require_all_configs'
33
	scripts/docgen.lua:230: in main chunk
34
Error: Process completed with exit code 1.
```