### PR TITLE
docs: add a direct link to lean.nvim (for leanls and lean3ls)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -3463,44 +3463,6 @@ require'lspconfig'.kotlin_language_server.setup{}
 ```
 
 
-## lean3ls
-
-https://github.com/leanprover/lean-client-js/tree/master/lean-language-server
-
-Lean installation instructions can be found
-[here](https://leanprover-community.github.io/get_started.html#regular-install).
-
-Once Lean is installed, you can install the Lean 3 language server by running
-```sh
-npm install -g lean-language-server
-```
-    
-
-
-**Snippet to enable the language server:**
-```lua
-require'lspconfig'.lean3ls.setup{}
-```
-
-**Commands and default values:**
-```lua
-  Commands:
-  
-  Default Values:
-    cmd = { "lean-language-server", "--stdio", "--", "-M", "4096", "-T", "100000" }
-    filetypes = { "lean3" }
-    on_new_config = function(config, root)
-          if not util.path.is_file(root .. "/leanpkg.toml") then
-            return
-          end
-          if not config.cmd_cwd then
-            config.cmd_cwd = root
-          end
-        end,
-    root_dir = root_pattern("leanpkg.toml") or root_pattern(".git") or path.dirname
-```
-
-
 ## leanls
 
 https://github.com/leanprover/lean4
@@ -3511,6 +3473,9 @@ Lean installation instructions can be found
 The Lean 4 language server is built-in with a Lean 4 install
 (and can be manually run with, e.g., `lean --server`).
     
+Note: that if you're using [lean.nvim](https://github.com/Julian/lean.nvim),
+that plugin fully handles the setup of the Lean language server,
+and you shouldn't set up `leanls` both with it and this plugin.
 
 
 **Snippet to enable the language server:**
@@ -3525,6 +3490,48 @@ require'lspconfig'.leanls.setup{}
   Default Values:
     cmd = { "lean", "--server" }
     filetypes = { "lean" }
+    on_new_config = function(config, root)
+          if not util.path.is_file(root .. "/leanpkg.toml") then
+            return
+          end
+          if not config.cmd_cwd then
+            config.cmd_cwd = root
+          end
+        end,
+    root_dir = root_pattern("leanpkg.toml") or root_pattern(".git") or path.dirname
+```
+
+
+## lean3ls
+
+https://github.com/leanprover/lean-client-js/tree/master/lean-language-server
+
+Lean installation instructions can be found
+[here](https://leanprover-community.github.io/get_started.html#regular-install).
+
+Once Lean is installed, you can install the Lean 3 language server by running
+```sh
+npm install -g lean-language-server
+```
+    
+Note: that if you're using [lean.nvim](https://github.com/Julian/lean.nvim),
+that plugin fully handles the setup of the Lean language server,
+and you shouldn't set up `lean3ls` both with it and this plugin. You still will
+need to install the language server.
+
+
+**Snippet to enable the language server:**
+```lua
+require'lspconfig'.lean3ls.setup{}
+```
+
+**Commands and default values:**
+```lua
+  Commands:
+  
+  Default Values:
+    cmd = { "lean-language-server", "--stdio", "--", "-M", "4096", "-T", "100000" }
+    filetypes = { "lean3" }
     on_new_config = function(config, root)
           if not util.path.is_file(root .. "/leanpkg.toml") then
             return

--- a/lua/lspconfig/lean3ls.lua
+++ b/lua/lspconfig/lean3ls.lua
@@ -28,6 +28,10 @@ Once Lean is installed, you can install the Lean 3 language server by running
 ```sh
 npm install -g lean-language-server
 ```
+
+Note: that if you're using [lean.nvim](https://github.com/Julian/lean.nvim),
+that plugin fully handles the setup of the Lean language server,
+and you shouldn't set up `lean3ls` both with it and this plugin.
     ]],
     default_config = {
       root_dir = [[root_pattern("leanpkg.toml") or root_pattern(".git") or path.dirname]],

--- a/lua/lspconfig/leanls.lua
+++ b/lua/lspconfig/leanls.lua
@@ -26,6 +26,10 @@ Lean installation instructions can be found
 
 The Lean 4 language server is built-in with a Lean 4 install
 (and can be manually run with, e.g., `lean --server`).
+
+Note: that if you're using [lean.nvim](https://github.com/Julian/lean.nvim),
+that plugin fully handles the setup of the Lean language server,
+and you shouldn't set up `leanls` both with it and this plugin.
     ]],
     default_config = {
       root_dir = [[root_pattern("leanpkg.toml") or root_pattern(".git") or path.dirname]],


### PR DESCRIPTION
Better than going back and forth on gitter I suppose :D @mjlbach.

Possibly this is a decent enough way to let people know something exists, though I'm not sure how many Leanfolk even know about this repo yet (hopefully that changes soon!).

(I also just put leanls above lean3ls in the readme, which is confusing GitHub's diff, but there's only a 4 line change here essentially).