### PR TITLE
Make intelephense work on Windows

### DIFF
--- a/lua/lspconfig/intelephense.lua
+++ b/lua/lspconfig/intelephense.lua
@@ -4,6 +4,10 @@ local util = require 'lspconfig/util'
 local server_name = "intelephense"
 local bin_name = "intelephense"
 
+if vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
+  bin_name = bin_name .. ".cmd"
+end
+
 configs[server_name] = {
   default_config = {
     cmd = {bin_name, "--stdio"};


### PR DESCRIPTION
This commit is just to add `.cmd` to the binary name `intelephense` so that the binary name becomes `intelephense.cmd`. LSP Neovim on Windows need to execute command 'intelephense.cmd' for LSP server to work.