### PR TITLE
Remove pylsp default_config doc

### DIFF
--- a/lua/lspconfig/pylsp.lua
+++ b/lua/lspconfig/pylsp.lua
@@ -27,11 +27,8 @@ A Python 3.6+ implementation of the Language Server Protocol.
 The language server has to be installed separately for example by `pipx install python-lsp-server`.
 Further instructions can be found in the [project's README](https://github.com/python-lsp/python-lsp-server).
 
-Note: This is a community for of `pyls`.
+Note: This is a community fork of `pyls`.
     ]];
-    default_config = {
-      root_dir = "vim's starting directory";
-    };
   };
 };
 -- vim:et ts=2 sw=2


### PR DESCRIPTION
See https://github.com/neovim/nvim-lspconfig/pull/883#discussion_r628316250

Today docgen made it to finish on my machine :upside_down_face: It now takes the `default_config` from the code.