### PR TITLE
fix(dockerls): remove duplicate filetype

### DIFF
--- a/lua/lspconfig/dockerls.lua
+++ b/lua/lspconfig/dockerls.lua
@@ -7,7 +7,7 @@ local bin_name = 'docker-langserver'
 configs[server_name] = {
   default_config = {
     cmd = { bin_name, '--stdio' },
-    filetypes = { 'Dockerfile', 'dockerfile' },
+    filetypes = { 'dockerfile' },
     root_dir = util.root_pattern 'Dockerfile',
   },
   docs = {


### PR DESCRIPTION
<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->
This is already covered in core:
https://github.com//neovim/neovim/blob/52fa1d26db43664e8aeb856a59a693e9cb6ad44f/runtime/filetype.vim#L396
