### PR TITLE
[WIP] feat: always fallback to parent directory for root

### DIFF
--- a/lua/lspconfig/als.lua
+++ b/lua/lspconfig/als.lua
@@ -12,7 +12,9 @@ configs[server_name] = {
     cmd = { bin_name },
     filetypes = { "ada" },
     -- *.gpr and *.adc would be nice to have here
-    root_dir = util.root_pattern("Makefile", ".git"),
+    root_dir = function(fname)
+      return util.root_pattern("Makefile", ".git")(fname) or util.path.dirname(fname)
+    end,
   },
   docs = {
     package_json = "https://raw.githubusercontent.com/AdaCore/ada_language_server/master/integration/vscode/ada/package.json",
@@ -34,9 +36,6 @@ require('lspconfig').als.setup{
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern("Makefile", ".git")]],
-    },
   },
 }
 

--- a/lua/lspconfig/angularls.lua
+++ b/lua/lspconfig/angularls.lua
@@ -28,7 +28,9 @@ configs[server_name] = {
     -- Check for angular.json or .git first since that is the root of the project.
     -- Don't check for tsconfig.json or package.json since there are multiple of these
     -- in an angular monorepo setup.
-    root_dir = util.root_pattern("angular.json", ".git"),
+    root_dir = function(fname)
+      return util.root_pattern("angular.json", ".git")(fname) or util.path.dirname(fname)
+    end,
   },
   on_new_config = function(new_config, new_root_dir)
     local new_probe_dir = get_probe_dir(new_root_dir)
@@ -63,8 +65,5 @@ require'lspconfig'.angularls.setup{
 }
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("angular.json", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/bashls.lua
+++ b/lua/lspconfig/bashls.lua
@@ -22,9 +22,6 @@ https://github.com/mads-hartmann/bash-language-server
 
 Language server for bash, written using tree sitter in typescript.
 ]],
-    default_config = {
-      root_dir = "vim's starting directory",
-    },
   },
 }
 

--- a/lua/lspconfig/beancount.lua
+++ b/lua/lspconfig/beancount.lua
@@ -24,9 +24,6 @@ https://github.com/polarmutex/beancount-language-server#installation
 
 See https://github.com/polarmutex/beancount-language-server#configuration for configuration options
 ]],
-    default_config = {
-      root_dir = [[root_pattern("elm.json")]],
-    },
   },
 }
 

