### PR TITLE
Increase the default memory and timeout limits in lean3ls

### DIFF
--- a/lua/lspconfig/lean3ls.lua
+++ b/lua/lspconfig/lean3ls.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig/util'
 
 configs.lean3ls = {
   default_config = {
-    cmd = {"lean-language-server", "--stdio"};
+    cmd = {"lean-language-server", "--stdio", "--", "-M", "4096", "-T", "100000" };
     filetypes = {"lean3"};
     root_dir = function(fname)
       return util.root_pattern("leanpkg.toml")(fname) or util.find_git_ancestor(fname) or util.path.dirname(fname)


### PR DESCRIPTION
Matches our VSCode's default found here:

https://github.com/leanprover/vscode-lean/blob/ca764c60acbfaeaca55a681bc0be65f84b0cae44/package.json#L32-L41