### PR TITLE
Add unified language server support

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -74,6 +74,8 @@ that config.
 - [texlab](#texlab)
 - [tflint](#tflint)
 - [tsserver](#tsserver)
+- [unified_language_server_md](#unified_language_server_md)
+- [unified_language_server_txt](#unified_language_server_txt)
 - [vala_ls](#vala_ls)
 - [vimls](#vimls)
 - [vls](#vls)
@@ -5440,6 +5442,48 @@ require'lspconfig'.tsserver.setup{}
     cmd = { "typescript-language-server", "--stdio" }
     filetypes = { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" }
     root_dir = root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")
+```
+
+## unified_language_server_md
+
+[Unified language server](https://github.com/unifiedjs/unified-language-server) designed by UnifiedJS
+
+Can be installed via npm or yarn
+```bash
+npm install -g unified-language-server  # npm
+yarn global add unified-language-server # yarn
+```
+
+
+```lua
+require'lspconfig'.unified_language_server_md.setup{}
+  Commands:
+  
+  Default Values:
+    cmd = { "unified-language-server", "--parser=remark-parse", "--stdio" }
+    filetypes = { "markdown" }
+    root_dir = util.path.dirname
+```
+
+## unified_language_server_txt
+
+[Unified language server](https://github.com/unifiedjs/unified-language-server) designed by UnifiedJS
+
+Can be installed via npm or yarn
+```bash
+npm install -g unified-language-server  # npm
+yarn global add unified-language-server # yarn
+```
+
+
+```lua
+require'lspconfig'.unified_language_server_txt.setup{}
+  Commands:
+  
+  Default Values:
+    cmd = { "unified-language-server", "--parser=retext-english", "--stdio" }
+    filetypes = { "text" }
+    root_dir = util.path.dirname
 ```
 
 ## vala_ls

--- a/lua/lspconfig/unified_language_server_md.lua
+++ b/lua/lspconfig/unified_language_server_md.lua
@@ -1,0 +1,25 @@
+local configs = require 'lspconfig/configs'
+local util = require 'lspconfig/util'
+
+configs.unified_language_server_md = {
+  default_config = {
+    cmd = { "unified-language-server", "--parser=remark-parse", "--stdio" },
+    filetypes = {"markdown"},
+    root_dir = util.path.dirname,
+  },
+  docs = {
+    description = [[
+[Unified language server](https://github.com/unifiedjs/unified-language-server) designed by UnifiedJS
+
+Can be installed via npm or yarn
+```bash
+npm install -g unified-language-server  # npm
+yarn global add unified-language-server # yarn
+```
+]];
+    default_config = {
+      root_dir = "util.path.dirname";
+    }
+  }
+}
+

--- a/lua/lspconfig/unified_language_server_txt.lua
+++ b/lua/lspconfig/unified_language_server_txt.lua
@@ -1,0 +1,26 @@
+local configs = require 'lspconfig/configs'
+local util = require 'lspconfig/util'
+
+configs.unified_language_server_txt = {
+  default_config = {
+    cmd = { "unified-language-server", "--parser=retext-english", "--stdio" },
+    filetypes = {"text"},
+    root_dir = util.path.dirname,
+  },
+  docs = {
+    description = [[
+[Unified language server](https://github.com/unifiedjs/unified-language-server) designed by UnifiedJS
+
+Can be installed via npm or yarn
+```bash
+npm install -g unified-language-server  # npm
+yarn global add unified-language-server # yarn
+```
+]];
+    default_config = {
+      root_dir = "util.path.dirname";
+    }
+  }
+}
+
+


### PR DESCRIPTION
Adds [Unified Language Server](https://github.com/unifiedjs/unified-language-server) for markdown and text files.

I had to make two entries: `unified_language_server_md` and `unified_language_server_txt` due to it having different arguments depending on what you want to check.

I ran the linters with success but had to manually generate the docs because the script would change way too many things.