### PR TITLE
Fix lemminx documentation

### DIFF
--- a/lua/lspconfig/lemminx.lua
+++ b/lua/lspconfig/lemminx.lua
@@ -22,6 +22,7 @@ require'lspconfig'.lemminx.setup{
     cmd = { "/path/to/lemminx/lemminx" };
     ...
 }
+```
 
 NOTE to macOS users: Binaries from unidentified developers are blocked by default. If you trust the downloaded binary from jboss.org, run it once, cancel the prompt, then remove the binary from Gatekeeper quarantine with `xattr -d com.apple.quarantine lemminx`. It should now run without being blocked.
 


### PR DESCRIPTION
Added a missing "code block end".
It is currently messed up. You can see this here: https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#lemminx