### PR TITLE
rust-analyzer: Ignore stderr when invoking cargo metadata

### DIFF
--- a/lua/lspconfig/rust_analyzer.lua
+++ b/lua/lspconfig/rust_analyzer.lua
@@ -18,14 +18,36 @@ configs.rust_analyzer = {
     filetypes = { 'rust' },
     root_dir = function(fname)
       local cargo_crate_dir = util.root_pattern 'Cargo.toml'(fname)
-      local cmd = 'cargo metadata --no-deps --format-version 1'
+      local cmd = { 'cargo', 'metadata', '--no-deps', '--format-version', '1' }
       if cargo_crate_dir ~= nil then
-        cmd = cmd .. ' --manifest-path ' .. util.path.join(cargo_crate_dir, 'Cargo.toml')
+        cmd[#cmd + 1] = '--manifest-path'
+        cmd[#cmd + 1] = util.path.join(cargo_crate_dir, 'Cargo.toml')
       end
-      local cargo_metadata = vim.fn.system(cmd)
+      local cargo_metadata = ''
+      local cargo_metadata_err = ''
+      local cm = vim.fn.jobstart(cmd, {
+        on_stdout = function(j, d, e)
+          cargo_metadata = table.concat(d, '\n')
+        end,
+        on_stderr = function(j, d, e)
+          cargo_metadata_err = table.concat(d, '\n')
+        end,
+        stdout_buffered = true,
+        stderr_buffered = true,
+      })
+      if cm > 0 then
+        cm = vim.fn.jobwait({ cm })[1]
+      else
+        cm = -1
+      end
       local cargo_workspace_dir = nil
-      if vim.v.shell_error == 0 then
+      if cm == 0 then
         cargo_workspace_dir = vim.fn.json_decode(cargo_metadata)['workspace_root']
+      else
+        vim.notify(
+          string.format('cmd [%q] failed:\n%s', table.concat(cmd, ' '), cargo_metadata_err),
+          vim.log.levels.Warning
+        )
       end
       return cargo_workspace_dir
         or cargo_crate_dir


### PR DESCRIPTION
Vim's `system` output [includes both STDOUT and STDERR](https://github.com/neovim/neovim/blob/3c497e214f48ee1433d759f5a56c028df5186f24/src/nvim/os/shell.c#L773-L776), which means it may contain all sorts of debug output, especially if the user is using custom rustup toolchains.

To reproduce, set up neovim to use `lsp-config`, and then:
```console
$ cargo new foo
     Created binary (application) `foo` package
$ cd foo/
$ mkdir -p toolchain/bin/
$ $EDITOR toolchain/bin/cargo
$ cat toolchain/bin/cargo
#!/bin/bash
echo "X" >&2
"$(env -u RUSTUP_TOOLCHAIN rustup +stable which cargo)" "$@"
exit 0
$ chmod +x toolchain/bin/cargo
$ ln -s "$(rustup +stable which rustc)" toolchain/bin/rustc
$ echo '[toolchain]' > rust-toolchain.toml
$ echo "path = \"$PWD/toolchain\"" >> rust-toolchain.toml
$ cargo check
X
    Checking foo v0.1.0 (/Users/jonhoo/dev/foo)
    Finished dev [unoptimized + debuginfo] target(s) in 0.91s
$ nvim src/main.rs
Error detected while processing FileType Autocommands for "rust":
E5108: Error executing lua Vim:E474: Unidentified byte: X
{"packages":[{"name":"foo","version":"0.1.0","id":"foo 0.1.0 (path+file:///Users/jonhoo/dev/foo)","license":null,"license_f
ile":null,"description":null,"source":null,"dependencies":[],"targets":[{"kind":["bin"],"crate_types":["bin"],"name":"foo",
"src_path":"/Users/jonhoo/dev/foo/src/main.rs","edition":"2018","doc":true,"doctest":false,"test":true}],"features":{},"man
ifest_path":"/Users/jonhoo/dev/foo/Cargo.toml","metadata":null,"publish":null,"authors":[],"categories":[],"keywords":[],"r
eadme":null,"repository":null,"homepage":null,"documentation":null,"edition":"2018","links":null}],"workspace_members":["fo
o 0.1.0 (path+file:///Users/jonhoo/dev/foo)"],"resolve":null,"target_directory":"/Users/jonhoo/dev/foo/target","version":1,
"workspace_root":"/Users/jonhoo/dev/foo","metadata":null}
```

With this fix, the error no longer occurs, and `rust-analyzer` starts correctly.

With this change, the plugin will also inform of `cargo metadata` failures. Replace `exit 0` with `exit 1` in `toolchain/bin/cargo`, and run `nvim src/main.rs`, and you'll see
```
cmd "cargo metadata --no-deps --format-version 1 --manifest-path /Users/jonhoo/dev/foo/Cargo.toml" is not executable:
X
```
Previously, this error would be entirely swallowed.