### PR TITLE
Better root directory detection when using rust-analyzer

### DIFF
--- a/lua/lspconfig/rust_analyzer.lua
+++ b/lua/lspconfig/rust_analyzer.lua
@@ -16,14 +16,7 @@ configs.rust_analyzer = {
     cmd = {"rust-analyzer"};
     filetypes = {"rust"};
     root_dir = function(fname)
-      -- Order of preference for how we choose the root dir:
-      --   * Current Cargo workspace (if any)
-      --   * Current Cargo crate (if any)
-      --   * Rust project root, for projects that don't use Cargo (if any)
-      --   * Current git repository
       local cargo_crate_dir = util.root_pattern("Cargo.toml")(fname)
-      -- Make sure that we run `cargo metadata` in the current project dir
-      -- rather that the dir from which nvim was initially launched.
       local cmd = "cargo metadata --no-deps --format-version 1"
       if cargo_crate_dir ~= nil then
         cmd = cmd .. " --manifest-path " .. util.path.join(cargo_crate_dir, "Cargo.toml")
@@ -31,12 +24,12 @@ configs.rust_analyzer = {
       local cargo_metadata = vim.fn.system(cmd)
       local cargo_workspace_dir = nil
       if vim.v.shell_error == 0 then
-        cargo_worspace_dir = vim.fn.json_decode(cargo_metadata)["workspace_root"]
+        cargo_workspace_dir = vim.fn.json_decode(cargo_metadata)["workspace_root"]
       end
       return cargo_workspace_dir or
         cargo_crate_dir or
-        nvim_lsp.util.root_pattern("rust-project.json")(fname) or
-        nvim_lsp.util.find_git_ancestor(fname)
+        util.root_pattern("rust-project.json")(fname) or
+        util.find_git_ancestor(fname)
     end;
     settings = {
       ["rust-analyzer"] = {}


### PR DESCRIPTION
This is a change I made in my own local nvim-lspconfig configuration but since I believe it makes things more "correct" I figured it was worth upstreaming.

The previous implementation had a couple of flaws, in particular when working with larger repositories containing multiple crates and potentially multiple Cargo workspaces.

- It would pick the current git repository by default.
- The workspace root resolution (via `cargo metadata`) was done based on the current working directory rather than the current buffer. In cases where nvim is launched at the root of the repo but a file deep down into a Cargo workspace is being edited, I would expect the workspace for that file to be chosen rather than the root of the repo.

For these reasons, we make the following changes:

- Identify the current Cargo workspace walking up from the *current* file being edited rather than the nvim cwd.
- Swap the order of preferences for root dir selection to be 1) workspace 2) crate 3) non cargo rust project root 4) git repository.

Since all existing locations are still being checked I'm not expecting this to be breaking existing workflows but to rather provide more precise root directory detection.