### PR TITLE
yamlls: Fix file-not-found on windows

### DIFF
--- a/lua/lspconfig/yamlls.lua
+++ b/lua/lspconfig/yamlls.lua
@@ -2,7 +2,13 @@ local configs = require 'lspconfig/configs'
 local util = require 'lspconfig/util'
 
 local server_name = "yamlls"
-local bin_name = "yaml-language-server"
+
+local bin_name
+if vim.fn.has("win32") == 1 then
+  bin_name = "yaml-language-server.cmd"
+else
+  bin_name = "yaml-language-server"
+end
 
 configs[server_name] = {
   default_config = {


### PR DESCRIPTION
You currently get a file not found error on windows as a result of yamlls having a different name than on other systems.
Yamlls as installed by npm is going to be called `yaml-language-server.cmd`, not `yaml-language-server` like on unix systems.

Closes #807