### PR TITLE
[jdtls] Use subdirectories in workspace directory

### DIFF
--- a/lua/lspconfig/jdtls.lua
+++ b/lua/lspconfig/jdtls.lua
@@ -19,7 +19,9 @@ local function get_java_executable()
 end
 
 local function get_workspace_dir()
-  return env.WORKSPACE and env.WORKSPACE or util.path.join(env.HOME, 'workspace')
+  local workspace_root = env.WORKSPACE or util.path.join(env.HOME, 'workspace')
+
+  return util.path.join(workspace_root, vim.fn.fnamemodify(vim.fn.getcwd(), ':p:h:t'))
 end
 
 local function get_jdtls_jar()


### PR DESCRIPTION
If one launches multiple eclipse.jdt.ls servers for different projects,
they should use unique data directories to not interfere with eachother.
This commit adds a project subdirectory in the workspace directory,
based on the directory name of the project.

This allows starting multiple servers without them overwriting the data of the previously launched servers.