### PR TITLE
fix: correctly handle windows paths & paths with spaces in autocommand

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -77,7 +77,7 @@ function configs.__newindex(t, config_name, config_def)
       api.nvim_command(
         string.format(
           "autocmd %s unsilent lua require'lspconfig'[%q].manager.try_add_wrapper()",
-          'BufReadPost ' .. util.path.normalize_for_autocmd(root_dir) .. '/*',
+          'BufReadPost ' .. vim.fn.fnameescape(util.path.to_unix_style(root_dir)) .. '/*',
           config.name
         )
       )

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -77,7 +77,7 @@ function configs.__newindex(t, config_name, config_def)
       api.nvim_command(
         string.format(
           "autocmd %s unsilent lua require'lspconfig'[%q].manager.try_add_wrapper()",
-          'BufReadPost ' .. root_dir .. '/*',
+          'BufReadPost ' .. util.path.normalize_for_autocmd(root_dir) .. '/*',
           config.name
         )
       )

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -215,8 +215,7 @@ M.path = (function()
     return dir == root
   end
 
-  -- autocommands always want '/' delimited paths, even on windows
-  local function normalize_for_autocmd(path)
+  local function to_unix_style(path)
     if is_windows then
       return (path:gsub('\\', '/'))
     else
@@ -235,7 +234,7 @@ M.path = (function()
     traverse_parents = traverse_parents,
     iterate_parents = iterate_parents,
     is_descendant = is_descendant,
-    normalize_for_autocmd = normalize_for_autocmd,
+    to_unix_style = to_unix_style,
   }
 end)()
 

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -215,6 +215,15 @@ M.path = (function()
     return dir == root
   end
 
+  -- autocommands always want '/' delimited paths, even on windows
+  local function normalize_for_autocmd(path)
+    if is_windows then
+      return (path:gsub('\\', '/'))
+    else
+      return path
+    end
+  end
+
   return {
     is_dir = is_dir,
     is_file = is_file,
@@ -226,6 +235,7 @@ M.path = (function()
     traverse_parents = traverse_parents,
     iterate_parents = iterate_parents,
     is_descendant = is_descendant,
+    normalize_for_autocmd = normalize_for_autocmd,
   }
 end)()
 


### PR DESCRIPTION
autocommands always want slash delimited paths, even on windows.

from `:help file-pattern` -
> ```
> Note that for all systems the '/' character is used for path separator (even
> Windows). This was done because the backslash is difficult to use in a pattern
> and to make the autocommands portable across different systems.
> ```

it seems like it usually works anyways and the autocommand will register fine despite its path containing backslashes, but there are a few cases where it will actually cause an error (and even if there weren't, it's still probably a good idea to format the path according to what the docs say)

in the case where i encountered the issue, i had a folder with a name that started with two underscores (`D:\__foo\`...), which caused this error:
```
E5108: Error executing lua ...ck\packer\start\nvim-lspconfig\configs.lua:84: Vim(autocmd):E877: (NFA regexp) Invalid character class: 95
```
, which was presumably due to the `_` character class expecting the character following it to be a valid character class. from `:help /character-classes` -
> ```
> Character classes:					*/character-classes*
>       magic   nomagic	matches 
> ...
> |/\_|	\_x	\_x	where x is any of the characters above: character
> 			class with end-of-line included
> ```

----

this PR fixes that issue with a `normalize_for_autocmd(path)` function in `util.path` that replaces `\` with `/` in the path if on windows
