### PR TITLE
Add serve_d.lua

### DIFF
--- a/lua/lspconfig/serve_d.lua
+++ b/lua/lspconfig/serve_d.lua
@@ -1,0 +1,22 @@
+local configs = require 'lspconfig/configs'
+local util = require 'lspconfig/util'
+
+configs.serve_d = {
+  default_config = {
+    cmd = { 'serve-d' },
+    filetypes = { 'd' },
+    root_dir = function(fname)
+      return util.root_pattern('dub.json', 'dub.sdl', '.git')(fname)
+    end,
+  },
+  docs = {
+    description = [[
+           https://github.com/Pure-D/serve-d
+
+           `Microsoft language server protocol implementation for D using workspace-d.`
+        ]],
+    default_config = {
+      root_dir = [[util.root_pattern("dub.json", "dub.sdl", ".git") or current_file_dirname]],
+    },
+  },
+}

--- a/lua/lspconfig/serve_d.lua
+++ b/lua/lspconfig/serve_d.lua
@@ -5,7 +5,7 @@ configs.serve_d = {
   default_config = {
     cmd = { 'serve-d' },
     filetypes = { 'd' },
-    root_dir =  util.root_pattern('dub.json', 'dub.sdl', '.git'),
+    root_dir = util.root_pattern('dub.json', 'dub.sdl', '.git'),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/serve_d.lua
+++ b/lua/lspconfig/serve_d.lua
@@ -1,11 +1,7 @@
 local configs = require 'lspconfig/configs'
 local util = require 'lspconfig/util'
 
-<<<<<<< HEAD
 configs.serve_d = {
-=======
-configs.zls = {
->>>>>>> f8bd92f845a213649e6716e9202bcc94665fb127
   default_config = {
     cmd = { 'serve-d' },
     filetypes = { 'd' },

--- a/lua/lspconfig/serve_d.lua
+++ b/lua/lspconfig/serve_d.lua
@@ -12,6 +12,7 @@ configs.serve_d = {
            https://github.com/Pure-D/serve-d
 
            `Microsoft language server protocol implementation for D using workspace-d.`
+           Download a binary from https://github.com/Pure-D/serve-d/releases and put it in your $PATH.
         ]],
     default_config = {
       root_dir = [[util.root_pattern("dub.json", "dub.sdl", ".git") or current_file_dirname]],

--- a/lua/lspconfig/serve_d.lua
+++ b/lua/lspconfig/serve_d.lua
@@ -15,7 +15,7 @@ configs.serve_d = {
            Download a binary from https://github.com/Pure-D/serve-d/releases and put it in your $PATH.
         ]],
     default_config = {
-      root_dir = [[util.root_pattern("dub.json", "dub.sdl", ".git") or current_file_dirname]],
+      root_dir = [[util.root_pattern("dub.json", "dub.sdl", ".git")]],
     },
   },
 }

--- a/lua/lspconfig/serve_d.lua
+++ b/lua/lspconfig/serve_d.lua
@@ -5,9 +5,7 @@ configs.serve_d = {
   default_config = {
     cmd = { 'serve-d' },
     filetypes = { 'd' },
-    root_dir = function(fname)
-      return util.root_pattern('dub.json', 'dub.sdl', '.git')(fname)
-    end,
+    root_dir =  util.root_pattern('dub.json', 'dub.sdl', '.git'),
   },
   docs = {
     description = [[


### PR DESCRIPTION
This adds support for the DLang LSP server, [serve-d](https://github.com/Pure-d/serve-d).
I've made a PR to the upstream readme about installation instructions but it doesn't seem right to include them in the docs.
