### PR TITLE
fix: don't pass the cwd to root_pattern

### DIFF
--- a/lua/lspconfig/dhall_lsp_server.lua
+++ b/lua/lspconfig/dhall_lsp_server.lua
@@ -5,7 +5,9 @@ configs.dhall_lsp_server = {
   default_config = {
     cmd = { 'dhall-lsp-server' },
     filetypes = { 'dhall' },
-    root_dir = util.root_pattern('.git', vim.fn.getcwd()),
+    root_dir = function(fname)
+      return util.root_pattern '.git'(fname) or util.path.dirname(fname)
+    end,
     docs = {
       description = [[
 https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-lsp-server
@@ -19,7 +21,7 @@ cabal install dhall-lsp-server
 prebuilt binaries can be found [here](https://github.com/dhall-lang/dhall-haskell/releases).
 ]],
       default_config = {
-        root_dir = [[root_pattern(".git", vim.fn.getcwd())]],
+        root_dir = [[root_pattern(".git") or dirname]],
       },
     },
   },

--- a/lua/lspconfig/jsonls.lua
+++ b/lua/lspconfig/jsonls.lua
@@ -11,7 +11,9 @@ configs[server_name] = {
     init_options = {
       provideFormatter = true,
     },
-    root_dir = util.root_pattern('.git', vim.fn.getcwd()),
+    root_dir = function(fname)
+      return util.root_pattern '.git'(fname) or util.path.dirname(fname)
+    end,
   },
   docs = {
     -- this language server config is in VSCode built-in package.json
@@ -41,7 +43,7 @@ require'lspconfig'.jsonls.setup {
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git", vim.fn.getcwd())]],
+      root_dir = [[root_pattern(".git") or dirname]],
     },
   },
 }

--- a/lua/lspconfig/yamlls.lua
+++ b/lua/lspconfig/yamlls.lua
@@ -8,7 +8,9 @@ configs[server_name] = {
   default_config = {
     cmd = { bin_name, '--stdio' },
     filetypes = { 'yaml' },
-    root_dir = util.root_pattern('.git', vim.fn.getcwd()),
+    root_dir = function(fname)
+      return util.root_pattern '.git'(fname) or util.path.dirname(fname)
+    end,
   },
   docs = {
     package_json = 'https://raw.githubusercontent.com/redhat-developer/vscode-yaml/master/package.json',
@@ -21,7 +23,7 @@ yarn global add yaml-language-server
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git", vim.fn.getcwd())]],
+      root_dir = [[root_pattern(".git") or dirname]],
     },
   },
 }


### PR DESCRIPTION
<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->

Fixes `root_dir` getting set to '/' because of wrong arguments to `utils.root_pattern`.
