### PR TITLE
Update for fsautocomplete (F# Language Server)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1649,27 +1649,28 @@ require'lspconfig'.fortls.setup{}
 
 https://github.com/fsharp/FsAutoComplete
 
-Language Server for F# provded by FsAutoComplete (FSAC).
-
-Download a release of FsAutoComplete from [here](https://github.com/fsharp/FsAutoComplete/releases).
-Instructions to compile from source are found on the main repository.
+Language Server for F# provided by FsAutoComplete (FSAC).
 
 FsAutoComplete requires the [dotnet-sdk](https://dotnet.microsoft.com/download) to be installed.
+
+With dotnet-sdk installed FsAutoComplete can be installed with `dotnet tool install --global fsautocomplete`.
+
+Also it's possible build from source from [here](https://github.com/fsharp/FsAutoComplete/releases).
+Instructions to compile from source are found on the main repository.
 
 You may also need to configure the filetype as Vim defaults to Forth for `*.fs` files:
 
 `autocmd BufNewFile,BufRead *.fs,*.fsx,*.fsi set filetype=fsharp`
 
-This is automatically done by plugins such as [vim-polyglot](https://github.com/sheerun/vim-polyglot), [PhilT/vim-fsharp](https://github.com/PhilT/vim-fsharp) or [fsharp/vim-fsharp](https://github.com/fsharp/vim-fsharp).
-
-**By default, this config doesn't have a `cmd` set.** This is because nvim-lspconfig does not make assumptions about your path. You must add the following to your init.vim or init.lua to set `cmd` to the absolute path ($HOME and ~ are not expanded) of your unzipped and compiled fsautocomplete.dll.
+This is automatically done by plugins such as [vim-polyglot](https://github.com/sheerun/vim-polyglot), [PhilT/vim-fsharp](https://github.com/PhilT/vim-fsharp), [fsharp/vim-fsharp](https://github.com/fsharp/vim-fsharp) or [adelarsq/neofsharp.vim](https://github.com/adelarsq/neofsharp.vim).
 
 ```lua
 require'lspconfig'.fsautocomplete.setup{
-  cmd = {'dotnet', 'path/to/fsautocomplete.dll', '--background-service-enabled'}
+  cmd = {'dotnet', 'fsautocomplete', '--background-service-enabled'}
+  -- Or for custom build:
+  -- cmd = {'dotnet', 'path/to/fsautocomplete.dll', '--background-service-enabled'}
 }
 ```
-    
 
 ```lua
 require'lspconfig'.fsautocomplete.setup{}


### PR DESCRIPTION
This is an update for the instructions to setup the F# Language Server:

- Add `dotnet tool install --global fsautocomplete` as prefered way to install
- Add [adelarsq/neofsharp.vim](https://github.com/adelarsq/neofsharp.vim) plugin for F# support
- Remove some instructions that differs between setups
- Some spell corrections