### PR TITLE
Use vim.api.nvim_create_buf instead of vim.fn.nvim_create_buf

### DIFF
--- a/lua/lspconfig/_lspui.lua
+++ b/lua/lspconfig/_lspui.lua
@@ -91,7 +91,7 @@ function win_float.percentage_range_window(col_range, row_range, options)
   win_opts.col = math.floor(vim.o.columns * col_start_percentage)
   win_opts.width = math.floor(vim.o.columns * width_percentage)
 
-  local bufnr = options.bufnr or vim.fn.nvim_create_buf(false, true)
+  local bufnr = options.bufnr or vim.api.nvim_create_buf(false, true)
   local win_id = vim.fn.nvim_open_win(bufnr, true, win_opts)
   vim.api.nvim_win_set_buf(win_id, bufnr)
 


### PR DESCRIPTION
Now that https://github.com/neovim/neovim/pull/13875, using `vim.fn.nvim_create_buf` throws an error.