### PR TITLE
revert: disable single file support

### DIFF
--- a/lua/lspconfig/efm.lua
+++ b/lua/lspconfig/efm.lua
@@ -8,9 +8,7 @@ configs[server_name] = {
   default_config = {
     cmd = { bin_name },
     root_dir = util.find_git_ancestor,
-    -- EFM does not support NULL root directories
-    -- https://github.com/neovim/nvim-lspconfig/issues/1412
-    single_file_support = false,
+    single_file_support = true,
   },
 
   docs = {


### PR DESCRIPTION
EFM does support NULL root directories.

This reverts commit 0d2722a63e7e79bfc97ea10322ecbbfd48154e77.