### PR TITLE
Fix eslint `fix_all` sync condition

### DIFF
--- a/lua/lspconfig/eslint.lua
+++ b/lua/lspconfig/eslint.lua
@@ -20,13 +20,13 @@ local function fix_all(opts)
   end
 
   local request
-  if opts.sync or false then
+  if opts.sync then
     request = function(bufnr, method, params)
-      eslint_lsp_client.request(method, params, nil, bufnr)
+      eslint_lsp_client.request_sync(method, params, nil, bufnr)
     end
   else
     request = function(bufnr, method, params)
-      eslint_lsp_client.request_sync(method, params, nil, bufnr)
+      eslint_lsp_client.request(method, params, nil, bufnr)
     end
   end
 


### PR DESCRIPTION
The condition to check if eslint's `fix_all` should trigger a sync request or not looks a bit iffy.