### PR TITLE
fix: restore compatibility with recent ansiblels versions (due to new required ansiblels settings)

### DIFF
--- a/lua/lspconfig/ansiblels.lua
+++ b/lua/lspconfig/ansiblels.lua
@@ -17,6 +17,9 @@ configs[server_name] = {
         ansible = {
           path = 'ansible',
         },
+        executionEnvironment = {
+          enabled = false,
+        },
       },
     },
     filetypes = { 'yaml' },


### PR DESCRIPTION
Using [ansible-language-server](https://github.com/ansible/ansible-language-server) with current `nvim-lspconfig` defaults produces the error:

```
Cannot read property 'enabled' of undefined                                                                                                 

Request Actions:
Type number and <Enter> or click with the mouse (q or empty cancels): Cannot read property 'enabled' of undefined
```
This pull requests restores compatibility by adding the required setting `executionEnvironment.enabled` with default `false`.

The breaking change was introduced in this commit:
https://github.com/ansible/ansible-language-server/commit/cefd599043311fcba5803e780edce16c09cc9c64

More info here:
https://github.com/williamboman/nvim-lsp-installer/issues/160