### PR TITLE
ci: use v2 tag for checkout actions

### DIFF
--- a/.github/workflows/close-config-changes.yml
+++ b/.github/workflows/close-config-changes.yml
@@ -9,7 +9,7 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2.3.1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/commit_lint.yml
+++ b/.github/workflows/commit_lint.yml
@@ -3,7 +3,7 @@ jobs:
   lint-commits:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - run: npm install --save-dev @commitlint/{cli,config-conventional}

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -6,7 +6,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2.3.1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - run: |


### PR DESCRIPTION
The official GitHub actions update the vX tags to be the latest.
Workflows automatically benefit from bugfixes/patches without manually
needing to update the workflows.
