### PR TITLE
Fixed a small gotcha where the server_path is set to nonsense if you print stuff in your startup.jl

### DIFF
--- a/lua/lspconfig/julials.lua
+++ b/lua/lspconfig/julials.lua
@@ -23,7 +23,7 @@ configs.julials = {
   default_config = {
     cmd = cmd;
     on_new_config = function(new_config, _)
-      local server_path = vim.fn.system("julia -e 'print(Base.find_package(\"LanguageServer\"))'")
+      local server_path = vim.fn.system("julia --startup-file=no -q -e 'print(Base.find_package(\"LanguageServer\"))'")
       local new_cmd = vim.deepcopy(cmd)
       table.insert(new_cmd, 2, "--project="..server_path:sub(0,-19))
       new_config.cmd = new_cmd


### PR DESCRIPTION
When I start julia I print out bayes formula in startup.jl which looks like this

```
          p(x|θ)p(θ)
p(θ|x) = ------------
          ∫p(x,θ)dθ
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.6.1 (2021-04-23)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |
```
Which makes the executed julia command for finding the location of LanguageServer get part of bayes formula as a path. This fix makes sure that startup.jl is not executed.