### PR TITLE
feat(lua-language-server): simplify configuration

### DIFF
--- a/lua/lspconfig/sumneko_lua.lua
+++ b/lua/lspconfig/sumneko_lua.lua
@@ -3,72 +3,59 @@ local util = require 'lspconfig/util'
 
 local name = 'sumneko_lua'
 
+local runtime_path = vim.split(package.path, ';')
+table.insert(runtime_path, 'lua/?.lua')
+table.insert(runtime_path, 'lua/?/init.lua')
+
 configs[name] = {
   default_config = {
+    cmd = { 'lua-language-server' },
     filetypes = { 'lua' },
     root_dir = function(fname)
       return util.find_git_ancestor(fname) or util.path.dirname(fname)
     end,
     log_level = vim.lsp.protocol.MessageType.Warning,
-    settings = { Lua = { telemetry = { enable = false } } },
+    settings = {
+      Lua = {
+        runtime = {
+          -- Tell the language server which version of Lua you're using (most likely LuaJIT in the case of Neovim)
+          version = 'LuaJIT',
+          -- Setup your lua path
+          path = runtime_path,
+        },
+        diagnostics = {
+          -- Get the language server to recognize the `vim` global
+          globals = { 'vim' },
+        },
+        workspace = {
+          -- Make the server aware of Neovim runtime files
+          library = vim.api.nvim_get_runtime_file('', true),
+        },
+        -- Do not send telemetry data containing a randomized but unique identifier
+        telemetry = {
+          enable = false,
+        },
+      },
+    },
   },
   docs = {
     package_json = 'https://raw.githubusercontent.com/sumneko/vscode-lua/master/package.json',
     description = [[
 https://github.com/sumneko/lua-language-server
 
-Lua language server.
+`lua-language-server` can be installed from your system's package manager if available, or from source by following the instructions [here](https://github.com/sumneko/lua-language-server/wiki/Build-and-Run-(Standalone)).
 
-`lua-language-server` can be installed by following the instructions [here](https://github.com/sumneko/lua-language-server/wiki/Build-and-Run-(Standalone)).
+If installing from your system's package manager, `lua-language-server` should already be on your path, and the default `cmd` should work.
 
-**By default, lua-language-server doesn't have a `cmd` set.** This is because nvim-lspconfig does not make assumptions about your path. You must add the following to your init.vim or init.lua to set `cmd` to the absolute path ($HOME and ~ are not expanded) of your unzipped and compiled lua-language-server.
+If installing from source, you can either add `/path/to/lua-language-server/bin/Linux` (or Windows, macOS) to your path, or set `cmd` in the server `setup{}` call.
 
-```lua
-local system_name
-if vim.fn.has("mac") == 1 then
-  system_name = "macOS"
-elseif vim.fn.has("unix") == 1 then
-  system_name = "Linux"
-elseif vim.fn.has('win32') == 1 then
-  system_name = "Windows"
-else
-  print("Unsupported system for sumneko")
-end
-
--- set the path to the sumneko installation; if you previously installed via the now deprecated :LspInstall, use
-local sumneko_root_path = vim.fn.stdpath('cache')..'/lspconfig/sumneko_lua/lua-language-server'
-local sumneko_binary = sumneko_root_path.."/bin/"..system_name.."/lua-language-server"
-
-local runtime_path = vim.split(package.path, ';')
-table.insert(runtime_path, "lua/?.lua")
-table.insert(runtime_path, "lua/?/init.lua")
-
+```
 require'lspconfig'.sumneko_lua.setup {
-  cmd = {sumneko_binary, "-E", sumneko_root_path .. "/main.lua"};
-  settings = {
-    Lua = {
-      runtime = {
-        -- Tell the language server which version of Lua you're using (most likely LuaJIT in the case of Neovim)
-        version = 'LuaJIT',
-        -- Setup your lua path
-        path = runtime_path,
-      },
-      diagnostics = {
-        -- Get the language server to recognize the `vim` global
-        globals = {'vim'},
-      },
-      workspace = {
-        -- Make the server aware of Neovim runtime files
-        library = vim.api.nvim_get_runtime_file("", true),
-      },
-      -- Do not send telemetry data containing a randomized but unique identifier
-      telemetry = {
-        enable = false,
-      },
-    },
-  },
+  -- note, substitute Linux for Windows or macOS
+  cmd = { "/path/to/lua-language-server/bin/Linux/lua-language-server"};
 }
 ```
+
 ]],
     default_config = {
       root_dir = [[root_pattern(".git") or bufdir]],


### PR DESCRIPTION
The vast majority of our users that are using lua-language-server, are using it for neovim development. I think we should ship the default configuration including the neovim runtime path. It's very easy for users who do *not* want this to opt-out. (just override the settings key).

Furthermore, `lua-language-server` is now the canonical command name, and it's getting packaged by more repositories. I personally packaged it for nix, and I know it's on the AUR now.

This should cut a good 20 lines out of everyone's config.