### PR TITLE
Correct prior commit: Update rome.lua link to website

### DIFF
--- a/lua/lspconfig/rome.lua
+++ b/lua/lspconfig/rome.lua
@@ -21,7 +21,7 @@ configs.rome = {
   },
   docs = {
       description = [[
-https://romefrontend.dev
+https://rome.tools
 
 Language server for the Rome Frontend Toolchain.
 


### PR DESCRIPTION
This fixes #945 by updating the link in the rome.lua rather than the autogenerated file.