--- a/lua/lspconfig/ccls.lua
+++ b/lua/lspconfig/ccls.lua
@@ -36,9 +36,6 @@ lspconfig.ccls.setup {
 ```
 
 ]],
-    default_config = {
-      root_dir = [[root_pattern("compile_commands.json", "compile_flags.txt", ".git") or dirname]],
-    },
   },
 }
 -- vim:et ts=2 sw=2

--- a/lua/lspconfig/clojure_lsp.lua
+++ b/lua/lspconfig/clojure_lsp.lua
@@ -5,7 +5,9 @@ configs.clojure_lsp = {
   default_config = {
     cmd = { "clojure-lsp" },
     filetypes = { "clojure", "edn" },
-    root_dir = util.root_pattern("project.clj", "deps.edn", ".git"),
+    root_dir = function(fname)
+      return util.root_pattern("project.clj", "deps.edn", ".git")(fname) or util.path.dirname(fname)
+    end,
   },
   docs = {
     description = [[
@@ -13,9 +15,6 @@ https://github.com/snoe/clojure-lsp
 
 Clojure Language Server
 ]],
-    default_config = {
-      root_dir = [[root_pattern("project.clj", "deps.edn", ".git")]],
-    },
   },
 }
 -- vim:et ts=2 sw=2

--- a/lua/lspconfig/cmake.lua
+++ b/lua/lspconfig/cmake.lua
@@ -18,9 +18,6 @@ https://github.com/regen100/cmake-language-server
 
 CMake LSP Implementation
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git", "compile_commands.json", "build") or dirname]],
-    },
   },
 }
 

--- a/lua/lspconfig/crystalline.lua
+++ b/lua/lspconfig/crystalline.lua
@@ -15,8 +15,5 @@ https://github.com/elbywan/crystalline
 
 Crystal language server.
 ]],
-    default_config = {
-      root_dir = [[root_pattern('shard.yml', '.git') or dirname]],
-    },
   },
 }

--- a/lua/lspconfig/cssls.lua
+++ b/lua/lspconfig/cssls.lua
@@ -11,7 +11,7 @@ configs[server_name] = {
     cmd = { bin_name, "--stdio" },
     filetypes = { "css", "scss", "less" },
     root_dir = function(fname)
-      return root_pattern(fname) or vim.loop.os_homedir()
+      return root_pattern(fname) or util.path.dirname(fname)
     end,
     settings = {
       css = { validate = true },
@@ -42,9 +42,6 @@ require'lspconfig'.cssls.setup {
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("package.json")]],
-    },
   },
 }
 

--- a/lua/lspconfig/dartls.lua
+++ b/lua/lspconfig/dartls.lua
@@ -31,7 +31,9 @@ configs[server_name] = {
   default_config = {
     cmd = { bin_name, analysis_server_snapshot_path(), "--lsp" },
     filetypes = { "dart" },
-    root_dir = util.root_pattern "pubspec.yaml",
+    root_dir = function(fname)
+      return util.root_pattern "pubspec.yaml"(fname) or util.path.dirname(fname)
+    end,
     init_options = {
       onlyAnalyzeProjectsWithOpenFiles = false,
       suggestFromUnimportedLibraries = true,
@@ -47,9 +49,6 @@ https://github.com/dart-lang/sdk/tree/master/pkg/analysis_server/tool/lsp_spec
 
 Language server for dart.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("pubspec.yaml")]],
-    },
   },
 }
 -- vim:et ts=2 sw=2

--- a/lua/lspconfig/denols.lua
+++ b/lua/lspconfig/denols.lua
@@ -102,8 +102,17 @@ end
 configs[server_name] = {
   default_config = {
     cmd = { "deno", "lsp" },
-    filetypes = { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" },
-    root_dir = util.root_pattern("package.json", "tsconfig.json", ".git"),
+    filetypes = {
+      "javascript",
+      "javascriptreact",
+      "javascript.jsx",
+      "typescript",
+      "typescriptreact",
+      "typescript.tsx",
+    },
+    root_dir = function(fname)
+      return util.root_pattern("package.json", "tsconfig.json", ".git")(fname) or util.path.dirname(fname)
+    end,
     init_options = {
       enable = true,
       lint = false,
@@ -138,9 +147,6 @@ https://github.com/denoland/deno
 
 Deno's built-in language server
 ]],
-    default_config = {
-      root_dir = [[root_pattern("package.json", "tsconfig.json", ".git")]],
-    },
   },
 }
 

--- a/lua/lspconfig/dhall_lsp_server.lua
+++ b/lua/lspconfig/dhall_lsp_server.lua
@@ -5,7 +5,9 @@ configs.dhall_lsp_server = {
   default_config = {
     cmd = { "dhall-lsp-server" },
     filetypes = { "dhall" },
-    root_dir = util.root_pattern(".git", vim.fn.getcwd()),
+    root_dir = function(fname)
+      return util.root_pattern ".git"(fname) or util.path.dirname(fname)
+    end,
     docs = {
       description = [[
 https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-lsp-server
@@ -18,9 +20,6 @@ cabal install dhall-lsp-server
 ```
 prebuilt binaries can be found [here](https://github.com/dhall-lang/dhall-haskell/releases).
 ]],
-      default_config = {
-        root_dir = [[root_pattern(".git", vim.fn.getcwd())]],
-      },
     },
   },
 }

--- a/lua/lspconfig/diagnosticls.lua
+++ b/lua/lspconfig/diagnosticls.lua
@@ -18,7 +18,6 @@ Diagnostic language server integrate with linters.
 ]],
     default_config = {
       filetypes = "Empty by default, override to add filetypes",
-      root_dir = "Vim's starting directory",
       init_options = "Configuration from https://github.com/iamcco/diagnostic-languageserver#config--document",
     },
   },

