### PR TITLE
Remove xcrun from sourcekit-lsp cmd

### DIFF
--- a/lua/lspconfig/sourcekit.lua
+++ b/lua/lspconfig/sourcekit.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig/util'
 
 configs.sourcekit = {
   default_config = {
-    cmd = { 'xcrun', 'sourcekit-lsp' },
+    cmd = { 'sourcekit-lsp' },
     filetypes = { 'swift', 'c', 'cpp', 'objective-c', 'objective-cpp' },
     root_dir = util.root_pattern('Package.swift', '.git'),
   },


### PR DESCRIPTION
With recent versions of macOS + Xcode sourcekit-lsp is now in /usr/bin,
so running it with `xcrun` is no longer necessary. This also enables
this configuration to work on Linux.