### PR TITLE
deno_ls: Add new Deno configuration files to root_dir

### DIFF
--- a/lua/lspconfig/denols.lua
+++ b/lua/lspconfig/denols.lua
@@ -116,7 +116,7 @@ configs[server_name] = {
       'typescriptreact',
       'typescript.tsx',
     },
-    root_dir = util.root_pattern('package.json', 'tsconfig.json', '.git'),
+    root_dir = util.root_pattern('deno.json', 'deno.jsonc', 'package.json', 'tsconfig.json', '.git'),
     init_options = {
       enable = true,
       lint = false,


### PR DESCRIPTION
This update is for the new configuration file format: https://deno.land/manual@v1.15.1/getting_started/configuration_file