### PR TITLE
fix(ui): gracefully handle null filetypes

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -321,12 +321,15 @@ function M.find_package_json_ancestor(startpath)
   end)
 end
 
-function M.get_active_client_by_ft(filetype)
+function M.get_active_clients_list_by_ft(filetype)
   local clients = vim.lsp.get_active_clients()
   local clients_list = {}
   for _, client in pairs(clients) do
-    if vim.tbl_contains(client.config.filetypes, filetype) then
-      table.insert(clients_list, client.name)
+    local filetypes = client.config.filetypes or {}
+    for _, ft in pairs(filetypes) do
+      if ft == filetype then
+        table.insert(clients_list, client.name)
+      end
     end
   end
   return clients_list
@@ -334,12 +337,12 @@ end
 
 function M.get_other_matching_providers(filetype)
   local configs = require 'lspconfig/configs'
-  local active_clients_list = M.get_active_client_by_ft(filetype)
+  local active_clients_list = M.get_active_clients_list_by_ft(filetype)
   local other_matching_configs = {}
   for _, config in pairs(configs) do
     if not vim.tbl_contains(active_clients_list, config.name) then
-      local filestypes = config.filetypes or {}
-      for _, ft in pairs(filestypes) do
+      local filetypes = config.filetypes or {}
+      for _, ft in pairs(filetypes) do
         if ft == filetype then
           table.insert(other_matching_configs, config)
         end


### PR DESCRIPTION
# Description

Avoid de-referencing a null `client.config.filetypes` entry.

Fixes #1215

## How has this been tested?

Using `minimal_init.lua` and `efm` which doesn't specify a type by default.