### PR TITLE
Add description to jsonls

### DIFF
--- a/lua/lspconfig/jsonls.lua
+++ b/lua/lspconfig/jsonls.lua
@@ -41,6 +41,18 @@ require'lspconfig'.jsonls.setup {
     }
 }
 ```
+
+Neovim does not currently include built-in snippets. `vscode-json-language-server` only provides completions when snippet support is enabled. To enable completion, install a snippet plugin and add the following override to your language client capabilities during setup.
+
+```lua
+--Enable (broadcasting) snippet capability for completion
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+capabilities.textDocument.completion.completionItem.snippetSupport = true
+
+require'lspconfig'.jsonls.setup {
+  capabilities = capabilities,
+}
+```
 ]],
     default_config = {
       root_dir = [[root_pattern(".git") or dirname]],


### PR DESCRIPTION
Same as css and html, `vscode-json-language-server` also needs snippet support enabled to make completion working.