### PR TITLE
feat: support using `minimal_init.lua` on windows

### DIFF
--- a/test/minimal_init.lua
+++ b/test/minimal_init.lua
@@ -1,8 +1,25 @@
-vim.cmd [[set runtimepath=$VIMRUNTIME]]
-vim.cmd [[set packpath=/tmp/nvim/site]]
+local on_windows = vim.loop.os_uname().version:match 'Windows'
 
-local package_root = '/tmp/nvim/site/pack'
-local install_path = package_root .. '/packer/start/packer.nvim'
+local function join_paths(...)
+  local path_sep = on_windows and '\\' or '/'
+  local result = table.concat({ ... }, path_sep)
+  return result
+end
+
+vim.cmd [[set runtimepath=$VIMRUNTIME]]
+
+local temp_dir
+if on_windows then
+  temp_dir = vim.loop.os_getenv 'TEMP'
+else
+  temp_dir = '/tmp'
+end
+
+vim.cmd('set packpath=' .. join_paths(temp_dir, 'nvim', 'site'))
+
+local package_root = join_paths(temp_dir, 'nvim', 'site', 'pack')
+local install_path = join_paths(package_root, 'packer', 'start', 'packer.nvim')
+local compile_path = join_paths(install_path, 'plugin', 'packer_compiled.lua')
 
 local function load_plugins()
   require('packer').startup {
@@ -12,7 +29,7 @@ local function load_plugins()
     },
     config = {
       package_root = package_root,
-      compile_path = install_path .. '/plugin/packer_compiled.lua',
+      compile_path = compile_path,
     },
   }
 end


### PR DESCRIPTION
- let `packpath` use the correct temp folder per platform
- use the appropriate path-separator per platform

<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->
