### PR TITLE
Add tflint configuration

### DIFF
--- a/lua/lspconfig/tflint.lua
+++ b/lua/lspconfig/tflint.lua
@@ -1,0 +1,22 @@
+local configs = require "lspconfig/configs"
+local util = require "lspconfig/util"
+
+configs.tflint = {
+  default_config = {
+    cmd = {"tflint", "--langserver"},
+    filetypes = {"terraform"},
+    root_dir = util.root_pattern(".terraform", ".git", ".tflint.hcl")
+  },
+  docs = {
+    description = [[
+https://github.com/terraform-linters/tflint
+
+A pluggable Terraform linter that can act as lsp server.
+Installation instructions can be found in https://github.com/terraform-linters/tflint#installation.
+]],
+    default_config = {
+      root_dir = [[root_pattern(".terraform", ".git", ".tflint.hcl")]]
+    }
+  }
+}
+-- vim:et ts=2 sw=2


### PR DESCRIPTION
tflint (https://github.com/terraform-linters/tflint) is a linter for Terraform which can also act as a language server. Would it be okay to include its configuration to the project? Thank you.

<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->
