### PR TITLE
Fix svelteserver on Windows

### DIFF
--- a/lua/lspconfig/svelte.lua
+++ b/lua/lspconfig/svelte.lua
@@ -3,6 +3,9 @@ local util = require 'lspconfig/util'
 
 local server_name = 'svelte'
 local bin_name = 'svelteserver'
+if vim.fn.has 'win32' == 1 then
+  bin_name = bin_name .. '.cmd'
+end
 
 configs[server_name] = {
   default_config = {


### PR DESCRIPTION
On Windows the call to the LS fails with the msg: 'E5108: Error executing lua ...ps\neovim\current\share\nvim\runtime\lua\vim\lsp\rpc.lua:384: start `svelteserver` failed: ENOENT: no such file or directory'.

It works quite fine if I use the custom cmd "svelterserver.cmd".
Other LS (e.g. pyright) also use this check.