### PR TITLE
docs(volar): Add Take Over Mode docs, Add example for global typescript detection

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -6744,6 +6744,22 @@ require'lspconfig'.sumneko_lua.setup {
 This server accepts configuration via the `settings` key.
 <details><summary>Available settings:</summary>
 
+- **`Lua.IntelliSense.traceBeSetted`**: `boolean`
+
+  null
+
+- **`Lua.IntelliSense.traceFieldInject`**: `boolean`
+
+  null
+
+- **`Lua.IntelliSense.traceLocalSet`**: `boolean`
+
+  null
+
+- **`Lua.IntelliSense.traceReturn`**: `boolean`
+
+  null
+
 - **`Lua.color.mode`**: `enum { "Grammar", "Semantic", "SemanticEnhanced" }`
 
   Default: `"Semantic"`
@@ -7695,14 +7711,50 @@ Volar can be installed via npm
 npm install -g @volar/server
 ```
 
-With Vue 3 projects - it works out of the box.
+Volar in Vue 3 projects doesn't need any additional configuration and work out of the box. Vue 2 projects needs [additional configuration](https://github.com/johnsoncodehk/volar/blob/master/extensions/vscode-vue-language-features/README.md?plain=1#L28-L63).
 
-With Vue 2 projects - requires [additional configuration](https://github.com/johnsoncodehk/volar#using)
+`volar` succeeds `vuels` (Vetur) as the main language server in the Vue ecosystem, so certain language features overlap between the two. To avoid getting duplicate completions, code actions etc. from two servers at once make sure `vuels` is not running alongside `volar`
 
-Do not run `vuels` and `volar` at the same time.
+**[Take Over Mode](https://github.com/johnsoncodehk/volar/discussions/471)**
 
-To check which language servers are running, open a `.vue` file and run the `:LspInfo` command.
+To enable:
 
+```lua
+require'lspconfig'.volar.setup{filetypes = {'typescript', 'javascript', 'javascriptreact', 'typescriptreact', 'vue', 'json'}}
+```
+
+Remember to **disable** `tsserver` — Volar's Take Over Mode replaces it.
+
+**Custom TypeScript detection**
+The default config looks for TS in local node_modules. The alternatives to this behavior are:
+
+* use global TS - `require'lspconfig'.volar.setup{init_options = { typescript = { serverPath = '/home/[yourusernamehere]/.npm/lib/node_modules/typescript/lib/tsserverlib.js' } }}`
+* use global TS only if local TS not found
+```lua
+local util = require 'lspconfig/util'
+
+local function get_typescript_server_path(root_dir)
+  local project_root = util.find_node_modules_ancestor(root_dir)
+
+  local local_tsserverlib = project_root ~= nil and util.path.join(project_root, 'node_modules', 'typescript', 'lib', 'tsserverlibrary.js')
+  local global_tsserverlib = '/home/[yourusernamehere]/.npm/lib/node_modules/typescript/lib/tsserverlibrary.js'
+
+  if local_tsserverlib and util.path.exists(local_tsserverlib) then
+    return local_tsserverlib
+  else
+    return global_tsserverlib
+  end
+end
+
+require'lspconfig'.volar.setup{
+  config = {
+    on_new_config = function(new_config, new_root_dir)
+      new_config.init_options.typescript.serverPath = get_typescript_server_path(new_root_dir)
+    end,
+  }
+}
+```
+    
 
 
 **Snippet to enable the language server:**

--- a/lua/lspconfig/volar.lua
+++ b/lua/lspconfig/volar.lua
@@ -76,13 +76,49 @@ Volar can be installed via npm
 npm install -g @volar/server
 ```
 
-With Vue 3 projects - it works out of the box.
+Volar in Vue 3 projects doesn't need any additional configuration and work out of the box. Vue 2 projects needs [additional configuration](https://github.com/johnsoncodehk/volar/blob/master/extensions/vscode-vue-language-features/README.md?plain=1#L28-L63).
 
-With Vue 2 projects - requires [additional configuration](https://github.com/johnsoncodehk/volar#using)
+`volar` succeeds `vuels` (Vetur) as the main language server in the Vue ecosystem, so certain language features overlap between the two. To avoid getting duplicate completions, code actions etc. from two servers at once make sure `vuels` is not running alongside `volar`
 
-Do not run `vuels` and `volar` at the same time.
+**[Take Over Mode](https://github.com/johnsoncodehk/volar/discussions/471)**
 
-To check which language servers are running, open a `.vue` file and run the `:LspInfo` command.
-]],
+To enable:
+
+```lua
+require'lspconfig'.volar.setup{filetypes = {'typescript', 'javascript', 'javascriptreact', 'typescriptreact', 'vue', 'json'}}
+```
+
+Remember to **disable** `tsserver` — Volar's Take Over Mode replaces it.
+
+**Custom TypeScript detection**
+The default config looks for TS in local node_modules. The alternatives to this behavior are:
+
+* use global TS - `require'lspconfig'.volar.setup{init_options = { typescript = { serverPath = '/home/[yourusernamehere]/.npm/lib/node_modules/typescript/lib/tsserverlib.js' } }}`
+* use global TS only if local TS not found
+```lua
+local util = require 'lspconfig/util'
+
+local function get_typescript_server_path(root_dir)
+  local project_root = util.find_node_modules_ancestor(root_dir)
+
+  local local_tsserverlib = project_root ~= nil and util.path.join(project_root, 'node_modules', 'typescript', 'lib', 'tsserverlibrary.js')
+  local global_tsserverlib = '/home/[yourusernamehere]/.npm/lib/node_modules/typescript/lib/tsserverlibrary.js'
+
+  if local_tsserverlib and util.path.exists(local_tsserverlib) then
+    return local_tsserverlib
+  else
+    return global_tsserverlib
+  end
+end
+
+require'lspconfig'.volar.setup{
+  config = {
+    on_new_config = function(new_config, new_root_dir)
+      new_config.init_options.typescript.serverPath = get_typescript_server_path(new_root_dir)
+    end,
+  }
+}
+```
+    ]],
   },
 }


### PR DESCRIPTION
Volar now has Take Over Mode(TM) which gives it ability to provide language features to .ts, .js files as tsserver does. https://github.com/johnsoncodehk/volar/discussions/471

Opening as draft as I'm not really sure if it's applicable to neovim. The Take Over Mode discussion mentions VSCode a lot, so I feel as if I need to think on it more, as neovim may not have the performance problems that VSCode has

Obviously I'll squash the commits once this PR has the green light