### PR TITLE
fix: add single_file_support for dockerls

### DIFF
--- a/lua/lspconfig/dockerls.lua
+++ b/lua/lspconfig/dockerls.lua
@@ -9,6 +9,7 @@ configs[server_name] = {
     cmd = { bin_name, '--stdio' },
     filetypes = { 'dockerfile' },
     root_dir = util.root_pattern 'Dockerfile',
+    single_file_support = true,
   },
   docs = {
     description = [[


### PR DESCRIPTION
<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->

Allow `dockerls` to attach to a dockerfiles regardless if the default `Dockerfile` is found.
This is useful for editing files with custom names, e.g. `Dockerfile.release`
