### PR TITLE
Use dofile instead of require for faster loading

### DIFF
--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -85,7 +85,7 @@ end
 local mt = {}
 function mt:__index(k)
   if configs[k] == nil then
-    pcall(require, 'lspconfig/'..k)
+    pcall(dofile, 'lspconfig/' .. k .. ".lua")
   end
   return configs[k]
 end


### PR DESCRIPTION
Closes #239

With this change, sourcing every language server takes < 1 ms (we don't need to add these to the module list as the configurations are added to a global table. 

The entire time for me to load lspconfig with this and #859 is now 6 ms.

