### PR TITLE
fix: fix buffer without file detection

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -161,7 +161,8 @@ function configs.__newindex(t, config_name, config_def)
 
     function manager.try_add(bufnr)
       bufnr = bufnr or api.nvim_get_current_buf()
-      if vim.api.nvim_buf_get_option(bufnr, "filetype") == "nofile" then
+      if vim.api.nvim_buf_get_option(bufnr, "filetype") == "nofile"
+         or vim.api.nvim_buf_get_option(bufnr, "buftype") == "nofile" then
         return
       end
       local root_dir = get_root_dir(api.nvim_buf_get_name(bufnr), bufnr)


### PR DESCRIPTION
we also need to check buftype value in case we need the filetype to be
set to a value different from "nofile"