### PR TITLE
feat(leanls): lean 4 uses a new tool called lake now

### DIFF
--- a/lua/lspconfig/leanls.lua
+++ b/lua/lspconfig/leanls.lua
@@ -15,7 +15,9 @@ configs.leanls = {
         end
       end
 
-      return util.root_pattern 'leanpkg.toml'(fname) or stdlib_dir or util.find_git_ancestor(fname)
+      return util.root_pattern('lakefile.lean', 'lean-toolchain', 'leanpkg.toml')(fname)
+        or stdlib_dir
+        or util.find_git_ancestor(fname)
     end,
     single_file_support = true,
     on_new_config = function(config, root)
@@ -39,7 +41,7 @@ that plugin fully handles the setup of the Lean language server,
 and you shouldn't set up `leanls` both with it and `lspconfig`.
     ]],
     default_config = {
-      root_dir = [[root_pattern("leanpkg.toml") or root_pattern(".git") or path.dirname]],
+      root_dir = [[root_pattern("lakefile.lean", "lean-toolchain", "leanpkg.toml", ".git")]],
     },
   },
 }


### PR DESCRIPTION
It lives [here](https://github.com/leanprover/lake), but is bundled with the LSP, and uses 2 new files ("lakefile.lean" and "lean-toolchain"), which I've added as markers (and prioritized).

Support is left for legacy `leanpkg.toml` files though in theory as Lean 4 gets closer to release, these likely will disappear.

(@gebner @rish987 FYI.)