### PR TITLE
Fix install command for yamlls

### DIFF
--- a/lua/lspconfig/yamlls.lua
+++ b/lua/lspconfig/yamlls.lua
@@ -15,9 +15,9 @@ configs[server_name] = {
     description = [[
 https://github.com/redhat-developer/yaml-language-server
 
-`yaml-language-server` can be installed via `npm`:
+`yaml-language-server` can be installed via `yarn`:
 ```sh
-npm install -g yaml-language-server
+yarn global add yaml-language-server
 ```
 ]],
     default_config = {


### PR DESCRIPTION
<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->
Installing yamlls through `npm install -g yaml-language-server` no longer works. The error I ran into is:

```sh
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'yaml-language-server@0.21.1',
npm WARN EBADENGINE   required: {
npm WARN EBADENGINE     node: '*',
npm WARN EBADENGINE     npm: '\n\nERROR: Please use yarn, npm is not supported in this repository!!!\n\n',
npm WARN EBADENGINE     yarn: '^1.22.5'
npm WARN EBADENGINE   },
npm WARN EBADENGINE   current: { node: 'v16.5.0', npm: '7.19.1' }
npm WARN EBADENGINE }
```

Therefore I updated the docs to use yarn.
