### PR TITLE
Add configuration for java-language-server

### DIFF
--- a/lua/lspconfig/java_language_server.lua
+++ b/lua/lspconfig/java_language_server.lua
@@ -1,0 +1,22 @@
+local lspconfig = require('lspconfig')
+local configs = require('lspconfig/configs')
+
+local name = 'java_language_server'
+
+configs[name] = {
+  default_config = {
+    cmd = {};
+    filetypes = {'java'};
+    root_dir = lspconfig.util.root_pattern('build.gradle', 'pom.xml', '.git');
+    settings = {}
+  };
+  docs = {
+    description = [[
+https://github.com/georgewfraser/java-language-server
+
+Java language server
+
+Point `cmd` to `lang_server_linux.sh` or the equivalent script for macOS/Windows provided by java-language-server
+]]
+  }
+}


### PR DESCRIPTION
I found this to be an easier setup compared to jdtls so I think it should be included here as an alternative.