### PR TITLE
docgen: explicitly allow pushing commits

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   docgen:
     runs-on: [ubuntu-latest]
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v2
     - run: date +%F > todays-date


### PR DESCRIPTION
We default to read-only permissions for the "contents" scope:

  https://github.com/neovim/nvim-lspconfig/settings/actions

Explicitly allow pushing commits.

https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-contents