### PR TITLE
docs: mistake scaping the character `

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -5983,7 +5983,7 @@ This server accepts configuration via the `settings` key.
 
 - **`Lua.runtime.nonstandardSymbol`**: `array`
 
-  Array items: `{enum = { "//", "/**/", "`", "+=", "-=", "*=", "/=", "||", "&&", "!", "!=", "continue" },type = "string"}`
+  Array items: ``{enum = { "//", "/**/", "`", "+=", "-=", "*=", "/=", "||", "&&", "!", "!=", "continue" },type = "string"}``
   
   null
 


### PR DESCRIPTION
Minor change
Double backquokes (\`\`  ``) instead of single backquokes (\` \`) to scape `