### PR TITLE
fix(lspinfo): fix autostart value reporting

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -47,7 +47,7 @@ local function make_config_info(config)
 
   local buffer_dir = vim.fn.expand '%:p:h'
   config_info.root_dir = config.get_root_dir(buffer_dir) or 'NA'
-  config_info.autostart = (config.autostart and 'true') or 'false'
+  config_info.autostart = (config._autostart and 'true') or 'false'
   config_info.handlers = table.concat(vim.tbl_keys(config.handlers), ', ')
   config_info.filetypes = table.concat(config.filetypes or {}, ', ')
 


### PR DESCRIPTION
`config.autostart` is a function in `make_config_info`.
https://github.com/neovim/nvim-lspconfig/blob/3a5d94df2d61992496d1fc986d2433b944584a8d/lua/lspconfig/configs.lua#L71-L97

Note: this line reports the correct value.
https://github.com/neovim/nvim-lspconfig/blob/3a5d94df2d61992496d1fc986d2433b944584a8d/lua/lspconfig/ui/lspinfo.lua#L78