### PR TITLE
fix(powershell_es): don't overwrite cmd when it is present in the new config

### DIFF
--- a/lua/lspconfig/powershell_es.lua
+++ b/lua/lspconfig/powershell_es.lua
@@ -4,20 +4,20 @@ local util = require 'lspconfig/util'
 local server_name = 'powershell_es'
 local temp_path = vim.fn.stdpath 'cache'
 
-local function make_cmd(bundle_path)
-  if bundle_path ~= nil then
+local function make_cmd(new_config)
+  if new_config.bundle_path ~= nil then
     local command_fmt =
       [[%s/PowerShellEditorServices/Start-EditorServices.ps1 -BundledModulesPath %s -LogPath %s/powershell_es.log -SessionDetailsPath %s/powershell_es.session.json -FeatureFlags @() -AdditionalModules @() -HostName nvim -HostProfileId 0 -HostVersion 1.0.0 -Stdio -LogLevel Normal]]
-    local command = command_fmt:format(bundle_path, bundle_path, temp_path, temp_path)
-    return { 'pwsh', '-NoLogo', '-NoProfile', '-Command', command }
+    local command = command_fmt:format(new_config.bundle_path, new_config.bundle_path, temp_path, temp_path)
+    return { new_config.shell, '-NoLogo', '-NoProfile', '-Command', command }
   end
 end
 
 configs[server_name] = {
   default_config = {
+    shell = 'pwsh',
     on_new_config = function(new_config, _)
-      local bundle_path = new_config.bundle_path
-      new_config.cmd = make_cmd(bundle_path)
+      new_config.cmd = make_cmd(new_config)
     end,
     filetypes = { 'ps1' },
     root_dir = util.find_git_ancestor,

--- a/lua/lspconfig/powershell_es.lua
+++ b/lua/lspconfig/powershell_es.lua
@@ -17,8 +17,12 @@ configs[server_name] = {
   default_config = {
     shell = 'pwsh',
     on_new_config = function(new_config, _)
-      new_config.cmd = make_cmd(new_config)
+      -- Don't overwrite cmd if already set
+      if not new_config.cmd then
+        new_config.cmd = make_cmd(new_config)
+      end
     end,
+
     filetypes = { 'ps1' },
     root_dir = util.find_git_ancestor,
     single_file_mode = true,

--- a/lua/lspconfig/powershell_es.lua
+++ b/lua/lspconfig/powershell_es.lua
@@ -42,6 +42,17 @@ require'lspconfig'.powershell_es.setup{
 }
 ```
 
+By default the languageserver is started in `pwsh` (PowerShell Core). This can be changed by specifying `shell`.
+
+```lua
+require'lspconfig'.powershell_es.setup{
+  bundle_path = 'c:/w/PowerShellEditorServices',
+  shell = 'powershell.exe',
+}
+```
+
+Note that the execution policy needs to be set to `Unrestricted` for the languageserver run under PowerShell
+
 If necessary, specific `cmd` can be defined instead of `bundle_path`.
 See [PowerShellEditorServices](https://github.com/PowerShell/PowerShellEditorServices#stdio)
 to learn more.


### PR DESCRIPTION
    1. Now the cmd in "new_config" is only generated with "make_cmd" if
       there is no cmd already in "new_config"
    2. make_cmd now takes "new_config" as an argument instead of just
       "bundle_path"
    3. Support support changing the execution shell by setting the
       "shell" member in "new_config"