### PR TITLE
Update documentation round 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Neovim supports the Language Server Protocol (LSP), which means it acts as a cli
 - format 
 - refactor
 
-Neovim provides an interface for all of these features, and the language server client is designed to be highly extensible to allow plugins to integrate language server features which are not yet present in Neovim core such as [**auto**-completion](https://github.com/neovim/nvim-lspconfig/wiki/Autocompletion) (as opposed to manual completion with omnifunc) and [snippet integration](https://github.com/neovim/nvim-lspconfig/wiki/Snippets).
+See `:h lsp-method` for more.
+
+Neovim provides an interface for all of these features, and the language server client is designed to allow plugins to integrate language server features which are not yet present in Neovim core, such as [**auto**-completion](https://github.com/neovim/nvim-lspconfig/wiki/Autocompletion) (as opposed to manual completion with omnifunc) and [snippet integration](https://github.com/neovim/nvim-lspconfig/wiki/Snippets).
 
 These features are not implemented in this repo, but in Neovim core. See `:help lsp` for more details.
 

--- a/scripts/vimdocgen.lua
+++ b/scripts/vimdocgen.lua
@@ -8,13 +8,9 @@ docs.generate = function()
     output_file = "./doc/lspconfig.txt",
     project_name = "lspconfig",
     header_aliases = {
-      ["Example: using the defaults"] = {"Defaults", "defaults"},
-      ["Example: override some defaults"] = {"Overriding server defaults", "override-server-defaults"},
-      ["Example: custom config"] = {"Custom config", "custom-config"},
-      ["Example: override default config for all servers"] = {"Overriding all defaults",  "override-all-defaults"},
-      ["Individual server settings and initialization options"] = { "Per-server documentation", "server-documentation"},
+      ["Automatically launching language servers"] = {"root-detection", "root-detection"},
+      ["Enabling additional language servers"] = {"adding-servers", "adding-servers"},
       ["Keybindings and completion"] = {"Keybindings", "keybindings"},
-      ["Manually starting (or restarting) language servers"] = {"Manual control", "manual-control"}
     }
   }
   docgen.generate_readme(metadata)


### PR DESCRIPTION
I merged the majority of the changes, which I think were already positive. Copying the feedback here.

levouh: You think there should be a table of contents, but possibly github's auto TOC mitigates this

levouh: You think we should add a little bit of wording above each mapped function to explain what they do (already did some of this)

David-Else: You think "Automatically launching language servers" should be renamed to explicitly call out root dir

