### PR TITLE
feat(diagnosticls): update config to support windows

### DIFF
--- a/lua/lspconfig/diagnosticls.lua
+++ b/lua/lspconfig/diagnosticls.lua
@@ -3,6 +3,9 @@ local util = require 'lspconfig/util'
 
 local server_name = 'diagnosticls'
 local bin_name = 'diagnostic-languageserver'
+if vim.fn.has 'win32' == 1 then
+  bin_name = bin_name .. '.cmd'
+end
 
 configs[server_name] = {
   default_config = {


### PR DESCRIPTION
I found this bit of code yanked from the `tsserver.lua` necessary to get the diagnostic-languageserver running properly on Windows.