### PR TITLE
Improve JDTLS defaults and improve documentation

### DIFF
--- a/lua/lspconfig/jdtls.lua
+++ b/lua/lspconfig/jdtls.lua
@@ -1,52 +1,44 @@
 local configs = require 'lspconfig/configs'
 local util = require 'lspconfig/util'
 local handlers = require 'vim.lsp.handlers'
-local path = util.path
 
 local server_name = 'jdtls'
 
-local cmd = {
-  util.path.join(tostring(vim.fn.getenv 'JAVA_HOME'), '/bin/java'),
-  '-Declipse.application=org.eclipse.jdt.ls.core.id1',
-  '-Dosgi.bundles.defaultStartLevel=4',
-  '-Declipse.product=org.eclipse.jdt.ls.core.product',
-  '-Dlog.protocol=true',
-  '-Dlog.level=ALL',
-  '-Xms1g',
-  '-Xmx2G',
-  '-jar',
-  tostring(vim.fn.getenv 'JAR'),
-  '-configuration',
-  tostring(vim.fn.getenv 'JDTLS_CONFIG'),
-  '-data',
-  tostring(vim.fn.getenv 'WORKSPACE'),
-  '--add-modules=ALL-SYSTEM',
-  '--add-opens java.base/java.util=ALL-UNNAMED',
-  '--add-opens java.base/java.lang=ALL-UNNAMED',
+local sysname = vim.loop.os_uname().sysname
+local env = {
+  HOME = vim.loop.os_homedir(),
+  JAVA_HOME = os.getenv 'JAVA_HOME',
+  JDTLS_HOME = os.getenv 'JDTLS_HOME',
+  WORKSPACE = os.getenv 'WORKSPACE',
 }
 
---- The presence of one of these files indicates a root directory.
---
--- We search for configuration files of the most common Java build systems. We
--- could add more build systems, such as Make, but let's keep things simple for
--- now.
-local root_files = {
-  -- Single-module projects
-  {
-    'build.xml', -- Ant
-    'pom.xml', -- Maven
-    'settings.gradle', -- Gradle
-    'settings.gradle.kts', -- Gradle
-  },
-  -- Multi-module projects
-  { 'build.gradle', 'build.gradle.kts' },
-}
+local function get_java_executable()
+  local executable = env.JAVA_HOME and util.path.join(env.JAVA_HOME, 'bin', 'java') or 'java'
 
---- Callback function for the `language/status` notification.
---
--- The server sends a non-standard notification when the status of the language
--- server changes. This can be used to display progress as the server is
--- starting up.
+  return sysname:match 'Windows' and executable .. '.exe' or executable
+end
+
+local function get_workspace_dir()
+  return env.WORKSPACE and env.WORKSPACE or util.path.join(env.HOME, 'workspace')
+end
+
+local function get_jdtls_jar()
+  return vim.fn.expand '$JDTLS_HOME/plugins/org.eclipse.equinox.launcher_*.jar'
+end
+
+local function get_jdtls_config()
+  if sysname:match 'Linux' then
+    return util.path.join(env.JDTLS_HOME, 'config_linux')
+  elseif sysname:match 'Darwin' then
+    return util.path.join(env.JDTLS_HOME, 'config_mac')
+  elseif sysname:match 'Windows' then
+    return util.path.join(env.JDTLS_HOME, 'config_win')
+  else
+    return util.path.join(env.JDTLS_HOME, 'config_linux')
+  end
+end
+
+-- Non-standard notification that can be used to display progress
 local function on_language_status(_, _, result)
   local command = vim.api.nvim_command
   command 'echohl ModeMsg'
@@ -54,8 +46,8 @@ local function on_language_status(_, _, result)
   command 'echohl None'
 end
 
--- If the text document version is 0, set it to nil instead so that Neovim
--- won't refuse to update a buffer that it believes is newer than edits.
+-- TextDocument version is reported as 0, override with nil so that
+-- the client doesn't think the document is newer and refuses to update
 -- See: https://github.com/eclipse/eclipse.jdt.ls/issues/1695
 local function fix_zero_version(workspace_edit)
   if workspace_edit and workspace_edit.documentChanges then
@@ -69,12 +61,40 @@ local function fix_zero_version(workspace_edit)
   return workspace_edit
 end
 
+local root_files = {
+  -- Single-module projects
+  {
+    'build.xml', -- Ant
+    'pom.xml', -- Maven
+    'settings.gradle', -- Gradle
+    'settings.gradle.kts', -- Gradle
+  },
+  -- Multi-module projects
+  { 'build.gradle', 'build.gradle.kts' },
+}
+
 configs[server_name] = {
   default_config = {
-    cmd = cmd,
-    cmd_env = {
-      JAR = vim.fn.getenv 'JAR',
-      GRADLE_HOME = vim.fn.getenv 'GRADLE_HOME',
+    cmd = {
+      get_java_executable(),
+      '-Declipse.application=org.eclipse.jdt.ls.core.id1',
+      '-Dosgi.bundles.defaultStartLevel=4',
+      '-Declipse.product=org.eclipse.jdt.ls.core.product',
+      '-Dlog.protocol=true',
+      '-Dlog.level=ALL',
+      '-Xms1g',
+      '-Xmx2G',
+      '-jar',
+      get_jdtls_jar(),
+      '-configuration',
+      get_jdtls_config(),
+      '-data',
+      get_workspace_dir(),
+      '--add-modules=ALL-SYSTEM',
+      '--add-opens',
+      'java.base/java.util=ALL-UNNAMED',
+      '--add-opens',
+      'java.base/java.lang=ALL-UNNAMED',
     },
     filetypes = { 'java' },
     root_dir = function(fname)
@@ -87,28 +107,19 @@ configs[server_name] = {
       return vim.fn.getcwd()
     end,
     init_options = {
-      workspace = path.join { vim.loop.os_homedir(), 'workspace' },
+      workspace = get_workspace_dir(),
       jvm_args = {},
       os_config = nil,
     },
     handlers = {
-      -- Due to an invalid protocol implementation in the jdtls we have to
-      -- conform these to be spec compliant.
+      -- Due to an invalid protocol implementation in the jdtls we have to conform these to be spec compliant.
       -- https://github.com/eclipse/eclipse.jdt.ls/issues/376
-      -- Command in org.eclipse.lsp5j -> https://github.com/eclipse/lsp4j/blob/master/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Command.java
-      -- CodeAction in org.eclipse.lsp4j -> https://github.com/eclipse/lsp4j/blob/master/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeAction.java
-      -- Command in LSP -> https://microsoft.github.io/language-server-protocol/specification#command
-      -- CodeAction in LSP -> https://microsoft.github.io/language-server-protocol/specification#textDocument_codeAction
       ['textDocument/codeAction'] = function(a, b, actions)
         for _, action in ipairs(actions) do
           -- TODO: (steelsojka) Handle more than one edit?
-          -- if command is string, then 'ation' is Command in java format,
-          -- then we add 'edit' property to change to CodeAction in LSP and 'edit' will be executed first
-          if action.command == 'java.apply.workspaceEdit' then
+          if action.command == 'java.apply.workspaceEdit' then -- 'action' is Command in java format
             action.edit = fix_zero_version(action.edit or action.arguments[1])
-            -- if command is table, then 'action' is CodeAction in java format
-            -- then we add 'edit' property to change to CodeAction in LSP and 'edit' will be executed first
-          elseif type(action.command) == 'table' and action.command.command == 'java.apply.workspaceEdit' then
+          elseif type(action.command) == 'table' and action.command.command == 'java.apply.workspaceEdit' then -- 'action' is CodeAction in java format
             action.edit = fix_zero_version(action.edit or action.command.arguments[1])
           end
         end
@@ -129,26 +140,54 @@ configs[server_name] = {
   docs = {
     package_json = 'https://raw.githubusercontent.com/redhat-developer/vscode-java/master/package.json',
     description = [[
-
 https://projects.eclipse.org/projects/eclipse.jdt.ls
 
 Language server for Java.
 
-See project page for installation instructions.
+IMPORTANT: If you want all the features jdtls has to offer, [nvim-jdtls](https://github.com/mfussenegger/nvim-jdtls)
+is highly recommended. If all you need is diagnostics, completion, imports, gotos and formatting and some code actions
+you can keep reading here.
 
-Due to the nature of java, the settings for eclipse jdtls cannot be automatically
-inferred. Please set the following environmental variables to match your installation. You can set these locally for your project with the help of [direnv](https://github.com/direnv/direnv). Note version numbers will change depending on your project's version of java, your version of eclipse, and in the case of JDTLS_CONFIG, your OS.
+For manual installation you can download precompiled binaries from the
+[official downloads site](http://download.eclipse.org/jdtls/snapshots/?d)
+
+Due to the nature of java, settings cannot be inferred. Please set the following
+environmental variables to match your installation. If you need per-project configuration
+[direnv](https://github.com/direnv/direnv) is highly recommended.
 
 ```bash
-export JAR=/path/to/eclipse.jdt.ls/org.eclipse.jdt.ls.product/target/repository/plugins/org.eclipse.equinox.launcher_1.6.0.v20200915-1508.jar
-export GRADLE_HOME=$HOME/gradle
-export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:/bin/java::")
-export JDTLS_CONFIG=/path/to/eclipse.jdt.ls/org.eclipse.jdt.ls.product/target/repository/config_linux
-export WORKSPACE=$HOME/workspace
+# Mandatory:
+# .bashrc
+export JDTLS_HOME=/path/to/jdtls_root # Directory with the plugin and configs directories
+
+# Optional:
+export JAVA_HOME=/path/to/java_home # In case you don't have java in path or want to use a version in particular
+export WORKSPACE=/path/to/workspace # Defaults to $HOME/workspace
 ```
+```lua
+  -- init.lua
+  require'lspconfig'.jdtls.setup{}
+```
+
+For automatic installation you can use the following unofficial installers/launchers under your own risk:
+  - [jdtls-launcher](https://github.com/eruizc-dev/jdtls-launcher) (Includes lombok support by default)
+    ```lua
+      -- init.lua
+      require'lspconfig'.jdtls.setup{ cmd = { 'jdtls' } }
+    ```
     ]],
     default_config = {
-      root_dir = [[root_pattern(".git")]],
+      root_dir = [[{
+        -- Single-module projects
+        {
+          'build.xml', -- Ant
+          'pom.xml', -- Maven
+          'settings.gradle', -- Gradle
+          'settings.gradle.kts', -- Gradle
+        },
+        -- Multi-module projects
+        { 'build.gradle', 'build.gradle.kts' },
+      } or vim.fn.getcwd()]],
     },
   },
 }


### PR DESCRIPTION
After the discussion in #1067 this is what came up:

 - Improve default root_dir: 
    - Some people complaint that projects without package managers didn't work, so I added Makefile and .git
    - The multi-file project root was unnecessary, it also included `.kts` files that are for Kottlin projects
 - Improve cmd autodetect:
    - Removed `cmd_env` property that did nothing
    - Made `JAVA_HOME` and `WORKSPACE` env variables optional
    - Unified `JAR` and `JDTLS_CONFIG` into `JDTLS_HOME`
    - Preserved `JAR` and `JDTLS_CONFIG` with a message to avoid breaking existing configurations
    - Added `.exe` for windows support
 - Update documentation
    - Add links to point in the right direction
    - Mention jdtls-launcher as unofficial installer/launcher
    - Mention nvim-jdtls as complete client implementation
    - Provide actual configuration examples