### PR TITLE
fix(health): fix problem of always showing warning

### DIFF
--- a/lua/lspconfig/health.lua
+++ b/lua/lspconfig/health.lua
@@ -2,7 +2,7 @@ local M = {}
 function M.check()
   local configs = require 'lspconfig/configs'
 
-  if not configs or #configs == 0 then
+  if not configs or vim.tbl_count(configs) == 0 then
     vim.fn['health#report_warn'] [[Can't find any config.]]
   end
   for _, top_level_config in pairs(configs) do


### PR DESCRIPTION
It seems that my last change was not reflected in #1461. Sorry, the first `#configs` was wrong. It seems to be a table without an array part, so it needs to be `not next(configs)`.