### PR TITLE
terraform-ls is for terraform only

### DIFF
--- a/lua/lspconfig/terraformls.lua
+++ b/lua/lspconfig/terraformls.lua
@@ -4,7 +4,7 @@ local util = require 'lspconfig/util'
 configs.terraformls = {
   default_config = {
     cmd = {"terraform-ls", "serve"};
-    filetypes = {"terraform", "hcl"};
+    filetypes = {"terraform"};
     root_dir = util.root_pattern(".terraform", ".git");
   };
   docs = {


### PR DESCRIPTION
The HCL format is used by lots of hashicorp tools - and some others - not only terraform: whereas the terraform language server is only meant for terraform and only useful for terraform.

This MR directly contradicts - and undoes - #757, therefore pinging @WhyNotHugo and @lithammer. I see there was some discussion in that issue: I think you simply came to the wrong conclusion.

I am currently considering switching hashivim/vim-terraform to use filetype hcl.terraform for terraform files, it was while investigating the consequences of that change that I spotted this.

hashivim/vim-terraform#168

If we do go that way, I'll likely follow up with an MR to use that filetype as a trigger for tflint and terraform-ls.

(NB this repository doesn't currently try to run tflint for non-terraform HCL files, which I think is right).