### PR TITLE
feat(csharp_ls): add support for C# using csharp-ls language server

### DIFF
--- a/lua/lspconfig/csharp_ls.lua
+++ b/lua/lspconfig/csharp_ls.lua
@@ -1,0 +1,26 @@
+local configs = require 'lspconfig/configs'
+local util = require 'lspconfig/util'
+
+local server_name = 'csharp_ls'
+
+configs[server_name] = {
+  default_config = {
+    cmd = { 'csharp-ls' },
+    root_dir = util.root_pattern('*.sln', '*.csproj', '.git'),
+    filetypes = { 'cs' },
+    init_options = {
+      AutomaticWorkspaceInit = true,
+    },
+  },
+  docs = {
+    description = [[
+https://github.com/razzmatazz/csharp-language-server
+
+Language Server for C#.
+
+csharp-ls requires the [dotnet-sdk](https://dotnet.microsoft.com/download) to be installed.
+
+The preferred way to install csharp-ls is with `dotnet tool install --global csharp-ls`.
+    ]],
+  },
+}


### PR DESCRIPTION
As on the tin

I used fsautocomplete code as a template for csharp-ls.. so I am not 100% if I adhere to project standarts for PRs.