### PR TITLE
ci: set pull-request permission to write to fix faulty workflow

### DIFF
--- a/.github/workflows/close-config-changes.yml
+++ b/.github/workflows/close-config-changes.yml
@@ -1,8 +1,10 @@
 name: "Close changes to config"
-on: [pull_request]
+on: [pull_request_target]
 jobs:
   close-changes:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Also change event trigger pull_request to pull_request_target since
github requires it to make any changes, even if the permission is set to
write.
