### PR TITLE
Use the file path as root_dir when ccls does not find root_dir

### DIFF
--- a/lua/lspconfig/ccls.lua
+++ b/lua/lspconfig/ccls.lua
@@ -5,7 +5,9 @@ configs.ccls = {
   default_config = {
     cmd = {"ccls"};
     filetypes = {"c", "cpp", "objc", "objcpp"};
-    root_dir = util.root_pattern("compile_commands.json", "compile_flags.txt", ".git");
+    root_dir = function(fname)
+      return util.root_pattern("compile_commands.json", "compile_flags.txt", ".git")(fname) or util.path.dirname(fname)
+    end;
   };
   docs = {
     description = [[
@@ -35,7 +37,7 @@ lspconfig.ccls.setup {
 
 ]];
     default_config = {
-      root_dir = [[root_pattern("compile_commands.json", "compile_flags.txt", ".git")]];
+      root_dir = [[root_pattern("compile_commands.json", "compile_flags.txt", ".git") or dirname]];
     };
   };
 }


### PR DESCRIPTION
Problem: when root_dir is not found, ccls does not work.

This pull request is using the file path as root_dir when ccls does not find root_dir