### PR TITLE
feat: add ruby typeprof support

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -111,6 +111,7 @@ that config.
 - [tflint](#tflint)
 - [theme_check](#theme_check)
 - [tsserver](#tsserver)
+- [typeprof](#typeprof)
 - [vala_ls](#vala_ls)
 - [vdmj](#vdmj)
 - [vimls](#vimls)
@@ -7635,6 +7636,28 @@ require'lspconfig'.tsserver.setup{}
       hostInfo = "neovim"
     }
     root_dir = root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")
+```
+
+
+## typeprof
+
+https://github.com/ruby/typeprof
+
+`typeprof` LSP implementation is built-in with Ruby 3.1 or higher.
+
+**Snippet to enable the language server:**
+```lua
+require'lspconfig'.typeprof.setup{}
+```
+
+**Commands and default values:**
+```lua
+  Commands:
+
+  Default Values:
+    cmd = { "typeprof", "--lsp", "--stdio" }
+    filetypes = { "ruby", "eruby" }
+    root_dir = root_pattern("Gemfile", ".git")
 ```
 
 

--- a/lua/lspconfig/typeprof.lua
+++ b/lua/lspconfig/typeprof.lua
@@ -1,0 +1,22 @@
+local configs = require 'lspconfig/configs'
+local util = require 'lspconfig/util'
+
+local server_name = 'typeprof'
+
+configs[server_name] = {
+  default_config = {
+    cmd = { 'typeprof', '--lsp', '--stdio' },
+    filetypes = { 'ruby', 'eruby' },
+    root_dir = util.root_pattern('Gemfile', '.git'),
+  },
+  docs = {
+    description = [[
+https://github.com/ruby/typeprof
+
+`typeprof` is the built-in analysis and LSP tool for Ruby 3.1+.
+    ]],
+    default_config = {
+      root_dir = [[root_pattern("Gemfile", ".git")]],
+    },
+  },
+}


### PR DESCRIPTION
In Ruby 3.1, TypeProf adds experimental LSP support. This adds a configuration profile for using that LSP in NeoVim.