### PR TITLE
Fix(graphql):  root dir not being set when using graphql.config.* files

### DIFF
--- a/lua/lspconfig/graphql.lua
+++ b/lua/lspconfig/graphql.lua
@@ -8,7 +8,7 @@ configs[server_name] = {
   default_config = {
     cmd = { bin_name, 'server', '-m', 'stream' },
     filetypes = { 'graphql' },
-    root_dir = util.root_pattern('.git', '.graphqlrc*', '.graphql.config.*'),
+    root_dir = util.root_pattern('.git', '.graphqlrc*', '.graphql.config.*', 'graphql.config.*'),
   },
 
   docs = {


### PR DESCRIPTION
This fixes grapqhl lsp not setting the correct root_dir when using graphql.config.* files