### PR TITLE
fix(solargraph): Add dirname to root_dir

### DIFF
--- a/lua/lspconfig/solargraph.lua
+++ b/lua/lspconfig/solargraph.lua
@@ -15,7 +15,9 @@ configs.solargraph = {
     },
     init_options = { formatting = true },
     filetypes = { 'ruby' },
-    root_dir = util.root_pattern('Gemfile', '.git'),
+    root_dir = function(fname)
+      return util.root_pattern 'Gemfile'(fname) or util.find_git_ancestor(fname) or util.path.dirname(fname)
+    end,
   },
   docs = {
     package_json = 'https://raw.githubusercontent.com/castwide/vscode-solargraph/master/package.json',
@@ -31,7 +33,7 @@ gem install --user-install solargraph
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("Gemfile", ".git")]],
+      root_dir = [[root_pattern("Gemfile", ".git") or dirname]],
     },
   },
 }


### PR DESCRIPTION
Add dirname to solargraph's root_dir

The reasons are as follows.
* `solargraph` can work as a standalone ruby script without a Gemfile
* I want to use `solargraph` in snippets (e.g. to check how it works)
* It's intuitive (especially beginner-friendly)