### PR TITLE
Set java-language-server default cmd

### DIFF
--- a/lua/lspconfig/java_language_server.lua
+++ b/lua/lspconfig/java_language_server.lua
@@ -5,7 +5,7 @@ local name = 'java_language_server'
 
 configs[name] = {
   default_config = {
-    cmd = {};
+    cmd = { "java-language-server" };
     filetypes = {'java'};
     root_dir = lspconfig.util.root_pattern('build.gradle', 'pom.xml', '.git');
     settings = {}
@@ -16,7 +16,7 @@ https://github.com/georgewfraser/java-language-server
 
 Java language server
 
-Point `cmd` to `lang_server_linux.sh` or the equivalent script for macOS/Windows provided by java-language-server
+If server does not start point `cmd` to `lang_server_linux.sh` or the equivalent script for macOS/Windows provided by java-language-server
 ]]
   }
 }


### PR DESCRIPTION
This sets the default `cmd` to `java-language-server`, which will make it work out of the box on machines with an installed java-language-server package (for example from AUR). It is also more consistent with other servers and avoids the cryptic error "E5108: Error executing lua Vim:E928: String required", when trying to get `:LspInfo` with no `cmd` provided, as it is now.