### PR TITLE
fix: be less strict about cmd validation

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -32,7 +32,7 @@ function configs.__newindex(t, config_name, config_def)
 
   function M.setup(config)
     validate {
-      cmd = { config.cmd, "t", default_config.cmd ~= nil },
+      cmd = { config.cmd, "t", true },
       root_dir = { config.root_dir, "f", default_config.root_dir ~= nil },
       filetypes = { config.filetype, "t", true },
       on_new_config = { config.on_new_config, "f", true },


### PR DESCRIPTION
Some language servers lazily build cmd based on a parameter passed to setup, like powershell_es. We should change this eventually, but for now be less strict.