### PR TITLE
Add documentation for tsserver type checking

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -7104,6 +7104,23 @@ https://github.com/theia-ide/typescript-language-server
 npm install -g typescript typescript-language-server
 ```
 
+By default, `typescript-language-server` will type check JavaScript files. If you'd like to disable
+this feature, you can do so by editing your `jsconfig.json` file and disable the `checkJs` option.
+Here's an example:
+
+```json
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "checkJs": false
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}
+```
+
 
 
 **Snippet to enable the language server:**


### PR DESCRIPTION
This PR is a direct follow up to #1301. It adds documentation on how to disable type checking in JavaScript files.

@mjlbach I know you suggested this should go in tsserver.lua, but I thought it might be a little easier to find in CONFIG.md. I'm happy to move it if you think that's best.