### PR TITLE
docs(yammlls): add examples for schemas

### DIFF
--- a/lua/lspconfig/yamlls.lua
+++ b/lua/lspconfig/yamlls.lua
@@ -24,6 +24,59 @@ https://github.com/redhat-developer/yaml-language-server
 ```sh
 yarn global add yaml-language-server
 ```
+
+To use a schema for validation, there are two options:
+
+1. Add a modeline to the file. A modeline is a comment of the form:
+
+```
+# yaml-language-server: $schema=<urlToTheSchema|relativeFilePath|absoluteFilePath}>
+```
+
+where the relative filepath is the path relative to the open yaml file, and the absolute filepath
+is the filepath relative to the filesystem root ('/' on unix systems)
+
+2. Associated a schema url, relative , or absolute (to root of project, not to filesystem root) path to
+the a glob pattern relative to the detected project root. Check `:LspInfo` to determine the resolved project
+root.
+
+```lua
+require('lspconfig').yamlls.setup {
+  ... -- other configuration for setup {}
+  settings = {
+    yaml = {
+      ... -- other settings. note this overrides the lspconfig defaults.
+      schemas = {
+        ["https://json.schemastore.org/github-workflow.json"] = "/.github/workflows/*"
+        ["../path/relative/to/file.yml"] = "/.github/workflows/*"
+        ["/path/from/root/of/project"] = "/.github/workflows/*"
+      },
+    },
+  }
+}
+```
+
+Currently, kubernetes is special-cased in yammls, see the following upstream issues:
+* [#211](https://github.com/redhat-developer/yaml-language-server/issues/211).
+* [#307](https://github.com/redhat-developer/yaml-language-server/issues/307).
+
+To override a schema to use a specific k8s schema version (for example, to use 1.18):
+
+```lua
+require('lspconfig').yamlls.setup {
+  ... -- other configuration for setup {}
+  settings = {
+    yaml = {
+      ... -- other settings. note this overrides the lspconfig defaults.
+      schemas = {
+        ["https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.18.0-standalone-strict/all.json"] = "/*.k8s.yaml",
+        ... -- other schemas
+      },
+    },
+  }
+}
+```
+
 ]],
     default_config = {
       root_dir = [[util.find_git_ancestor]],


### PR DESCRIPTION
Closes https://github.com/neovim/nvim-lspconfig/issues/1207

We get a lot of questions about settings schemas, probably worth embedding in the documentation.

cc @longwuyuan @kylo252 

I'm still not sure I understand using the yaml store url instead of the direct url path, as from the documentation I got the impression you need to explicitly associate a document uri with a schema.