### PR TITLE
Update lua lsp wiki url

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -6355,7 +6355,7 @@ https://github.com/sumneko/lua-language-server
 
 Lua language server.
 
-`lua-language-server` can be installed by following the instructions [here](https://github.com/sumneko/lua-language-server/wiki/Build-and-Run-(Standalone)).
+`lua-language-server` can be installed by following the instructions [here](https://github.com/sumneko/lua-language-server/wiki/Build-and-Run).
 
 **By default, lua-language-server doesn't have a `cmd` set.** This is because nvim-lspconfig does not make assumptions about your path. You must add the following to your init.vim or init.lua to set `cmd` to the absolute path ($HOME and ~ are not expanded) of your unzipped and compiled lua-language-server.
 


### PR DESCRIPTION
Url of the wiki changed it now redirects to:

<img width="600" alt="Screen Shot 2021-11-10 at 12 05 33 AM" src="https://user-images.githubusercontent.com/25288435/141019746-78e43c5b-b7f6-42e7-93ee-4e66836546b0.png">

Changed it to redirect to the correct url