### PR TITLE
fix(lean3ls): use utf-32 offset encoding

### DIFF
--- a/lua/lspconfig/server_configurations/lean3ls.lua
+++ b/lua/lspconfig/server_configurations/lean3ls.lua
@@ -4,6 +4,7 @@ return {
   default_config = {
     cmd = { 'lean-language-server', '--stdio', '--', '-M', '4096', '-T', '100000' },
     filetypes = { 'lean3' },
+    offset_encoding = "utf-32",
     root_dir = function(fname)
       -- check if inside elan stdlib
       local stdlib_dir


### PR DESCRIPTION
@Julian @gebner this should fix things for us following neovim/neovim#16382.