--- a/lua/lspconfig/dockerls.lua
+++ b/lua/lspconfig/dockerls.lua
@@ -8,7 +8,9 @@ configs[server_name] = {
   default_config = {
     cmd = { bin_name, "--stdio" },
     filetypes = { "Dockerfile", "dockerfile" },
-    root_dir = util.root_pattern "Dockerfile",
+    root_dir = function(fname)
+      return util.root_pattern "Dockerfile"(fname) or util.path.dirname(fname)
+    end,
   },
   docs = {
     description = [[
@@ -19,9 +21,6 @@ https://github.com/rcjsuen/dockerfile-language-server-nodejs
 npm install -g dockerfile-language-server-nodejs
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("Dockerfile")]],
-    },
   },
 }
 

--- a/lua/lspconfig/dotls.lua
+++ b/lua/lspconfig/dotls.lua
@@ -12,8 +12,8 @@ configs[server_name] = {
   default_config = {
     cmd = { bin_name, "--stdio" },
     filetypes = { "dot" },
-    root_dir = function(filename)
-      return util.root_pattern(unpack(root_files))(filename) or util.path.dirname(filename)
+    root_dir = function(fname)
+      return util.root_pattern(unpack(root_files))(fname) or util.path.dirname(fname)
     end,
   },
   docs = {

--- a/lua/lspconfig/efm.lua
+++ b/lua/lspconfig/efm.lua
@@ -18,9 +18,6 @@ https://github.com/mattn/efm-langserver
 
 General purpose Language Server that can use specified error message format generated from specified command.
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern(".git")(fname) or util.path.dirname(fname)]],
-    },
   },
 }
 -- vim:et ts=2 sw=2

--- a/lua/lspconfig/elixirls.lua
+++ b/lua/lspconfig/elixirls.lua
@@ -6,7 +6,7 @@ configs[server_name] = {
   default_config = {
     filetypes = { "elixir", "eelixir" },
     root_dir = function(fname)
-      return util.root_pattern("mix.exs", ".git")(fname) or vim.loop.os_homedir()
+      return util.root_pattern("mix.exs", ".git")(fname) or util.path.dirname(fname)
     end,
   },
   docs = {
@@ -35,9 +35,6 @@ require'lspconfig'.elixirls.setup{
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("mix.exs", ".git") or vim.loop.os_homedir()]],
-    },
   },
 }
 

--- a/lua/lspconfig/elmls.lua
+++ b/lua/lspconfig/elmls.lua
@@ -18,7 +18,7 @@ configs[server_name] = {
     root_dir = function(fname)
       local filetype = api.nvim_buf_get_option(0, "filetype")
       if filetype == "elm" or (filetype == "json" and fname:match "elm%.json$") then
-        return elm_root_pattern(fname)
+        return elm_root_pattern(fname) or util.path.dirname(fname)
       end
     end,
     init_options = {
@@ -38,9 +38,6 @@ If you don't want to use Nvim to install it, then you can use:
 npm install -g elm elm-test elm-format @elm-tooling/elm-language-server
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("elm.json")]],
-    },
   },
 }
 

--- a/lua/lspconfig/ember.lua
+++ b/lua/lspconfig/ember.lua
@@ -8,7 +8,9 @@ configs[server_name] = {
   default_config = {
     cmd = { bin_name, "--stdio" },
     filetypes = { "handlebars", "typescript", "javascript" },
-    root_dir = util.root_pattern("ember-cli-build.js", ".git"),
+    root_dir = function(fname)
+      return util.root_pattern("ember-cli-build.js", ".git")(fname) or util.path.dirname(fname)
+    end,
   },
   docs = {
     description = [[
@@ -20,9 +22,6 @@ https://github.com/lifeart/ember-language-server
 npm install -g @lifeart/ember-language-server
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("ember-cli-build.js", ".git")]],
-    },
   },
 }
 

--- a/lua/lspconfig/erlangls.lua
+++ b/lua/lspconfig/erlangls.lua
@@ -24,8 +24,5 @@ Installation requirements:
     - [Erlang OTP 21+](https://github.com/erlang/otp)
     - [rebar3 3.9.1+](https://github.com/erlang/rebar3)
 ]],
