### PR TITLE
[denols] Fix root_dir

### DIFF
--- a/lua/lspconfig/denols.lua
+++ b/lua/lspconfig/denols.lua
@@ -103,7 +103,13 @@ configs[server_name] = {
   default_config = {
     cmd = { 'deno', 'lsp' },
     filetypes = { 'javascript', 'javascriptreact', 'javascript.jsx', 'typescript', 'typescriptreact', 'typescript.tsx' },
-    root_dir = util.root_pattern('package.json', 'tsconfig.json', '.git'),
+    root_dir = function(fname)
+      local root_files = {
+        'package.json',
+        'tsconfig.json',
+      }
+      return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname) or util.path.dirname(fname)
+    end,
     init_options = {
       enable = true,
       lint = false,


### PR DESCRIPTION
At the moment denols may [fail to start since root directory is not detected](https://github.com/neovim/nvim-lspconfig/blob/b4661ec91e4675a339289d5662a93e646aeabe6f/lua/lspconfig/configs.lua#L71-L73).

I referred to
https://github.com/neovim/nvim-lspconfig/blob/b4661ec91e4675a339289d5662a93e646aeabe6f/lua/lspconfig/pylsp.lua#L8-L17