### PR TITLE
feat(gopls): add support for "go.work" files

### DIFF
--- a/lua/lspconfig/gopls.lua
+++ b/lua/lspconfig/gopls.lua
@@ -5,10 +5,10 @@ configs.gopls = {
   default_config = {
     cmd = { 'gopls' },
     filetypes = { 'go', 'gomod' },
-    root_dir = util.root_pattern('go.mod', '.git'),
+    root_dir = function(fname)
+      return util.root_pattern 'go.work'(fname) or util.root_pattern('go.mod', '.git')(fname)
+    end,
   },
-  -- on_new_config = function(new_config) end;
-  -- on_attach = function(client, bufnr) end;
   docs = {
     description = [[
 https://github.com/golang/tools/tree/master/gopls


### PR DESCRIPTION
> Support go.work files ([proposal](https://go.googlesource.com/proposal/+/master/design/45713-workspace.md)).
>
> In order to better support the new proposal for a multi-module workspace mode (golang/go#45713), gopls has added support for go.work files. Try adding a go.work file to the root of your module (you still need to enable [`experimentalWorkspaceModule` mode](https://github.com/golang/tools/blob/master/gopls/doc/workspace.md#multiple-modules)) and try out the proposal!

See https://github.com/golang/tools/releases/tag/gopls%2Fv0.7.1