### PR TITLE
Gracefully abort on incompatible Neovim versions

### DIFF
--- a/plugin/lspconfig.vim
+++ b/plugin/lspconfig.vim
@@ -2,6 +2,9 @@ if exists('g:lspconfig')
   finish
 endif
 let g:lspconfig = 1
+if !has("nvim-0.5")
+  finish
+endif
 
 lua << EOF
 lsp_complete_configured_servers = function()


### PR DESCRIPTION
This is helpful when trying to use the same configuration across many machines, but being, for whatever reason, stuck with an older version somewhere.

I understand this behavior might be confusing because it’s “silently failing” in a way, so certainly open to adjusting to have a clear error message or requiring a variable setting to opt-in to silently ignoring.