### PR TITLE
Fix conditional keymap in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,9 @@ local on_attach = function(client, bufnr)
   -- Set some keybinds conditional on server capabilities
   if client.resolved_capabilities.document_formatting then
     buf_set_keymap("n", "<space>f", "<cmd>lua vim.lsp.buf.formatting()<CR>", opts)
-  elseif client.resolved_capabilities.document_range_formatting then
-    buf_set_keymap("n", "<space>f", "<cmd>lua vim.lsp.buf.range_formatting()<CR>", opts)
+  end
+  if client.resolved_capabilities.document_range_formatting then
+    buf_set_keymap("v", "<space>f", "<cmd>lua vim.lsp.buf.range_formatting()<CR>", opts)
   end
 
   -- Set autocommands conditional on server_capabilities


### PR DESCRIPTION
The recommended configuration in the `README.md` doesn't setup the keymap for range formatting correctly: this needs to be done independent from the full document formatting and making sure the keymap is set in visual mode as it's meant to work on the selection.