### PR TITLE
ci: remove brackets on the "runs-on" argument

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docgen:
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint:
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
         run: selene --display-style=quiet .
 
   style-lint:
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ubuntu:
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
       run: |
         make test
   macos:
-    runs-on: [macos-latest]
+    runs-on: macos-latest
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2


### PR DESCRIPTION
This will silence the false warning 'Value must be "self-hosted"'
warning from yamlls.
