### PR TITLE
Add doc/tags to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .luacheckcache
 neovim
+doc/tags


### PR DESCRIPTION
I keep my plugins in submodules in my dotfiles repo, which I load through the builtin plugin manager. When I generate helptags, a file is put in `doc/tags`, which should be ignored by git. This ends up being annoying because it is shown in the git status in my main dotfiles repo as "uncommitted changes".