### PR TITLE
fix(julials): add language-specific root marker

### DIFF
--- a/lua/lspconfig/julials.lua
+++ b/lua/lspconfig/julials.lua
@@ -48,7 +48,9 @@ configs.julials = {
       new_config.cmd_cwd = root_dir
     end,
     filetypes = { 'julia' },
-    root_dir = util.find_git_ancestor,
+    root_dir = function(fname)
+      return util.root_pattern 'Project.toml'(fname) or util.find_git_ancestor(fname)
+    end,
     single_file_support = true,
   },
   docs = {


### PR DESCRIPTION
Proper Julia packages have a `Project.toml` in the root directory. Use that as root marker (but keep `.git` as a fallback).