### PR TITLE
Fix julials

### DIFF
--- a/lua/lspconfig/julials.lua
+++ b/lua/lspconfig/julials.lua
@@ -9,7 +9,7 @@ local cmd = {
   [[
     using Pkg
     Pkg.activate(Base.current_project())
-    using LanguageServer, SymbolServer, StaticLint
+    using LanguageServer
     depot_path = get(ENV, "JULIA_DEPOT_PATH", "")
     project_path = let
         dirname(something(

--- a/lua/lspconfig/julials.lua
+++ b/lua/lspconfig/julials.lua
@@ -8,7 +8,7 @@ local cmd = {
   '-e',
   [[
     using Pkg
-    Pkg.instantiate()
+    Pkg.activate(Base.current_project())
     using LanguageServer
     depot_path = get(ENV, "JULIA_DEPOT_PATH", "")
     project_path = let

--- a/lua/lspconfig/julials.lua
+++ b/lua/lspconfig/julials.lua
@@ -39,7 +39,7 @@ configs.julials = {
   default_config = {
     cmd = cmd,
     on_new_config = function(new_config, _)
-      local server_path = vim.fn.system 'julia --startup-file=no -q -e \'print(Base.find_package("LanguageServer"))\''
+      local server_path = vim.fn.system 'julia --startup-file=no -q -e \'print(dirname(something(Base.find_package("LanguageServer"))))\''
       local new_cmd = vim.deepcopy(cmd)
       table.insert(new_cmd, 2, '--project=' .. server_path:sub(0, -19))
       new_config.cmd = new_cmd

--- a/lua/lspconfig/julials.lua
+++ b/lua/lspconfig/julials.lua
@@ -9,7 +9,7 @@ local cmd = {
   [[
     using Pkg
     Pkg.activate(Base.current_project())
-    using LanguageServer
+    using LanguageServer, SymbolServer, StaticLint
     depot_path = get(ENV, "JULIA_DEPOT_PATH", "")
     project_path = let
         dirname(something(

--- a/lua/lspconfig/julials.lua
+++ b/lua/lspconfig/julials.lua
@@ -39,7 +39,7 @@ configs.julials = {
   default_config = {
     cmd = cmd,
     on_new_config = function(new_config, _)
-      local server_path = vim.fn.system 'julia --startup-file=no -q -e \'print(dirname(something(Base.find_package("LanguageServer"))))\''
+      local server_path = vim.fn.system 'julia --startup-file=no -q -e \'print(dirname(something(Base.current_project(Base.find_package("LanguageServer")))))\''
       local new_cmd = vim.deepcopy(cmd)
       table.insert(new_cmd, 2, '--project=' .. server_path)
       new_config.cmd = new_cmd

--- a/lua/lspconfig/julials.lua
+++ b/lua/lspconfig/julials.lua
@@ -41,7 +41,7 @@ configs.julials = {
     on_new_config = function(new_config, _)
       local server_path = vim.fn.system 'julia --startup-file=no -q -e \'print(dirname(something(Base.find_package("LanguageServer"))))\''
       local new_cmd = vim.deepcopy(cmd)
-      table.insert(new_cmd, 2, '--project=' .. server_path:sub(0, -19))
+      table.insert(new_cmd, 2, '--project=' .. server_path)
       new_config.cmd = new_cmd
     end,
     filetypes = { 'julia' },


### PR DESCRIPTION
I noticed that the default config for julials, `server_path` is not a path but a file, `print(Base.find_package("LanguageServer"))` prints `"/home/uncomfy/.julia/packages/LanguageServer/JrIEf/src/LanguageServer.jl"` - which is a file. I edited it to `print(dirname(something(Base.current_project(Base.find_package("LanguageServer")))))` so it will give `"/home/uncomfy/.julia/packages/LanguageServer/JrIEf"`. If this small change is not merged, the server will not run due to an error because of `server_path` needs to be a path, and not a file.