### PR TITLE
Better default root_dir for fortls.

### DIFF
--- a/lua/lspconfig/fortls.lua
+++ b/lua/lspconfig/fortls.lua
@@ -6,7 +6,7 @@ configs.fortls = {
     cmd = { 'fortls' },
     filetypes = { 'fortran' },
     root_dir = function(fname)
-      return util.root_pattern('.fortls') or util.find_git_ancestor(fname) or util.path.dirname(fname)
+      return util.root_pattern('.fortls') or util.find_git_ancestor(fname)
     end,
     settings = {
       nthreads = 1,

--- a/lua/lspconfig/fortls.lua
+++ b/lua/lspconfig/fortls.lua
@@ -5,7 +5,7 @@ configs.fortls = {
   default_config = {
     cmd = { 'fortls' },
     filetypes = { 'fortran' },
-    root_dir = util.root_pattern '.fortls',
+    root_dir = return util.root_pattern('.fortls') or util.find_git_ancestor(fname) or util.path.dirname(fname),
     settings = {
       nthreads = 1,
     },

--- a/lua/lspconfig/fortls.lua
+++ b/lua/lspconfig/fortls.lua
@@ -6,7 +6,7 @@ configs.fortls = {
     cmd = { 'fortls' },
     filetypes = { 'fortran' },
     root_dir = function(fname)
-      return util.root_pattern('.fortls') or util.find_git_ancestor(fname)
+      return util.root_pattern('.fortls')(fname) or util.find_git_ancestor(fname)
     end,
     settings = {
       nthreads = 1,

--- a/lua/lspconfig/fortls.lua
+++ b/lua/lspconfig/fortls.lua
@@ -5,7 +5,9 @@ configs.fortls = {
   default_config = {
     cmd = { 'fortls' },
     filetypes = { 'fortran' },
-    root_dir = return util.root_pattern('.fortls') or util.find_git_ancestor(fname) or util.path.dirname(fname),
+    root_dir = function(fname) 
+      return util.root_pattern('.fortls') or util.find_git_ancestor(fname) or util.path.dirname(fname)
+    end,
     settings = {
       nthreads = 1,
     },

--- a/lua/lspconfig/fortls.lua
+++ b/lua/lspconfig/fortls.lua
@@ -5,7 +5,7 @@ configs.fortls = {
   default_config = {
     cmd = { 'fortls' },
     filetypes = { 'fortran' },
-    root_dir = function(fname) 
+    root_dir = function(fname)
       return util.root_pattern('.fortls') or util.find_git_ancestor(fname) or util.path.dirname(fname)
     end,
     settings = {


### PR DESCRIPTION
Require an explicit `.fortls` file in every project to activate Fortran LSP is not very intuitive I think, so I add either a git folder or the current working directory.