### PR TITLE
fix(texlab): add language-specific root marker

### DIFF
--- a/lua/lspconfig/texlab.lua
+++ b/lua/lspconfig/texlab.lua
@@ -69,7 +69,9 @@ configs.texlab = {
   default_config = {
     cmd = { 'texlab' },
     filetypes = { 'tex', 'bib' },
-    root_dir = util.find_git_ancestor,
+    root_dir = function(fname)
+      return util.root_pattern '.latexmkrc'(fname) or util.find_git_ancestor(fname)
+    end,
     single_file_support = true,
     settings = {
       texlab = {
@@ -122,9 +124,6 @@ A completion engine built from scratch for (La)TeX.
 
 See https://github.com/latex-lsp/texlab/blob/master/docs/options.md for configuration options.
 ]],
-    default_config = {
-      root_dir = "vim's starting directory",
-    },
   },
 }
 


### PR DESCRIPTION
For multifile projects, it is common to have a `.latexmkrc` in the project root directory to set default build options. Use that as root marker (but keep `.git` as a fallback).