### PR TITLE
Add tf filetype in terraformls and tflint default configs

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -7261,7 +7261,7 @@ require'lspconfig'.terraformls.setup{}
   
   Default Values:
     cmd = { "terraform-ls", "serve" }
-    filetypes = { "terraform" }
+    filetypes = { "terraform", "tf" }
     root_dir = root_pattern(".terraform", ".git")
 ```
 
@@ -7339,7 +7339,7 @@ require'lspconfig'.tflint.setup{}
   
   Default Values:
     cmd = { "tflint", "--langserver" }
-    filetypes = { "terraform" }
+    filetypes = { "terraform", "tf" }
     root_dir = root_pattern(".terraform", ".git", ".tflint.hcl")
 ```
 

--- a/lua/lspconfig/terraformls.lua
+++ b/lua/lspconfig/terraformls.lua
@@ -4,7 +4,7 @@ local util = require 'lspconfig/util'
 configs.terraformls = {
   default_config = {
     cmd = { 'terraform-ls', 'serve' },
-    filetypes = { 'terraform' },
+    filetypes = { 'terraform', 'tf' },
     root_dir = util.root_pattern('.terraform', '.git'),
   },
   docs = {

--- a/lua/lspconfig/tflint.lua
+++ b/lua/lspconfig/tflint.lua
@@ -4,7 +4,7 @@ local util = require 'lspconfig/util'
 configs.tflint = {
   default_config = {
     cmd = { 'tflint', '--langserver' },
-    filetypes = { 'terraform' },
+    filetypes = { 'terraform', 'tf' },
     root_dir = util.root_pattern('.terraform', '.git', '.tflint.hcl'),
   },
   docs = {


### PR DESCRIPTION
I was wondering why I had 0 client attached on my buffer although it was named `main.tf` and after checking what was in the `LspInfo` popup, it appears that's because the detected filetype is `tf` and it's not included in the default config of both terraformls and tflint so here it is!