### PR TITLE
Allow EFM to work on non-git repos

### DIFF
--- a/lua/lspconfig/efm.lua
+++ b/lua/lspconfig/efm.lua
@@ -8,7 +8,9 @@ local bin_name = "efm-langserver"
 configs[server_name] = {
   default_config = {
     cmd = {bin_name};
-    root_dir = util.root_pattern(".git");
+    root_dir = function(fname)
+      return util.root_pattern(".git")(fname) or util.path.dirname(fname)
+    end;
   };
 
   docs = {
@@ -18,7 +20,7 @@ https://github.com/mattn/efm-langserver
 General purpose Language Server that can use specified error message format generated from specified command.
 ]];
     default_config = {
-      root_dir = [[root_pattern(".git")]];
+      root_dir = [[util.root_pattern(".git")(fname) or util.path.dirname(fname)]];
     };
   };
 }


### PR DESCRIPTION
The current settings for EFM make it so that it will only work within a git repository.

This change adds a fallback, so that if the current file is _not_ inside a git repository
then the current directory is used instead.

This is useful, for example, when opening a random python file, so as to get feedback
from the system flake8.