### PR TITLE
docs: remove volar package.json

### DIFF
--- a/lua/lspconfig/volar.lua
+++ b/lua/lspconfig/volar.lua
@@ -67,7 +67,6 @@ configs[server_name] = {
     end,
   },
   docs = {
-    package_json = 'https://raw.githubusercontent.com/johnsoncodehk/volar/master/package.json',
     description = [[
 https://github.com/johnsoncodehk/volar/tree/master/packages/server
 


### PR DESCRIPTION
This package.json does not expose relevant documentation and blocks
docgen.