### PR TITLE
fix: normalize drive letter in windows path

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -2599,6 +2599,12 @@ This server accepts configuration via the `settings` key.
   
   Specifies how modifications on build files update the Java classpath\/configuration
 
+- **`java.configuration.workspaceCacheLimit`**: `null|integer`
+
+  Default: `vim.NIL`
+  
+  The number of days \(if enabled\) to keep unused workspace cache data\. Beyond this limit\, cached workspace data may be removed\.
+
 - **`java.contentProvider.preferred`**: `string`
 
   Default: `vim.NIL`

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -164,6 +164,14 @@ M.path = (function()
     return result
   end
 
+  -- For now, this only normalizes the drive letter of a Windows path to lowercase
+  local function normalize_path(path)
+    local has_windows_drive_letter = path:match '^%a:'
+    if has_windows_drive_letter then
+      return path:sub(1,1):lower()..path:sub(2)
+    end
+  end
+
   -- Traverse the path calling cb along the way.
   local function traverse_parents(path, cb)
     path = uv.fs_realpath(path)
@@ -223,6 +231,7 @@ M.path = (function()
     sep = path_sep,
     dirname = dirname,
     join = path_join,
+    normalize_path = normalize_path,
     traverse_parents = traverse_parents,
     iterate_parents = iterate_parents,
     is_descendant = is_descendant,
@@ -237,6 +246,8 @@ function M.server_per_root_dir_manager(_make_config)
   local manager = {}
 
   function manager.add(root_dir, single_file_mode)
+    root_dir = M.path.normalize_path(root_dir)
+
     local client_id
     if single_file_mode then
       client_id = single_file_clients[root_dir]


### PR DESCRIPTION
Closes #1168

As @aqez has investigated, a LSP server, when sends a windows path, normalizes the drive letter to lowercase. This allowed the linked issue to happen, in which lspconfig spawned two servers to the same path (one starting with `C:\` and the other with `c:\`). This also happens if you directly open a file with a lower case drive letter, e.g., `:e c:\my_root_dir\my_file.txt`.

This PR solves the problem by normalizing the drive letter of the `root_dir` before checking and storing it in the `clients` list in the `server_per_root_dir_manager`.

Another solution for this problem would be normalizing all paths inside Neovim, which would also solve some inconsistencies in the `:buffers` list, but this would be harder to do.