### PR TITLE
fix: set offset encoding by default

### DIFF
--- a/lua/lspconfig/clangd.lua
+++ b/lua/lspconfig/clangd.lua
@@ -45,11 +45,6 @@ configs.clangd = {
       local filename = util.path.is_absolute(fname) and fname or util.path.join(vim.loop.cwd(), fname)
       return root_pattern(filename) or util.path.dirname(filename)
     end,
-    on_init = function(client, result)
-      if result.offsetEncoding then
-        client.offset_encoding = result.offsetEncoding
-      end
-    end,
     capabilities = default_capabilities,
   },
   commands = {
@@ -72,7 +67,6 @@ For details on how to automatically generate one using CMake look [here](https:/
 ]],
     default_config = {
       root_dir = [[root_pattern("compile_commands.json", "compile_flags.txt", ".git") or dirname]],
-      on_init = [[function to handle changing offsetEncoding]],
       capabilities = [[default capabilities, with offsetEncoding utf-8]],
     },
   },

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -123,7 +123,13 @@ function configs.__newindex(t, config_name, config_def)
         pcall(config.on_new_config, new_config, _root_dir)
       end
 
-      new_config.on_init = util.add_hook_after(new_config.on_init, function(client, _result)
+      new_config.on_init = util.add_hook_after(new_config.on_init, function(client, result)
+        -- Handle offset encoding by default
+        if result.offsetEncoding then
+          client.offset_encoding = result.offsetEncoding
+        end
+
+        -- Send `settings to server via workspace/didChangeConfiguration
         function client.workspace_did_change_configuration(settings)
           if not settings then
             return


### PR DESCRIPTION
Some servers (clangd, rust-analyzer) support using byte ranges (utf-8
encodings). Currently this logic is handled in the configuration's
on_init. This is moved into the on_init wrapper to avoid being
overridden accidentally by users.