### PR TITLE
feature: add a pre-attach callback that allows stopping the attach

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -10,6 +10,7 @@ function configs.__newindex(t, config_name, config_def)
     default_config = { config_def.default_config, 't' },
     on_new_config = { config_def.on_new_config, 'f', true },
     on_attach = { config_def.on_attach, 'f', true },
+    pre_attach = { config_def.pre_attach, 'f', true },
     commands = { config_def.commands, 't', true },
   }
   if config_def.commands then
@@ -198,6 +199,10 @@ function configs.__newindex(t, config_name, config_def)
     end)
 
     function manager.try_add(bufnr)
+      if config.pre_attach and not config.pre_attach(bufnr) then
+        return
+      end
+
       bufnr = bufnr or api.nvim_get_current_buf()
 
       if vim.api.nvim_buf_get_option(bufnr, 'buftype') == 'nofile' then

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -199,11 +199,11 @@ function configs.__newindex(t, config_name, config_def)
     end)
 
     function manager.try_add(bufnr)
+      bufnr = bufnr or api.nvim_get_current_buf()
+
       if config.pre_attach and not config.pre_attach(bufnr) then
         return
       end
-
-      bufnr = bufnr or api.nvim_get_current_buf()
 
       if vim.api.nvim_buf_get_option(bufnr, 'buftype') == 'nofile' then
         return


### PR DESCRIPTION
Add an optional pre_attach callback configuration option that controls whether the language server attaches to the buffer. This would be useful because it enables a user to create custom logic to prevent language server instances from being spawned for files they don't care about or to prevent adding files they don't care about to the currently running language server instance.

A couple examples of when this could be useful to a user:
* A user has triggered a diff using fugitive. Current behavior causes an `Autostart for server failed: matching root directory not detected.` message. With the feature the user could now add a simple check of the buffer's file path to prevent the attach attempt from proceeding and thereby prevent this message from appearing.
* A user goes to the definition of a symbol that brings them to a library file. Current behavior would either spawn a new language server instance or add the file to the current language server instance depending on the root of the library file. With the feature the user could now add a check for library files to prevent the attach process and thereby prevent the additional hardware resource usage of the language server.
* A user has that one project that brings the language server to its knees. Currently the user would have to disable auto start entirely for that language server to prevent it from attaching to that project. With the feature the user could create custom logic that only prevents that one project from starting the language server and still use the auto-start functionality on other projects.

Open to thoughts and suggestions on this. Documentation probably needs to be added before this is merged as well if it's decided the feature is valuable.