### PR TITLE
fix(bashls): consider .git when selecting root_dir

### DIFF
--- a/lua/lspconfig/bashls.lua
+++ b/lua/lspconfig/bashls.lua
@@ -14,7 +14,9 @@ configs[server_name] = {
       GLOB_PATTERN = vim.env.GLOB_PATTERN or '*@(.sh|.inc|.bash|.command)',
     },
     filetypes = { 'sh' },
-    root_dir = util.path.dirname,
+    root_dir = function(fname)
+      return util.root_pattern '.git'(fname) or util.path.dirname(fname)
+    end,
   },
   docs = {
     description = [[


### PR DESCRIPTION
When using bashls with plugins like https://github.com/ahmedkhalf/project.nvim it is very annoying, when the project root suddenly changes, when you are editing a script, which is a part of a bigger project. This change should fix the issue. 

See also: https://github.com/LunarVim/LunarVim/issues/1467