### PR TITLE
ci: run codespell on pull requests

### DIFF
--- a/.codespellignorewords
+++ b/.codespellignorewords
@@ -1,0 +1,3 @@
+als
+edn
+esy

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,21 @@
+name: codespell
+on: [pull_request]
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          fetch-depth: 0
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install codespell
+      - name: Use codespell
+        run: |
+          codespell --quiet-level=2 --check-hidden --skip=CONFIG.md --ignore-words=.codespellignorewords || exit

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -221,7 +221,7 @@ function M.server_per_root_dir_manager(_make_config)
       return
     end
 
-    -- Check if we have a client alredy or start and store it.
+    -- Check if we have a client already or start and store it.
     local client_id = clients[root_dir]
     if not client_id then
       local new_config = _make_config(root_dir)


### PR DESCRIPTION
I've added two files related to codespell:

- `.codespellignorewords`: if you want to disable a word globally then just add it here.
- `.codespellignorelines`: if you want to stop codespell from warning in one specific instance, but not globally, then add the entire string (aka the full line) to ignore it. I don't know how to explain it well but just check the file and I think you'll get what I mean.

It's also possible to ignore files/directories, but that has to be done with the `--skip` flag to codespell.