### PR TITLE
fix: add compat shim for handler breaking change

### DIFF
--- a/lua/lspconfig/clangd.lua
+++ b/lua/lspconfig/clangd.lua
@@ -5,16 +5,21 @@ local util = require 'lspconfig/util'
 local function switch_source_header(bufnr)
   bufnr = util.validate_bufnr(bufnr)
   local params = { uri = vim.uri_from_bufnr(bufnr) }
-  vim.lsp.buf_request(bufnr, 'textDocument/switchSourceHeader', params, function(err, _, result)
-    if err then
-      error(tostring(err))
-    end
-    if not result then
-      print 'Corresponding file cannot be determined'
-      return
-    end
-    vim.api.nvim_command('edit ' .. vim.uri_to_fname(result))
-  end)
+  vim.lsp.buf_request(
+    bufnr,
+    'textDocument/switchSourceHeader',
+    params,
+    util.compat_handler(function(err, result)
+      if err then
+        error(tostring(err))
+      end
+      if not result then
+        print 'Corresponding file cannot be determined'
+        return
+      end
+      vim.api.nvim_command('edit ' .. vim.uri_to_fname(result))
+    end)
+  )
 end
 
 local root_pattern = util.root_pattern('compile_commands.json', 'compile_flags.txt', '.git')

--- a/lua/lspconfig/rust_analyzer.lua
+++ b/lua/lspconfig/rust_analyzer.lua
@@ -1,10 +1,9 @@
 local configs = require 'lspconfig/configs'
 local util = require 'lspconfig/util'
-local lsp = vim.lsp
 
 local function reload_workspace(bufnr)
   bufnr = util.validate_bufnr(bufnr)
-  lsp.buf_request(bufnr, 'rust-analyzer/reloadWorkspace', nil, function(err, _, result, _)
+  vim.lsp.buf_request(bufnr, 'rust-analyzer/reloadWorkspace', nil, function(err)
     if err then
       error(tostring(err))
     end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -19,6 +19,27 @@ M.default_config = {
 -- global on_setup hook
 M.on_setup = nil
 
+-- add compatibility shim for breaking signature change
+-- from https://github.com/mfussenegger/nvim-lsp-compl/
+-- TODO: remove after Neovim release
+function M.compat_handler(handler)
+  return function(...)
+    local config_or_client_id = select(4, ...)
+    local is_new = type(config_or_client_id) ~= 'number'
+    if is_new then
+      return handler(...)
+    else
+      local err = select(1, ...)
+      local method = select(2, ...)
+      local result = select(3, ...)
+      local client_id = select(4, ...)
+      local bufnr = select(5, ...)
+      local config = select(6, ...)
+      return handler(err, result, { method = method, client_id = client_id, bufnr = bufnr }, config)
+    end
+  end
+end
+
 function M.validate_bufnr(bufnr)
   validate {
     bufnr = { bufnr, 'n' },


### PR DESCRIPTION
Add a compatibility shim to `util.lua` adapting to breaking change
in handler signature and use it where needed.

(Skipped `denols` and ` rust-analyzer` since those requests don't actually use a a handler.)

Closes #1239 