### PR TITLE
 feat(clojure_lsp) add support for shadow-cljs in clojure_lsp 

### DIFF
--- a/lua/lspconfig/clojure_lsp.lua
+++ b/lua/lspconfig/clojure_lsp.lua
@@ -5,7 +5,7 @@ configs.clojure_lsp = {
   default_config = {
     cmd = { 'clojure-lsp' },
     filetypes = { 'clojure', 'edn' },
-    root_dir = util.root_pattern('project.clj', 'deps.edn', 'build.boot', '.git'),
+    root_dir = util.root_pattern('project.clj', 'deps.edn', 'build.boot', 'shadow-cljs.edn', '.git'),
   },
   docs = {
     description = [[
@@ -14,7 +14,8 @@ https://github.com/snoe/clojure-lsp
 Clojure Language Server
 ]],
     default_config = {
-      root_dir = [[root_pattern("project.clj", "deps.edn", "build.boot", ".git")]],
+      root_dir = [[root_pattern("project.clj", "deps.edn", "build.boot", "shadow-cljs.edn", ".git")]],
     },
   },
 }
+"

--- a/lua/lspconfig/clojure_lsp.lua
+++ b/lua/lspconfig/clojure_lsp.lua
@@ -18,4 +18,3 @@ Clojure Language Server
     },
   },
 }
-"


### PR DESCRIPTION
Shadow-cljs is a build tool for cljs with many features such as npm integration and live reloading.
Link: https://github.com/thheller/shadow-cljs