### PR TITLE
Fix starting the LSP server when creating a new file

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -157,7 +157,7 @@ M.path = (function()
 
   -- Iterate the path until we find the rootdir.
   local function iterate_parents(path)
-    path = uv.fs_realpath(path)
+    path = uv.fs_realpath(path) or path
     local function it(s, v)
       if not v then return end
       if is_fs_root(v) then return end


### PR DESCRIPTION
I ran into a problem where language servers weren't starting properly if I edited a new file (e.g. running nvim foo.go inside a git repository or directory with a go.mod file inside, but where foo.go doesn't yet exist), and think I've tracked down the issue.

As part of looking for the root directory, the code uses vim.loop.fs_realpath to resolve symlinks. This doesn't work if the path involved doesn't yet exist (such as when creating a new file). The current behavior is to give up at this point as the returned 'real' path is nil, but we can do better by taking the unresolved path and just allowing the iterate_parents path to get the directory that the file is in (which will likely exist in most cases). This change does just that - if fs_realpath returns nil, then we just proceed with the unresolved path.

This allows language servers to autostart even if the file doesn't yet exist. Apparently some language servers do require the file to exist beforehand anyway, but this will allow those without that restriction to work correctly. I tested it at least with terraform-ls and gopls and it seems to work fine.