### PR TITLE
Validate buffer before setup

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -188,6 +188,9 @@ function configs.__newindex(t, config_name, config_def)
   end
 
   function M._setup_buffer(client_id, bufnr)
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+      return
+    end
     local client = lsp.get_client_by_id(client_id)
     if client.config._on_attach then
       client.config._on_attach(client, bufnr)


### PR DESCRIPTION
I wrote a plugin to switch sessions and I am intermittently encountering the following error:
![изображение](https://user-images.githubusercontent.com/22453358/116323707-456c7b80-a7c7-11eb-91f7-6ad0307df0df.png)
[This](https://github.com/Shatur95/neovim-session-manager/blob/74bc3400d8cdb28a2089153614b210098bd6aa1e/lua/session_manager/init.lua#L19) code triggers the issue.
This PR fixes this problem by adding a buffer validation check. I think that this check will not hurt even for such a specific use case.