### PR TITLE
Doc: Remove the util prefix to avoid ambiguity and also to unify

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -107,7 +107,7 @@ require'lspconfig'.als.setup{}
   Default Values:
     cmd = { "ada_language_server" }
     filetypes = { "ada" }
-    root_dir = util.root_pattern("Makefile", ".git")
+    root_dir = root_pattern("Makefile", ".git")
 ```
 
 ## angularls

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -107,7 +107,7 @@ require'lspconfig'.als.setup{}
   Default Values:
     cmd = { "ada_language_server" }
     filetypes = { "ada" }
-    root_dir = root_pattern("Makefile", ".git")
+    root_dir = util.root_pattern("Makefile", ".git")
 ```
 
 ## angularls

--- a/lua/lspconfig/als.lua
+++ b/lua/lspconfig/als.lua
@@ -35,7 +35,7 @@ require('lspconfig').als.setup{
 ```
 ]];
     default_config = {
-      root_dir = [[util.root_pattern("Makefile", ".git")]];
+      root_dir = [[root_pattern("Makefile", ".git")]];
     };
   };
 };


### PR DESCRIPTION
The others do not have the `util` prefix