### PR TITLE
[RDY] show autostart status in LspInfo

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -92,6 +92,7 @@ function configs.__newindex(t, config_name, config_def)
     M.filetypes = config.filetypes
     M.handlers = config.handlers
     M.cmd = config.cmd
+    M._autostart = config.autostart
 
     -- In the case of a reload, close existing things.
     local reload = false

--- a/lua/lspconfig/lspinfo.lua
+++ b/lua/lspconfig/lspinfo.lua
@@ -47,6 +47,13 @@ return function()
     return cmd
   end
 
+  local function autostart_to_str(autostart)
+    local autostart_status = 'True'
+    if autostart == false then
+      autostart_status = 'Disabled'
+    end
+    return autostart_status
+  end
   local indent = '  '
   local function make_client_info(client)
     local lines = {
@@ -62,6 +69,7 @@ return function()
       indent .. '\troot:      ' .. client.workspaceFolders[1].name,
       indent .. '\tfiletypes: ' .. table.concat(client.config.filetypes or {}, ', '),
       indent .. '\tcmd:       ' .. remove_newlines(client.config.cmd),
+      indent .. '\tautostart: ' .. autostart_to_str(client._autostart),
     }
     if client.config.lspinfo then
       local server_specific_info = client.config.lspinfo(client.config)
@@ -116,6 +124,7 @@ return function()
             indent .. '\tcmd:               ' .. cmd,
             indent .. '\tcmd is executable: ' .. cmd_is_executable,
             indent .. '\tidentified root:   ' .. (config.get_root_dir(buffer_dir) or 'None'),
+            indent .. '\tautostart:         ' .. autostart_to_str(config._autostart),
             indent .. '\tcustom handlers:   ' .. table.concat(vim.tbl_keys(config.handlers), ', '),
           }
           vim.list_extend(buf_lines, matching_config_info)

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -13,6 +13,7 @@ M.default_config = {
   settings = vim.empty_dict(),
   init_options = vim.empty_dict(),
   handlers = {},
+  autostart = true,
 }
 
 -- global on_setup hook


### PR DESCRIPTION
autostart can explain why a server is not active so I think it deserves a place in `:LspInfo`. Seems like this PR wont work though because the `autostart` setting is not forwarded to the generated client, there is an `autostart()` function in its stead. 

Maybe we can rename the `autostart()` function ?