-    default_config = {
-      root_dir = [[root_pattern('rebar.config', 'erlang.mk', '.git') or util.path.dirname(fname)]],
-    },
   },
 }

--- a/lua/lspconfig/flow.lua
+++ b/lua/lspconfig/flow.lua
@@ -5,7 +5,9 @@ configs.flow = {
   default_config = {
     cmd = { "npx", "--no-install", "flow", "lsp" },
     filetypes = { "javascript", "javascriptreact", "javascript.jsx" },
-    root_dir = util.root_pattern ".flowconfig",
+    root_dir = function(fname)
+      return util.root_pattern ".flowconfig"(fname) or util.path.dirname(fname)
+    end,
   },
   docs = {
     package_json = "https://raw.githubusercontent.com/flowtype/flow-for-vscode/master/package.json",
@@ -22,9 +24,6 @@ See below for lsp command options.
 npx flow lsp --help
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern(".flowconfig")]],
-    },
   },
 }
 -- vim:et ts=2 sw=2

--- a/lua/lspconfig/fortls.lua
+++ b/lua/lspconfig/fortls.lua
@@ -5,7 +5,9 @@ configs.fortls = {
   default_config = {
     cmd = { "fortls" },
     filetypes = { "fortran" },
-    root_dir = util.root_pattern ".fortls",
+    root_dir = function(fname)
+      return util.root_pattern ".fortls"(fname) or util.path.dirname(fname)
+    end,
     settings = {
       nthreads = 1,
     },
@@ -17,9 +19,6 @@ https://github.com/hansec/fortran-language-server
 
 Fortran Language Server for the Language Server Protocol
     ]],
-    default_config = {
-      root_dir = [[root_pattern(".fortls")]],
-    },
   },
 }
 -- vim:et ts=2 sw=2

--- a/lua/lspconfig/fsautocomplete.lua
+++ b/lua/lspconfig/fsautocomplete.lua
@@ -6,7 +6,9 @@ local server_name = "fsautocomplete"
 configs[server_name] = {
   default_config = {
     cmd = { "dotnet", "fsautocomplete", "--background-service-enabled" },
-    root_dir = util.root_pattern("*.sln", "*.fsproj", ".git"),
+    root_dir = function(fname)
+      return util.root_pattern("*.sln", "*.fsproj", ".git")(fname) or util.path.dirname(fname)
+    end,
     filetypes = { "fsharp" },
     init_options = {
       AutomaticWorkspaceInit = true,

--- a/lua/lspconfig/gdscript.lua
+++ b/lua/lspconfig/gdscript.lua
@@ -5,7 +5,9 @@ configs.gdscript = {
   default_config = {
     cmd = { "nc", "localhost", "6008" },
     filetypes = { "gd", "gdscript", "gdscript3" },
-    root_dir = util.root_pattern("project.godot", ".git"),
+    root_dir = function(fname)
+      return util.root_pattern("project.godot", ".git")(fname) or util.path.dirname(fname)
+    end,
   },
   docs = {
     description = [[
@@ -13,9 +15,6 @@ https://github.com/godotengine/godot
 
 Language server for GDScript, used by Godot Engine.
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern("project.godot", ".git")]],
-    },
   },
 }
 

--- a/lua/lspconfig/ghcide.lua
+++ b/lua/lspconfig/ghcide.lua
@@ -5,7 +5,10 @@ configs.ghcide = {
   default_config = {
     cmd = { "ghcide", "--lsp" },
     filetypes = { "haskell", "lhaskell" },
-    root_dir = util.root_pattern("stack.yaml", "hie-bios", "BUILD.bazel", "cabal.config", "package.yaml"),
+    root_dir = function(fname)
+      return util.root_pattern("stack.yaml", "hie-bios", "BUILD.bazel", "cabal.config", "package.yaml")(fname)
+        or util.path.dirname(fname)
+    end,
   },
 
   docs = {
@@ -15,9 +18,6 @@ https://github.com/digital-asset/ghcide
 A library for building Haskell IDE tooling.
 "ghcide" isn't for end users now. Use "haskell-language-server" instead of "ghcide".
 ]],
-    default_config = {
-      root_dir = [[root_pattern("stack.yaml", "hie-bios", "BUILD.bazel", "cabal.config", "package.yaml")]],
-    },
   },
 }
 -- vim:et ts=2 sw=2

