### PR TITLE
feat: added global_config hooks

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -50,6 +50,10 @@ function configs.__newindex(t, config_name, config_def)
 
     config = tbl_extend('keep', config, default_config)
 
+    if util.on_setup then
+      pcall(util.on_setup, config)
+    end
+
     local trigger
     if config.filetypes then
       trigger = 'FileType ' .. table.concat(config.filetypes, ',')

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -84,7 +84,7 @@ function configs.__newindex(t, config_name, config_def)
     end
 
     -- Used by :LspInfo
-    M.get_root_dir = config.root_dir
+    M.get_root_dir = get_root_dir
     M.filetypes = config.filetypes
     M.handlers = config.handlers
     M.cmd = config.cmd

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -222,6 +222,10 @@ function M.server_per_root_dir_manager(_make_config)
     local client_id = clients[root_dir]
     if not client_id then
       local new_config = _make_config(root_dir)
+      -- do nothing if the client is not enabled
+      if new_config.enabled == false then
+        return
+      end
       --TODO:mjlbach -- these prints only show up with nvim_error_writeln()
       if not new_config.cmd then
         print(

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -15,6 +15,9 @@ M.default_config = {
   handlers = {},
 }
 
+-- global on_setup hook
+M.on_setup = nil
+
 function M.validate_bufnr(bufnr)
   validate {
     bufnr = { bufnr, 'n' },


### PR DESCRIPTION
For the workspace stuff I'm working on, it would be good to have two ways to hook into lspconfig:

1. global `on_setup`. Every client config will be passed through this global function during setup if it exists.
2. `config.enabled`. When `false`, the client won't start. Use case is to disable certain lsp servers in a workspace, or programmatically based on other conditions in `config.on_new_config` (same as coc)