### PR TITLE
feat: add vdmj language server

### DIFF
--- a/lua/lspconfig/vdmj.lua
+++ b/lua/lspconfig/vdmj.lua
@@ -1,0 +1,135 @@
+local configs = require 'lspconfig/configs'
+local util = require 'lspconfig/util'
+
+if vim.fn.has 'nvim-0.5.1' == 0 then
+  vim.notify('The VDMJ language server requires nvim > 0.5', vim.log.levels.ERROR)
+  return
+end
+
+local server_name = 'vdmj'
+
+local mavenrepo = util.path.join(vim.env.HOME, '.m2', 'repository', 'com', 'fujitsu')
+
+local function get_jar_path(config, package, version)
+  return util.path.join(config.options.mavenrepo, package, version, package .. '-' .. version .. '.jar')
+end
+
+local function with_precision(version, is_high_precision)
+  return is_high_precision and version:gsub('([%d.]+)', '%1-P') or version
+end
+
+local function get_latest_installed_version(repo)
+  local path = util.path.join(repo, 'lsp')
+  local sort = vim.fn.sort
+
+  local subdirs = function(file)
+    local stat = vim.loop.fs_stat(util.path.join(path, file))
+    return stat.type == 'directory' and 1 or 0
+  end
+
+  local candidates = vim.fn.readdir(path, subdirs)
+  local sorted = sort(sort(candidates, 'l'), 'N')
+  return sorted[#sorted]
+end
+
+local function find_vscode_ancestor(startpath)
+  return util.search_ancestors(startpath, function(path)
+    if util.path.is_dir(util.path.join(path, '.vscode')) then
+      return path
+    end
+  end)
+end
+
+configs[server_name] = {
+  default_config = {
+    cmd = { 'java' },
+    filetypes = { 'vdmsl', 'vdmpp', 'vdmrt' },
+    root_dir = function(fname)
+      return util.find_git_ancestor(fname) or find_vscode_ancestor(fname) or util.path.dirname(fname)
+    end,
+    options = {
+      java = vim.env.JAVA_HOME and util.path.join(vim.env.JAVA_HOME, 'bin', 'java') or 'java',
+      java_opts = { '-Xmx3000m', '-Xss1m' },
+      annotation_paths = {},
+      mavenrepo = mavenrepo,
+      version = get_latest_installed_version(mavenrepo),
+      logfile = util.path.join(vim.fn.stdpath 'cache', 'vdm-lsp.log'),
+      debugger_port = -1,
+      high_precision = false,
+    },
+  },
+  docs = {
+    description = [[
+https://github.com/nickbattle/vdmj
+
+The VDMJ language server can be installed by cloning the VDMJ repository and
+running `mvn clean install`.
+
+Various options are provided to configure the language server (see below). In
+particular:
+- `annotation_paths` is a list of folders and/or jar file paths for annotations
+that should be used with the language server;
+- any value of `debugger_port` less than zero will disable the debugger; note
+that if a non-zero value is used, only one instance of the server can be active
+at a time.
+
+More settings for VDMJ can be changed in a file called `vdmj.properties` under
+`root_dir/.vscode`. For a description of the available settings, see
+[Section 7 of the VDMJ User Guide](https://raw.githubusercontent.com/nickbattle/vdmj/master/vdmj/documentation/UserGuide.pdf).
+
+Note: proof obligations and combinatorial testing are not currently supported
+by neovim.
+]],
+    default_config = {
+      cmd = 'Generated from the options given',
+      root_dir = "Git root or vim's starting directory",
+      options = {
+        java = '$JAVA_HOME/bin/java',
+        java_opts = { '-Xmx3000m', '-Xss1m' },
+        annotation_paths = {},
+        mavenrepo = '$HOME/.m2/repository/com/fujitsu',
+        version = 'The latest version installed in `mavenrepo`',
+        logfile = "path.join(vim.fn.stdpath 'cache', 'vdm-lsp.log')",
+        debugger_port = -1,
+        high_precision = false,
+      },
+    },
+  },
+  on_new_config = function(config, root_dir)
+    local version = with_precision(
+      config.options.version or get_latest_installed_version(config.options.mavenrepo),
+      config.options.high_precision
+    )
+
+    local classpath = table.concat({
+      get_jar_path(config, 'vdmj', version),
+      get_jar_path(config, 'annotations', version),
+      get_jar_path(config, 'lsp', version),
+      util.path.join(root_dir, '.vscode'),
+      unpack(config.options.annotation_paths),
+    }, ':')
+
+    local java_cmd = {
+      config.options.java,
+      config.options.java_opts,
+      '-Dlsp.log.filename=' .. config.options.logfile,
+      '-cp',
+      classpath,
+    }
+
+    local dap = {}
+
+    if config.options.debugger_port >= 0 then
+      -- TODO: LS will fail to start if port is already in use
+      dap = { '-dap', tostring(config.options.debugger_port) }
+    end
+
+    local vdmj_cmd = {
+      'lsp.LSPServerStdio',
+      '-' .. vim.bo.filetype,
+      dap,
+    }
+
+    config.cmd = vim.tbl_flatten { java_cmd, vdmj_cmd }
+  end,
+}

--- a/lua/lspconfig/vdmj.lua
+++ b/lua/lspconfig/vdmj.lua
@@ -32,6 +32,7 @@ local function get_latest_installed_version(repo)
   return sorted[#sorted]
 end
 
+-- Special case, as vdmj store particular settings under root_dir/.vscode
 local function find_vscode_ancestor(startpath)
   return util.search_ancestors(startpath, function(path)
     if util.path.is_dir(util.path.join(path, '.vscode')) then
@@ -45,7 +46,7 @@ configs[server_name] = {
     cmd = { 'java' },
     filetypes = { 'vdmsl', 'vdmpp', 'vdmrt' },
     root_dir = function(fname)
-      return util.find_git_ancestor(fname) or find_vscode_ancestor(fname) or util.path.dirname(fname)
+      return util.find_git_ancestor(fname) or find_vscode_ancestor(fname)
     end,
     options = {
       java = vim.env.JAVA_HOME and util.path.join(vim.env.JAVA_HOME, 'bin', 'java') or 'java',
@@ -82,7 +83,7 @@ by neovim.
 ]],
     default_config = {
       cmd = 'Generated from the options given',
-      root_dir = "Git root or vim's starting directory",
+      root_dir = 'util.find_git_ancestor(fname) or find_vscode_ancestor(fname)',
       options = {
         java = '$JAVA_HOME/bin/java',
         java_opts = { '-Xmx3000m', '-Xss1m' },


### PR DESCRIPTION
This PR adds a configuration for the VDMJ language server. Below I highlighted a couple of small issues I would like some help with before merging.

I tested this configuration on Arch Linux and MacOS Catalina, but I have no way to test it on Windows. I expect some minor modification will be needed to make it work on Windows.

Also, for this to work properly https://github.com/neovim/neovim/commit/1dab9357de586b08431175f19a1b44bb294866d6 is needed. What is the appropriate way to mention this in the docstring (if needed at all)?