### PR TITLE
feat: add worktree support to find_git_ancestor

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -343,7 +343,8 @@ function M.root_pattern(...)
 end
 function M.find_git_ancestor(startpath)
   return M.search_ancestors(startpath, function(path)
-    if M.path.is_dir(M.path.join(path, '.git')) then
+    -- Support git directories and git files (worktrees)
+    if M.path.is_dir(M.path.join(path, '.git')) or M.path.is_file(M.path.join(path, '.git')) then
       return path
     end
   end)


### PR DESCRIPTION
* find_git_ancestor previously only checked for `.git ` directories
* git worktrees use a `.git` file with reference to the original git
  directory