### PR TITLE
Add formatting true flag to init_options for solargraph

### DIFF
--- a/lua/lspconfig/solargraph.lua
+++ b/lua/lspconfig/solargraph.lua
@@ -13,6 +13,7 @@ configs.solargraph = {
         diagnostics = true,
       },
     },
+    init_options = { formatting = true },
     filetypes = { "ruby" },
     root_dir = util.root_pattern("Gemfile", ".git"),
   },


### PR DESCRIPTION
Per this issue: https://github.com/castwide/solargraph/issues/455

Solargraph needs to be told it supports formatting, otherwise it won't return document_formatting as a resolved capability. 