### PR TITLE
clangd: "can’t" -> "cannot" in switchSourceHeader failure message

### DIFF
--- a/lua/lspconfig/clangd.lua
+++ b/lua/lspconfig/clangd.lua
@@ -7,7 +7,7 @@ local function switch_source_header(bufnr)
   local params = { uri = vim.uri_from_bufnr(bufnr) }
   vim.lsp.buf_request(bufnr, 'textDocument/switchSourceHeader', params, function(err, _, result)
     if err then error(tostring(err)) end
-    if not result then print ("Corresponding file can’t be determined") return end
+    if not result then print ("Corresponding file cannot be determined") return end
     vim.api.nvim_command('edit '..vim.uri_to_fname(result))
   end)
 end


### PR DESCRIPTION
The `’` character does not display well in non-unicode terminals. Additionally, "cannot" is better formal English, which I think should be preferred in error messages.