### PR TITLE
feat: try to run lsp client at startup

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -56,6 +56,11 @@ function configs.__newindex(t, config_name, config_def)
       trigger = "BufReadPost *"
     end
     if not (config.autostart == false) then
+      if not config.filetypes or vim.tbl_contains(config.filetypes, vim.bo.ft) then
+        vim.schedule(function()
+          M.manager.try_add()
+        end)
+      end
       api.nvim_command(string.format(
           "autocmd %s lua require'lspconfig'[%q].manager.try_add()"
           , trigger


### PR DESCRIPTION
This change makes it so that an lsp client gets attached to a directly opened file, i.e.

```
nvim /path/to/file.lua
```

Currently, when a file gets opened this way, the lsp client is started, but the file buffer itself is not getting attached via `manager.try_add()`. A user has to work around this problem, by postponing the opening of a file. For example:

```
nvim -c ':e /path/to/file.lua'
```