### PR TITLE
feat(solidity): support solang language server

### DIFF
--- a/lua/lspconfig/solang.lua
+++ b/lua/lspconfig/solang.lua
@@ -1,0 +1,24 @@
+local configs = require 'lspconfig/configs'
+local util = require 'lspconfig/util'
+
+configs.solang = {
+  default_config = {
+    cmd = { 'solang', '--language-server' },
+    filetypes = { 'solidity' },
+    root_dir = util.root_pattern '.git',
+  },
+  docs = {
+    description = [[
+Solang provides the following:
+
+See [docs](https://solang.readthedocs.io/en/latest/installing.html) for installation.
+
+A language server for Solidity providing, diagnostics and hover docs
+
+There is currently no support for completion, or goto definition, references etc..
+]],
+    default_config = {
+      root_dir = [[root_pattern(".git")]],
+    },
+  },
+}


### PR DESCRIPTION
This is not a perfect solidity language server but it will at least provide basic diagnostics. 

installing langserver docs: https://solang.readthedocs.io/en/latest/installing.html

^^ download a binary release from above, rename to `solang` and add it to your `PATH`

repo: https://github.com/hyperledger-labs/solang