### PR TITLE
feat(eslint): Run eslint for vue files

### DIFF
--- a/lua/lspconfig/eslint.lua
+++ b/lua/lspconfig/eslint.lua
@@ -53,6 +53,7 @@ configs.eslint = {
       'typescript',
       'typescriptreact',
       'typescript.tsx',
+      'vue',
     },
     -- https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats
     root_dir = util.root_pattern(


### PR DESCRIPTION
Eslint provides useful feedback in vue files. Which is why I added 'vue' to the default filetypes.
I tested it locally with a vue project and it works fine.

For reference – null-lsp runs eslint on vue as well:
https://github.com/jose-elias-alvarez/null-ls.nvim/blob/bd0f8daa3c70d099857e9223f33eec9511b6047c/lua/null-ls/builtins/formatting.lua#L131