### PR TITLE
pyright: add package_json path

### DIFF
--- a/lua/lspconfig/pyright.lua
+++ b/lua/lspconfig/pyright.lua
@@ -47,6 +47,7 @@ configs[server_name] = {
     };
   };
   docs = {
+    package_json = 'https://raw.githubusercontent.com/microsoft/pyright/master/packages/vscode-pyright/package.json',
     description = [[
 https://github.com/microsoft/pyright
 


### PR DESCRIPTION
I think we can use the [package.json](https://raw.githubusercontent.com/microsoft/pyright/master/packages/vscode-pyright/package.json) in vscode-pyright for the package.json of pyright, what do you think?

I'd be happy to hear your opinion on this.