### PR TITLE
chore: remove executable check

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -258,15 +258,12 @@ function M.server_per_root_dir_manager(_make_config)
         return
       end
       if not new_config.cmd then
-        print(
+        vim.notify(
           string.format(
-            'Error: cmd not defined for %q. You must manually set cmd in the setup{} call according to server_configurations.md, see :help lspconfig-index.',
+            'Error: cmd not defined for %q. Manually set cmd in the setup {} call according to server_configurations.md, see :help lspconfig-index.',
             new_config.name
           )
         )
-        return
-      elseif vim.fn.executable(new_config.cmd[1]) == 0 then
-        vim.notify(string.format('cmd [%q] is not executable.', new_config.cmd[1]), vim.log.levels.Error)
         return
       end
       new_config.on_exit = M.add_hook_before(new_config.on_exit, function()
@@ -285,6 +282,12 @@ function M.server_per_root_dir_manager(_make_config)
         new_config.workspace_folders = nil
       end
       client_id = lsp.start_client(new_config)
+
+      -- Handle failures in start_client
+      if not client_id then
+        return
+      end
+
       if single_file_mode then
         single_file_clients[root_dir] = client_id
       else


### PR DESCRIPTION
* start_client handles checking if the server is executable, it is
  redundant to check this in lspconfig
* vim.fn.executable does not respect cmd_env, which can allow injecting
  servers via a local PATH override

cc @williamboman 