### PR TITLE
fix(ansiblels): add yaml.ansible filetype and add ".git" to root_dir pattern

### DIFF
--- a/lua/lspconfig/ansiblels.lua
+++ b/lua/lspconfig/ansiblels.lua
@@ -22,9 +22,9 @@ configs[server_name] = {
         },
       },
     },
-    filetypes = { 'yaml' },
+    filetypes = { 'yaml', 'yaml.ansible' },
     root_dir = function(fname)
-      return util.root_pattern { '*.yml', '*.yaml' }(fname)
+      return util.root_pattern('*.yml', '*.yaml', '.git')(fname)
     end,
   },
   docs = {

--- a/lua/lspconfig/ansiblels.lua
+++ b/lua/lspconfig/ansiblels.lua
@@ -23,9 +23,7 @@ configs[server_name] = {
       },
     },
     filetypes = { 'yaml', 'yaml.ansible' },
-    root_dir = function(fname)
-      return util.root_pattern('*.yml', '*.yaml', '.git')(fname)
-    end,
+    root_dir = util.root_pattern('*.yml', '*.yaml', '.git'),
   },
   docs = {
     description = [[


### PR DESCRIPTION
The current root pattern seems a bit off?

The `yaml.ansible` filetype seems to be a generally accepted filetype for ansible yaml files:

- https://github.com/sheerun/vim-polyglot/blob/b147123070e5d7418fe67e315a53599cfde38d58/autoload/polyglot/init.vim#L1833-L1837
- https://github.com/pearofducks/ansible-vim