### PR TITLE
feat: add ruby typeprof support

### DIFF
--- a/lua/lspconfig/typeprof.lua
+++ b/lua/lspconfig/typeprof.lua
@@ -1,0 +1,22 @@
+local configs = require 'lspconfig/configs'
+local util = require 'lspconfig/util'
+
+local server_name = 'typeprof'
+
+configs[server_name] = {
+  default_config = {
+    cmd = { 'typeprof', '--lsp', '--stdio' },
+    filetypes = { 'ruby', 'eruby' },
+    root_dir = util.root_pattern('Gemfile', '.git'),
+  },
+  docs = {
+    description = [[
+https://github.com/ruby/typeprof
+
+`typeprof` is the built-in analysis and LSP tool for Ruby 3.1+.
+    ]],
+    default_config = {
+      root_dir = [[root_pattern("Gemfile", ".git")]],
+    },
+  },
+}


### PR DESCRIPTION
In Ruby 3.1, TypeProf adds experimental LSP support. This adds a configuration profile for using that LSP in NeoVim.