### PR TITLE
docs: fix broken codeblocks in CONFIG descriptions

### DIFF
--- a/lua/lspconfig/arduino_language_server.lua
+++ b/lua/lspconfig/arduino_language_server.lua
@@ -8,8 +8,9 @@ configs.arduino_language_server = {
     root_dir = function(fname)
       return util.root_pattern '*.ino'(fname)
     end,
-    docs = {
-      description = [[
+  },
+  docs = {
+    description = [[
 https://github.com/arduino/arduino-language-server
 
 Language server for Arduino
@@ -48,7 +49,6 @@ lspconfig.arduino_language_server.setup({
 For further instruction about configuration options, run `arduino-language-server --help`.
 
 ]],
-    },
   },
 }
 

--- a/lua/lspconfig/dhall_lsp_server.lua
+++ b/lua/lspconfig/dhall_lsp_server.lua
@@ -8,8 +8,9 @@ configs.dhall_lsp_server = {
     root_dir = function(fname)
       return util.root_pattern '.git'(fname) or util.path.dirname(fname)
     end,
-    docs = {
-      description = [[
+  },
+  docs = {
+    description = [[
 https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-lsp-server
 
 language server for dhall
@@ -20,9 +21,8 @@ cabal install dhall-lsp-server
 ```
 prebuilt binaries can be found [here](https://github.com/dhall-lang/dhall-haskell/releases).
 ]],
-      default_config = {
-        root_dir = [[root_pattern(".git") or dirname]],
-      },
+    default_config = {
+      root_dir = [[root_pattern(".git") or dirname]],
     },
   },
 }

--- a/lua/lspconfig/fstar.lua
+++ b/lua/lspconfig/fstar.lua
@@ -12,8 +12,7 @@ configs.fstar = {
 https://github.com/FStarLang/FStar
 
 LSP support is included in FStar. Make sure `fstar.exe` is in your PATH.
-```
-    ]],
+]],
     default_config = {
       root_dir = [[root_pattern(".git")]],
     },

--- a/lua/lspconfig/r_language_server.lua
+++ b/lua/lspconfig/r_language_server.lua
@@ -13,16 +13,16 @@ configs.r_language_server = {
   docs = {
     package_json = 'https://raw.githubusercontent.com/REditorSupport/vscode-r-lsp/master/package.json',
     description = [[
-    [languageserver](https://github.com/REditorSupport/languageserver) is an
-    implementation of the Microsoft's Language Server Protocol for the R
-    language.
+[languageserver](https://github.com/REditorSupport/languageserver) is an
+implementation of the Microsoft's Language Server Protocol for the R
+language.
 
-    It is released on CRAN and can be easily installed by
+It is released on CRAN and can be easily installed by
 
-    ```R
-    install.packages("languageserver")
-    ```
-    ]],
+```R
+install.packages("languageserver")
+```
+]],
     default_config = {
       root_dir = [[root_pattern(".git") or os_homedir]],
     },


### PR DESCRIPTION
Screenshot of changes:

<details><summary>arduino_language_server</summary>

### WAS:

![image](https://user-images.githubusercontent.com/66286082/139970677-11d23a98-8e38-4323-90cc-5a3e0ebf3158.png)

### NOW:

![image](https://user-images.githubusercontent.com/66286082/139970757-219d8eeb-6e71-4047-b5e3-55d772174457.png)

</details>

<details><summary>dhall_lsp_server</summary>

### WAS:

![image](https://user-images.githubusercontent.com/66286082/139970839-270a86c2-37b4-4909-bfb1-1f2e5ce442d5.png)

### NOW: 

![image](https://i.imgur.com/MVVKPus.png)

</details>

<details><summary>fstar</summary>

### WAS:

![image](https://i.imgur.com/N4eTYVd.png)

### NOW: 

![image](https://i.imgur.com/NOYgt6m.png)

</details>

<details><summary>r_language_server</summary>

### WAS:

![image](https://i.imgur.com/tY8QZl4.png)

### NOW: 

![image](https://i.imgur.com/sgxAHx1.png)

</details>
