### PR TITLE
Respect the setting of $FLUTTER_SDK

### DIFF
--- a/lua/lspconfig/dartls.lua
+++ b/lua/lspconfig/dartls.lua
@@ -5,13 +5,13 @@ local server_name = 'dartls'
 local bin_name = 'dart'
 
 local find_dart_sdk_root_path = function()
-  if os.getenv 'FLUTTER_SDK' ~= nil then
+  if os.getenv 'FLUTTER_SDK' then
     local flutter_path = os.getenv 'FLUTTER_SDK'
-    return util.path.path_join(flutter_path, '/cache/dart-sdk/bin/dart')
+    return util.path.path_join(flutter_path, 'cache', 'dart-sdk', 'bin', 'dart')
   elseif vim.fn['executable'] 'flutter' == 1 then
     local flutter_path = vim.fn['resolve'](vim.fn['exepath'] 'flutter')
     local flutter_bin = vim.fn['fnamemodify'](flutter_path, ':h')
-    return flutter_bin .. '/cache/dart-sdk/bin/dart'
+    return util.path.path_join(flutter_bin, 'cache', 'dart-sdk', 'bin', 'dart')
   elseif vim.fn['executable'] 'dart' == 1 then
     return vim.fn['resolve'](vim.fn['exepath'] 'dart')
   else
@@ -21,7 +21,7 @@ end
 
 local analysis_server_snapshot_path = function()
   local dart_sdk_root_path = vim.fn['fnamemodify'](find_dart_sdk_root_path(), ':h')
-  local snapshot = dart_sdk_root_path .. '/snapshots/analysis_server.dart.snapshot'
+  local snapshot = util.path.path_join(dart_sdk_root_path, 'snapshots', 'analysis_server.dart.snapshot')
 
   if vim.fn['has'] 'win32' == 1 or vim.fn['has'] 'win64' == 1 then
     snapshot = snapshot:gsub('/', '\\')

--- a/lua/lspconfig/dartls.lua
+++ b/lua/lspconfig/dartls.lua
@@ -5,7 +5,10 @@ local server_name = 'dartls'
 local bin_name = 'dart'
 
 local find_dart_sdk_root_path = function()
-  if vim.fn['executable'] 'flutter' == 1 then
+  if os.getenv 'FLUTTER_SDK' ~= nil then
+    local flutter_path = os.getenv 'FLUTTER_SDK'
+    return util.path.path_join(flutter_path, '/cache/dart-sdk/bin/dart')
+  elseif vim.fn['executable'] 'flutter' == 1 then
     local flutter_path = vim.fn['resolve'](vim.fn['exepath'] 'flutter')
     local flutter_bin = vim.fn['fnamemodify'](flutter_path, ':h')
     return flutter_bin .. '/cache/dart-sdk/bin/dart'


### PR DESCRIPTION
On some systems, notably, NixOS, the Flutter SDK does not reside with the executable.
`$FLUTTER_SDK` is used to set a new path for the SDK, so this will search there first.
This solves the workaround of manually setting `cmd` in the config for dartls.
<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->
