### PR TITLE
jdtls: add package_json path

### DIFF
--- a/lua/lspconfig/jdtls.lua
+++ b/lua/lspconfig/jdtls.lua
@@ -127,6 +127,7 @@ configs[server_name] = {
     };
   };
   docs = {
+    package_json = "https://raw.githubusercontent.com/redhat-developer/vscode-java/master/package.json",
     description = [[
 
 https://projects.eclipse.org/projects/eclipse.jdt.ls


### PR DESCRIPTION
I think we can use the [package.json](https://github.com/redhat-developer/vscode-java/blob/master/package.json) in [vscode-java](https://github.com/redhat-developer/vscode-java) for the `package.json` of `jdtls`, what do you think?

Thank you!