### PR TITLE
refactor(vala): refine vala project root detection

### DIFF
--- a/lua/lspconfig/vala_ls.lua
+++ b/lua/lspconfig/vala_ls.lua
@@ -1,13 +1,34 @@
 local configs = require 'lspconfig/configs'
 local util = require 'lspconfig/util'
 
+local meson_matcher = function (path)
+  local pattern = "meson.build"
+  local f = vim.fn.glob(util.path.join(path, pattern))
+  if f == '' then
+    return nil
+  end
+  for line in io.lines(f) do
+    -- skip meson comments
+    if not line:match('^%s*#.*') then
+      local str = line:gsub('%s+', '')
+      if str ~= '' then
+        if str:match('^project%(') then
+          return path
+        else
+          break
+        end
+      end
+    end
+  end
+end
+
 configs.vala_ls = {
   default_config = {
     cmd = {'vala-language-server'},
     filetypes = {'vala', 'genie'},
-    root_dir = function(fname)
-      return util.root_pattern("meson.build")(fname)
-        or util.find_git_ancestor(fname)
+    root_dir = function (fname)
+      local root = util.search_ancestors(fname, meson_matcher)
+      return root or util.find_git_ancestor(fname)
     end,
   },
   docs = {


### PR DESCRIPTION
take `https://github.com/phw/peek` or `https://github.com/benwaffle/vala-language-server` for example,


```shell
git clone https://github.com/benwaffle/vala-language-server
cd vala-language-server
nvim
```
we opened `src/server.vala` then the lsp will run `meson build` under the wrong dir `src/`

because the `src` dir has a file named `meson.build` which actully is not a real `meson.build`,
it is included by the root `meson.build`, and the lsp server will complain the "ERROR: First statement must be a call to project"


this PR:

1. detect the valid `meson.build` file by detection first line include `project(` detective or not
~~2. prefer cwd if root is a descendant, otherwise fallback to git repo~~
