### PR TITLE
Update ocaml default settings

### DIFF
--- a/lua/lspconfig/ocamlls.lua
+++ b/lua/lspconfig/ocamlls.lua
@@ -8,7 +8,7 @@ configs[server_name] = {
   default_config = {
     cmd = { bin_name, "--stdio" };
     filetypes = { "ocaml", "reason" };
-    root_dir = util.root_pattern(".merlin", "package.json");
+    root_dir = util.root_pattern("*.opam","esy.json","package.json");
   };
   docs = {
     description = [[
@@ -20,7 +20,7 @@ npm install -g ocaml-langauge-server
 ```
     ]];
     default_config = {
-      root_dir = [[root_pattern(".merlin", "package.json")]];
+      root_dir = [[root_pattern("*.opam", "esy.json", "package.json")]];
     };
   };
 };

--- a/lua/lspconfig/ocamlls.lua
+++ b/lua/lspconfig/ocamlls.lua
@@ -8,7 +8,7 @@ configs[server_name] = {
   default_config = {
     cmd = { bin_name, "--stdio" };
     filetypes = { "ocaml", "reason" };
-    root_dir = util.root_pattern("*.opam","esy.json","package.json");
+    root_dir = util.root_pattern("*.opam", "esy.json", "package.json");
   };
   docs = {
     description = [[

--- a/lua/lspconfig/ocamllsp.lua
+++ b/lua/lspconfig/ocamllsp.lua
@@ -5,7 +5,7 @@ configs.ocamllsp = {
   default_config = {
     cmd = {"ocamllsp",};
     filetypes = {'ocaml', 'reason'};
-    root_dir = util.root_pattern(".merlin", "package.json", ".git");
+    root_dir = util.root_pattern("*.opam","esy.json","package.json", ".git");
   };
   docs = {
     description = [[
@@ -20,7 +20,7 @@ opam install ocaml-lsp-server
 ```
     ]];
     default_config = {
-      root_dir = [[root_pattern(".merlin", "package.json")]];
+      root_dir = [[root_pattern("*.opam","esy.json","package.json",".git")]];
     };
   };
 }

--- a/lua/lspconfig/ocamllsp.lua
+++ b/lua/lspconfig/ocamllsp.lua
@@ -5,7 +5,7 @@ configs.ocamllsp = {
   default_config = {
     cmd = {"ocamllsp",};
     filetypes = {'ocaml', 'reason'};
-    root_dir = util.root_pattern("*.opam","esy.json","package.json", ".git");
+    root_dir = util.root_pattern("*.opam", "esy.json", "package.json", ".git");
   };
   docs = {
     description = [[
@@ -20,7 +20,7 @@ opam install ocaml-lsp-server
 ```
     ]];
     default_config = {
-      root_dir = [[root_pattern("*.opam","esy.json","package.json",".git")]];
+      root_dir = [[root_pattern("*.opam", "esy.json", "package.json", ".git")]];
     };
   };
 }


### PR DESCRIPTION
Since .merlin is now being [generated](https://tarides.com/blog/2021-01-26-recent-and-upcoming-changes-to-merlin) by dune build system, it will be less common to see it, so instead of using it as a default value i add a `*.opam` which almost every OCaml projects has it, i also added `esy.json` since it is an alternative to `package.json` in esy projects