### PR TITLE
sumneko: do not send telemetry data by default

### DIFF
--- a/lua/lspconfig/sumneko_lua.lua
+++ b/lua/lspconfig/sumneko_lua.lua
@@ -10,6 +10,7 @@ configs[name] = {
       return util.find_git_ancestor(fname) or util.path.dirname(fname)
     end;
     log_level = vim.lsp.protocol.MessageType.Warning;
+    settings = { Lua = { telemetry = { enable = false }}};
   };
   docs = {
     package_json = "https://raw.githubusercontent.com/sumneko/vscode-lua/master/package.json";
@@ -58,6 +59,10 @@ require'lspconfig'.sumneko_lua.setup {
           [vim.fn.expand('$VIMRUNTIME/lua')] = true,
           [vim.fn.expand('$VIMRUNTIME/lua/vim/lsp')] = true,
         },
+      },
+      -- Do not send telemetry data containing a randomized but unique identifier
+      telemetry = {
+        enable = false,
       },
     },
   },


### PR DESCRIPTION
By default, sumneko sends telemetry data containing a [randomized but unique identifier](https://github.com/sumneko/lua-language-server/blob/master/script/service/telemetry.lua#L12) to a Chinese IP. The token can be found in `lua-language-server/log/token`.

The string sent looks like this in my case (I X'ed the identifier):

```
$...pulse.XXXXXXXXXXXXXXXX.Neovim 0.5.0.J...platform.XXXXXXXXXXXXXXXX.macOS 64.libc++ libc++ 10000.clang Clang 12.0.0.
```

In case of errors, that log is sent, too. You can visit the IP to get a summary of the collected data: http://119.45.194.183

Telemetry data should always be opt-in, IMHO.