### PR TITLE
Support tsserver in yarn PnP projects

### DIFF
--- a/lua/lspconfig/tsserver.lua
+++ b/lua/lspconfig/tsserver.lua
@@ -9,6 +9,7 @@ end
 
 configs[server_name] = {
   default_config = {
+    init_options = { hostInfo = 'neovim' },
     cmd = { bin_name, '--stdio' },
     filetypes = { 'javascript', 'javascriptreact', 'javascript.jsx', 'typescript', 'typescriptreact', 'typescript.tsx' },
     root_dir = function(fname)


### PR DESCRIPTION
This small change to the default tsserver config allows yarn's Plug'n'Play SDK to identify neovim as the editor and appropriately resolve virtual paths. It mirrors how the SDK handles other editors.

Related work
- https://github.com/theia-ide/typescript-language-server/pull/220
- https://github.com/yarnpkg/berry/pull/3041
- https://github.com/neovim/neovim/pull/14959 / https://github.com/neovim/neovim/pull/15017
- https://github.com/lbrayner/vim-rzip/issues/15