### PR TITLE
Add volar

### DIFF
--- a/lua/lspconfig/volar.lua
+++ b/lua/lspconfig/volar.lua
@@ -1,0 +1,89 @@
+local configs = require 'lspconfig/configs'
+local util = require 'lspconfig/util'
+
+local function get_typescript_server_path(root_dir)
+  local project_root = util.find_node_modules_ancestor(root_dir)
+  return project_root and (util.path.join(project_root, 'node_modules', 'typescript', 'lib', 'tsserverlibrary.js'))
+    or ''
+end
+
+local server_name = 'volar'
+local bin_name = 'volar-server'
+
+-- https://github.com/johnsoncodehk/volar/blob/master/packages/shared/src/types.ts
+local volar_init_options = {
+  typescript = {
+    serverPath = '',
+  },
+  languageFeatures = {
+    -- not supported - https://github.com/neovim/neovim/pull/14122
+    semanticTokens = false,
+    references = true,
+    definition = true,
+    typeDefinition = true,
+    callHierarchy = true,
+    hover = true,
+    rename = true,
+    renameFileRefactoring = true,
+    signatureHelp = true,
+    codeAction = true,
+    completion = {
+      defaultTagNameCase = 'both',
+      defaultAttrNameCase = 'kebabCase',
+    },
+    schemaRequestService = true,
+    documentHighlight = true,
+    documentLink = true,
+    codeLens = true,
+    diagnostics = true,
+  },
+  documentFeatures = {
+    -- not supported - https://github.com/neovim/neovim/pull/13654
+    documentColor = false,
+    selectionRange = true,
+    foldingRange = true,
+    linkedEditingRange = true,
+    documentSymbol = true,
+    documentFormatting = {
+      defaultPrintWidth = 100,
+    },
+  },
+}
+
+configs[server_name] = {
+  default_config = {
+    cmd = { bin_name, '--stdio' },
+    filetypes = { 'vue' },
+    root_dir = util.root_pattern 'package.json',
+    init_options = volar_init_options,
+    on_new_config = function(new_config, new_root_dir)
+      if
+        new_config.init_options
+        and new_config.init_options.typescript
+        and new_config.init_options.typescript.serverPath == ''
+      then
+        new_config.init_options.typescript.serverPath = get_typescript_server_path(new_root_dir)
+      end
+    end,
+  },
+  docs = {
+    package_json = 'https://raw.githubusercontent.com/johnsoncodehk/volar/master/package.json',
+    description = [[
+https://github.com/johnsoncodehk/volar/tree/master/packages/server
+
+Volar language server for Vue
+Volar can be installed via npm
+```sh
+npm install -g @volar/server
+```
+
+With Vue 3 projects - it works out of the box.
+
+With Vue 2 projects - requires [additional configuration](https://github.com/johnsoncodehk/volar#using)
+
+Do not run `vuels` and `volar` at the same time.
+
+To check which language servers are running, open a `.vue` file and run the `:LspInfo` command.
+]],
+  },
+}


### PR DESCRIPTION
After the release of Vue 3 there arose a need of a new language server that suppors the new syntax.
We already have `vuels` in the repo (so that's the one that existed pre-Vue 3) and the new `volarvuels` I'm adding here that supports the new syntax.

https://github.com/johnsoncodehk/volar

https://github.com/johnsoncodehk/volar#communitys-language-client-implements - it's supported in many vim lsp configuration providing extensions, I'm just adding it also here :P

See https://github.com/johnsoncodehk/volar/discussions/441

Problems:
- [x] <s>If this is merged we'll have `vls`, `vuels` and `volarvuels` which makes things even more confusing, since `vuels` is normally `vls`, but `vls` is taken by the V language server, so this repo uses `vuels` instead. But now we have `volarvuels`. AND there's also https://github.com/vuedx/languagetools/tree/main/packages/vue-languageservice which is a third language server for Vue </s> Decided on just volar
- [x] It's actually crucial to pass serverPath. I'll need to look at angularls's code to detect it dynamically
- [x] Improve docs -  I assume as long as the nvim set-rtp command from CONTRIBUTING.md has the word 'volar' I'm good. Since it's not modifying the CONFIG.md for me locally
- [x] <s>bin_name uses volar-server, which I got from the AUR. Better wait for https://github.com/johnsoncodehk/volar/issues/458</s> - fixed because newest alpha version exposes vue-server binary. <s>Let's still wait for this to stabilize</s> Volar's maitainer's words sound like it's gonna be a while until this changes
- [x]  <s>Run linters, right now it probably has lots of lint errors</s>
