### PR TITLE
feat: Add Nickel Language Server

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -61,6 +61,7 @@ that config.
 - [metals](#metals)
 - [mint](#mint)
 - [nimls](#nimls)
+- [nls](#nls)
 - [ocamlls](#ocamlls)
 - [ocamllsp](#ocamllsp)
 - [omnisharp](#omnisharp)
@@ -4554,6 +4555,45 @@ require'lspconfig'.nimls.setup{}
     filetypes = { "nim" }
     root_dir = function(fname)
           return util.root_pattern '*.nimble'(fname) or util.find_git_ancestor(fname) or util.path.dirname(fname)
+        end,
+```
+
+
+## nls
+
+Nickel Language Server
+
+https://github.com/tweag/nickel
+
+`nls` can be installed with cargo from the Nickel repository.
+```sh
+git clone https://github.com/tweag/nickel.git
+cd nickel/lsp/nls
+cargo install --path .
+```
+
+```vim
+augroup filetype_nickel
+  autocmd!
+  autocmd BufReadPost *.ncl setlocal filetype=nickel
+  autocmd BufReadPost *.nickel setlocal filetype=nickel
+augroup END
+```
+
+**Snippet to enable the language server:**
+```lua
+require'lspconfig'.nls.setup{}
+```
+
+**Commands and default values:**
+```lua
+  Commands:
+
+  Default Values:
+    cmd = { "nls" }
+    filetypes = { "ncl", "nickel" }
+    root_dir = function(fname)
+          return util.find_git_ancestor(fname) or util.path.dirname(fname)
         end,
 ```
 

--- a/lua/lspconfig/nls.lua
+++ b/lua/lspconfig/nls.lua
@@ -1,0 +1,56 @@
+local configs = require 'lspconfig/configs'
+local util = require 'lspconfig/util'
+
+configs.nls = {
+    default_config = {
+        cmd = {'nls'},
+        filetypes = {'ncl', 'nickel'},
+        root_dir = function(fname)
+            return util.find_git_ancestor(fname) or util.path.dirname(fname)
+        end
+    },
+
+    docs = {
+        description = [[
+Nickel Language Server
+
+https://github.com/tweag/nickel
+
+`nls` can be installed with cargo from the Nickel repository.
+```sh
+git clone https://github.com/tweag/nickel.git
+cd nickel/lsp/nls
+cargo install --path .
+```
+
+```vim
+augroup filetype_nickel
+  autocmd!
+  autocmd BufReadPost *.ncl setlocal filetype=nickel
+  autocmd BufReadPost *.nickel setlocal filetype=nickel
+augroup END
+```
+
+**Snippet to enable the language server:**
+```lua
+require'lspconfig'.nls.setup{}
+```
+
+**Commands and default values:**
+```lua
+  Commands:
+
+  Default Values:
+    cmd = { "nls" }
+    filetypes = { "ncl", "nickel" }
+    root_dir = function(fname)
+          return util.find_git_ancestor(fname) or util.path.dirname(fname)
+        end,
+```
+        ]],
+
+        default_config = {
+            root_dir = [[util.find_git_ancestor(fname) or util.path.dirname(fname)]]
+        }
+    }
+}


### PR DESCRIPTION

Nickel Language Server

https://github.com/tweag/nickel

`nls` can be installed with cargo from the Nickel repository.
```sh
git clone https://github.com/tweag/nickel.git
cd nickel/lsp/nls
cargo install --path .
```

```vim
augroup filetype_nickel
  autocmd!
  autocmd BufReadPost *.ncl setlocal filetype=nickel
  autocmd BufReadPost *.nickel setlocal filetype=nickel
augroup END
```

**Snippet to enable the language server:**
```lua
require'lspconfig'.nls.setup{}
```

**Commands and default values:**
```lua
  Commands:
  Default Values:
    cmd = { "nls" }
    filetypes = { "ncl", "nickel" }
    root_dir = function(fname)
          return util.find_git_ancestor(fname) or util.path.dirname(fname)
        end,
```