### PR TITLE
Require config if dofile cannot find file

### DIFF
--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -89,6 +89,9 @@ function mt:__index(k)
     -- dofile is used here as a performance hack to increase the speed of calls to setup({})
     -- dofile does not cache module lookups, and requires the absolute path to the target file
     pcall(dofile, script_path .. 'lspconfig/' .. k .. ".lua")
+    if configs[k] == nil then
+      pcall(require, 'lspconfig/' .. k)
+    end
   end
   return configs[k]
 end


### PR DESCRIPTION
When a plugin (or user's config) tries to extend **lspconfig** with a config file i.e. `lua/lspconfig/my_server.lua`, dofile won't be able to find it because it uses the absolute path.

Now:
```lua
require("lspconfig/my_server") -- it's now required because of dofile
require("lspconfig").my_server.setup {}
```

With this PR, it should work the way it used to:
```lua
require("lspconfig").my_server.setup {}
```


Would it be possible to add the require back in case dofile does not find the file? It shouldn't have any impact in performance because it would only use require in case dofile does not find it.

