### PR TITLE
Fix all server configuration doc links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lspconfig
 
-A [collection of common configurations](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md) for Neovim's built-in [language server client](https://neovim.io/doc/user/lsp.html).
+A [collection of common configurations](doc/server_configurations.md) for Neovim's built-in [language server client](https://neovim.io/doc/user/lsp.html).
 
 This plugin allows for declaratively configuring, launching, and initializing language servers you have installed on your system. Language server configurations are community-maintained.
 
@@ -40,7 +40,7 @@ These features are not implemented in this repo, but in Neovim core. See `:help 
     npm i -g pyright
     ```
 
-2. Add the language server setup to your init.vim. The server name must match those found in the table of contents in [server_configurations.md](server_configurations.md)
+2. Add the language server setup to your init.vim. The server name must match those found in the table of contents in [server_configurations.md](doc/server_configurations.md)
 
     ```lua
     lua << EOF
@@ -149,7 +149,7 @@ The most common reasons a language server does not start or attach are:
 
 1. The language server is not installed. 'lspconfig' does not install language servers for you. You should be able to run the `cmd` defined in each server's lua module from the command line and see that the language server starts. If the `cmd` is an executable name, ensure it is on your path.
 
-2. Not triggering root detection. The language server will only start if it is opened in a directory, or child directory, containing a file which signals the *root* of the project. Most of the time, this is a `.git` folder, but each server defines the root config in the lua file. See [server_configurations.md](server_configurations.md) or the source for the list of root directories.
+2. Not triggering root detection. The language server will only start if it is opened in a directory, or child directory, containing a file which signals the *root* of the project. Most of the time, this is a `.git` folder, but each server defines the root config in the lua file. See [server_configurations.md](doc/server_configurations.md) or the source for the list of root directories.
 
 3. Misconfiguration. You must pass `on_attach` and `capabilities` for **each** `setup {}` if you want these to take effect. You must also **not call `setup {}` twice for the same server**. The second call to `setup {}` will overwrite the first.
 


### PR DESCRIPTION
Several of the links to `server_configurations.md` were broken, as they were missing the `doc/` prefix. Fix all of them, and give them all the same relative URL.

I considered whether to use the absolute URL for all of them, or the relative URL, and it made sense to me to use the relative URL so that a fork could conceivably update the `server_configurations` document and its links would still work. I have no preference there so if you have a preference on what the actual link should be just let me know.