### PR TITLE
fix: set the right default cwd for cmds when unset

### DIFF
--- a/lua/lspconfig/julials.lua
+++ b/lua/lspconfig/julials.lua
@@ -44,9 +44,6 @@ local cmd = {
 configs.julials = {
   default_config = {
     cmd = cmd,
-    on_new_config = function(new_config, root_dir)
-      new_config.cmd_cwd = root_dir
-    end,
     filetypes = { 'julia' },
     root_dir = function(fname)
       return util.root_pattern 'Project.toml'(fname) or util.find_git_ancestor(fname)

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -271,8 +271,10 @@ function M.server_per_root_dir_manager(_make_config)
         single_file_clients[root_dir] = nil
       end)
 
-      -- Launch the server in the root directory used internally by lspconfig, if applicable
-      new_config.cwd = root_dir
+      -- Launch the server in the root directory used internally by lspconfig, if otherwise unset
+      if not new_config.cmd_cwd then
+        new_config.cmd_cwd = root_dir
+      end
 
       -- Sending rootDirectory and workspaceFolders as null is not explicitly
       -- codified in the spec. Certain servers crash if initialized with a NULL


### PR DESCRIPTION
#1474 [breaks `lean.nvim`'s CI making the LSP not come up properly](https://github.com/Julian/lean.nvim/runs/4326198672?check_suite_focus=true#step:8:47) and I don't understand why :/ but it'd appear indeed it has different behavior in a relevant way to us.

Re-submitting the fix as I originally had it for this, which seems to pass the tests as well as make the error go away.