### PR TITLE
fix(solang): add --target argument

### DIFF
--- a/lua/lspconfig/solang.lua
+++ b/lua/lspconfig/solang.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig/util'
 
 configs.solang = {
   default_config = {
-    cmd = { 'solang', '--language-server' },
+    cmd = { 'solang', '--language-server', '--target', 'ewasm' },
     filetypes = { 'solidity' },
     root_dir = util.root_pattern '.git',
   },


### PR DESCRIPTION
Solang needs to specify a target now, can be: ewasm, solana, substrate.
We will default to ewasm.

Ported from https://github.com/williamboman/nvim-lsp-installer/pull/249