### PR TITLE
Add multiple types for ocamllsp

### DIFF
--- a/lua/lspconfig/ocamllsp.lua
+++ b/lua/lspconfig/ocamllsp.lua
@@ -2,7 +2,10 @@ local configs = require 'lspconfig/configs'
 local util = require 'lspconfig/util'
 
 local language_id_of = {
+  menhir = 'ocaml.menhir';
   ocaml = 'ocaml';
+  ocamlinterface = 'ocaml.interface';
+  ocamllex = 'ocaml.ocamllex';
   reason = 'reason';
 }
 

--- a/lua/lspconfig/ocamllsp.lua
+++ b/lua/lspconfig/ocamllsp.lua
@@ -1,11 +1,25 @@
 local configs = require 'lspconfig/configs'
 local util = require 'lspconfig/util'
 
+local language_id_of = {
+  ocaml = 'ocaml';
+  reason = 'reason';
+}
+
+local filetypes = {}
+
+for ftype, _ in pairs(language_id_of) do
+  table.insert(filetypes, ftype)
+end
+
+local get_language_id = function (_, ftype) return language_id_of[ftype] end
+
 configs.ocamllsp = {
   default_config = {
     cmd = {"ocamllsp",};
-    filetypes = {'ocaml', 'reason'};
+    filetypes = filetypes;
     root_dir = util.root_pattern("*.opam", "esy.json", "package.json", ".git");
+    get_language_id = get_language_id;
   };
   docs = {
     description = [[


### PR DESCRIPTION
Hi, I'm working on splitting the ocaml filetype into several ones.

Historically several file formats have been detected as just "ocaml" filetype. The filetype needs splitting because they need to uses specialized tree-sitter parsers. The plan is to adapt plugins like this one to support the filetypes before the breaking change of splitting the filetype is introduced into (neo)vim: https://github.com/ocaml/vim-ocaml/pull/61

This PR adds support for these filetypes while maintaining current behaviour when all file formats are detected as the ocaml filetype. To further complicate matters the new filetypes and the language_id expected by the server are different, so a map is added and get_language_id is defined. 


I'm new to lua, feel free to point out errors in style, I'll gladly fix them.