### PR TITLE
Fix case sensitivity in Windows when determining root_dir

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -66,7 +66,13 @@ function configs.__newindex(t, config_name, config_def)
       )
     end
 
-    local get_root_dir = config.root_dir
+    local get_root_dir = function(fname, bufnum)
+        local dir = config.root_dir(fname, bufnum)
+        if vim.fn.has('win32') then
+            dir = dir:lower()
+        end
+        return dir
+    end
 
     function M.autostart()
       local root_dir = get_root_dir(api.nvim_buf_get_name(0), api.nvim_get_current_buf())

--- a/lua/lspconfig/omnisharp.lua
+++ b/lua/lspconfig/omnisharp.lua
@@ -6,11 +6,7 @@ configs[server_name] = {
   default_config = {
     filetypes = { 'cs', 'vb' },
     root_dir = function(fname)
-      local dir = util.root_pattern '*.sln'(fname) or util.root_pattern '*.csproj'(fname)
-      if vim.fn.has('win32') then
-          dir = dir:lower()
-      end
-      return dir
+      return util.root_pattern '*.sln'(fname) or util.root_pattern '*.csproj'(fname)
     end,
     on_new_config = function(new_config, new_root_dir)
       if new_root_dir then

--- a/lua/lspconfig/omnisharp.lua
+++ b/lua/lspconfig/omnisharp.lua
@@ -6,7 +6,11 @@ configs[server_name] = {
   default_config = {
     filetypes = { 'cs', 'vb' },
     root_dir = function(fname)
-      return util.root_pattern '*.sln'(fname) or util.root_pattern '*.csproj'(fname)
+      local dir = util.root_pattern '*.sln'(fname) or util.root_pattern '*.csproj'(fname)
+      if vim.fn.has('win32') then
+          dir = dir:lower()
+      end
+      return dir
     end,
     on_new_config = function(new_config, new_root_dir)
       if new_root_dir then


### PR DESCRIPTION
Because of path insensitivity in windows, sometimes we get back different casings of the same path for the root_dir, and these should be treated as the same thing. Fixes #1329 