--- a/lua/lspconfig/gopls.lua
+++ b/lua/lspconfig/gopls.lua
@@ -5,7 +5,9 @@ configs.gopls = {
   default_config = {
     cmd = { "gopls" },
     filetypes = { "go", "gomod" },
-    root_dir = util.root_pattern("go.mod", ".git"),
+    root_dir = function(fname)
+      return util.root_pattern("go.mod", ".git")(fname) or util.path.dirname(fname)
+    end,
   },
   -- on_new_config = function(new_config) end;
   -- on_attach = function(client, bufnr) end;
@@ -15,9 +17,6 @@ https://github.com/golang/tools/tree/master/gopls
 
 Google's lsp server for golang.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("go.mod", ".git")]],
-    },
   },
 }
 -- vim:et ts=2 sw=2

--- a/lua/lspconfig/graphql.lua
+++ b/lua/lspconfig/graphql.lua
@@ -8,7 +8,9 @@ configs[server_name] = {
   default_config = {
     cmd = { bin_name, "server", "-m", "stream" },
     filetypes = { "graphql" },
-    root_dir = util.root_pattern(".git", ".graphqlrc"),
+    root_dir = function(fname)
+      return util.root_pattern(".git", ".graphqlrc")(fname) or util.path.dirname(fname)
+    end,
   },
 
   docs = {
@@ -21,9 +23,6 @@ https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service-
 npm install -g graphql-language-service-cli
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern('.git', '.graphqlrc')]],
-    },
   },
 }
 

--- a/lua/lspconfig/groovyls.lua
+++ b/lua/lspconfig/groovyls.lua
@@ -12,7 +12,9 @@ configs[name] = {
       bin_name,
     },
     filetypes = { "groovy" },
-    root_dir = util.root_pattern ".git" or vim.loop.os_homedir(),
+    root_dir = function(fname)
+      return util.root_pattern ".git"(fname) or util.path.dirname(fname)
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/haxe_language_server.lua
+++ b/lua/lspconfig/haxe_language_server.lua
@@ -5,7 +5,9 @@ configs.haxe_language_server = {
   default_config = {
     cmd = { "haxe-language-server" },
     filetypes = { "haxe" },
-    root_dir = util.root_pattern "*.hxml",
+    root_dir = function(fname)
+      return util.root_pattern "*.hxml"(fname) or util.path.dirname(fname)
+    end,
     settings = {
       haxe = {
         executable = "haxe",
@@ -41,8 +43,5 @@ By default, an HXML compiler arguments file named `build.hxml` is expected in
 your project's root directory. If your file is named something different,
 specify it using the `init_options.displayArguments` setting.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("*.hxml")]],
-    },
   },
 }

--- a/lua/lspconfig/tsserver.lua
+++ b/lua/lspconfig/tsserver.lua
@@ -10,7 +10,14 @@ end
 configs[server_name] = {
   default_config = {
     cmd = { bin_name, "--stdio" },
-    filetypes = { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" },
+    filetypes = {
+      "javascript",
+      "javascriptreact",
+      "javascript.jsx",
+      "typescript",
+      "typescriptreact",
+      "typescript.tsx",
+    },
     root_dir = function(fname)
       return util.root_pattern "tsconfig.json"(fname) or util.root_pattern("package.json", "jsconfig.json", ".git")(
         fname


### PR DESCRIPTION
Users consistently get tripped up by root directory triggers. This commit adds the current directory of the open file as the fallback root for all servers that support it. I will probably replace util.path.dirname with some sort of wrapper function that either warns the user that we are falling back to the current directory of the file, or provides an interactive prompt to specify the root (that can be silenced).

* chore: consistently use fname as the input to the root directory resolution function
* chore: remove all references to root directory in manual documentation, CI extracts this automatically now.