### PR TITLE
WIP: Add cSpell Support

### DIFF
--- a/lua/lspconfig/cspell.lua
+++ b/lua/lspconfig/cspell.lua
@@ -1,0 +1,30 @@
+local configs = require "lspconfig/configs"
+local util = require "lspconfig/util"
+
+local server_name = "cspell"
+
+configs[server_name] = {
+  default_config = {
+    cmd = {
+      "/bin/node",
+      "/home/zethra/Downloads/build/extension/server/server.js",
+      "--stdio",
+    },
+    filetypes = { "text" },
+    root_dir = function(fname)
+      return util.root_pattern ".git"(fname) or util.path.dirname(fname)
+    end,
+  },
+
+  docs = {
+    description = [[
+https://github.com/mattn/efm-langserver
+
+General purpose Language Server that can use specified error message format generated from specified command.
+]],
+    default_config = {
+      root_dir = [[util.root_pattern(".git")(fname) or util.path.dirname(fname)]],
+    },
+  },
+}
+-- vim:et ts=2 sw=2


### PR DESCRIPTION
@mjlbach I've create the draft PR as requested. At the moment I have the cmd just pointing at where I have the LSP on my system. I figure I'd work on the installer or whatever after I got it working. I also have the file types just set to text for testing, ultimately I'd add more. Or have it run on every file type if that's possible. I'm using this version of the [lsp server](https://github.com/streetsidesoftware/vscode-spell-checker/releases/tag/v1.10.4). Currently I can't get the nvim to recognize the lsp. Meaning that it doesn't up in LspInfo when I open a text file.