### PR TITLE
update stylelint_lsp documentation

### DIFF
--- a/lua/lspconfig/stylelint_lsp.lua
+++ b/lua/lspconfig/stylelint_lsp.lua
@@ -20,6 +20,7 @@ configs.stylelint_lsp = {
     settings = {};
   },
   docs = {
+    package_json = "https://raw.githubusercontent.com/bmatcuk/coc-stylelintplus/master/package.json";
     description = [[
 https://github.com/bmatcuk/stylelint-lsp
 
@@ -27,6 +28,18 @@ https://github.com/bmatcuk/stylelint-lsp
 
 ```sh
 npm i -g stylelint-lsp
+```
+
+Can be configured by passing a `settings.stylelintplus` object to `stylelint_lsp.setup`:
+
+```lua
+require'lspconfig'.stylelint_lsp.setup{
+  settings = {
+    stylelintplus = {
+      -- see available options in stylelint-lsp documentation
+    }
+  }
+}
 ```
 ]];
     default_config = {


### PR DESCRIPTION
I am the maintainer of stylelint-lsp. I recently [had a question](https://github.com/bmatcuk/stylelint-lsp/issues/13) about configuring stylelint-lsp in lspconfig, so I wanted to update the documentation. stylelint-lsp was originally written for [coc.nvim](https://github.com/neoclide/coc.nvim), which already had a stylelint plugin, so I had to use a different name for the project - one that is, sadly, not intuitive for configuring the settings in lspconfig: `stylelintplus`. I also maintain the [coc-stylelintplus](https://github.com/bmatcuk/coc-stylelintplus) project which has all of the settings details in the package.json, so I've included that in the documentation.

Happy to make any additional changes to this PR =) I have _very_ little experience with lua, so I hope I didn't mess that up.