### PR TITLE
Update the `on_attach` hook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ local on_attach = function(client, bufnr)
 
 end
 
--- Use a loop to conveniently call 'setup' on multiple servers and
+-- Use a loop to conveniently call 'setup' on all available servers and
 -- map buffer local keybindings when the language server attaches
-local servers = { 'pyright', 'rust_analyzer', 'tsserver' }
-for _, lsp in ipairs(servers) do
-  nvim_lsp[lsp].setup {
+local available_servers = nvim_lsp.available_servers()
+for _, server_name in pairs(available_servers) do
+  nvim_lsp[server_name].setup {
     on_attach = on_attach,
     flags = {
       debounce_text_changes = 150,


### PR DESCRIPTION
Previously the example had the user specifying their LSP servers manually. This change looks at available servers and attaches to all of them. This makes sense if it's more likely that the user will be interested in attaching this hook to all available servers, not just a subset of them.