### PR TITLE
docs(denlos): mention codefences for hover

### DIFF
--- a/lua/lspconfig/denols.lua
+++ b/lua/lspconfig/denols.lua
@@ -150,6 +150,16 @@ configs[server_name] = {
 https://github.com/denoland/deno
 
 Deno's built-in language server
+
+To approrpiately highlight codefences returned from denols, you will need to augment vim.g.markdown_fenced languages
+ in your init.lua. Example:
+
+```lua
+vim.g.markdown_fenced_languages = {
+  "ts=typescript"
+}
+```
+
 ]],
     default_config = {
       root_dir = [[root_pattern("deno.json", "deno.jsonc", "package.json", "tsconfig.json", ".git")]],


### PR DESCRIPTION
* deno ls uses ts for typescript, which requires a custom markdown
  codefence