### PR TITLE
fix: update references to single_file_support

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -138,7 +138,7 @@ listed in `:help vim.lsp.start_client()` with the following unique entries:
     created. If `false`, allows for deferring language servers until manually
     launched with `:LspStart` (|lspconfig-commands|).
 
-- {single_file_mode}
+- {single_file_support}
 
     `bool` (default: nil)
 

--- a/lua/lspconfig/server_configurations/jdtls.lua
+++ b/lua/lspconfig/server_configurations/jdtls.lua
@@ -132,7 +132,7 @@ return {
         end
       end
     end,
-    single_file_mode = true,
+    single_file_support = true,
     init_options = {
       workspace = get_workspace_dir(),
       jvm_args = {},

--- a/lua/lspconfig/server_configurations/perlls.lua
+++ b/lua/lspconfig/server_configurations/perlls.lua
@@ -22,7 +22,7 @@ return {
     },
     filetypes = { 'perl' },
     root_dir = util.find_git_ancestor,
-    single_file_mode = true,
+    single_file_support = true,
   },
   docs = {
     package_json = 'https://raw.githubusercontent.com/richterger/Perl-LanguageServer/master/clients/vscode/perl/package.json',

--- a/lua/lspconfig/server_configurations/powershell_es.lua
+++ b/lua/lspconfig/server_configurations/powershell_es.lua
@@ -23,7 +23,7 @@ return {
 
     filetypes = { 'ps1' },
     root_dir = util.find_git_ancestor,
-    single_file_mode = true,
+    single_file_support = true,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -236,9 +236,9 @@ function M.server_per_root_dir_manager(_make_config)
   local single_file_clients = {}
   local manager = {}
 
-  function manager.add(root_dir, single_file_mode)
+  function manager.add(root_dir, single_file_support)
     local client_id
-    if single_file_mode then
+    if single_file_support then
       client_id = single_file_clients[root_dir]
     else
       if not root_dir then
@@ -280,7 +280,7 @@ function M.server_per_root_dir_manager(_make_config)
       -- Sending rootDirectory and workspaceFolders as null is not explicitly
       -- codified in the spec. Certain servers crash if initialized with a NULL
       -- root directory.
-      if single_file_mode then
+      if single_file_support then
         new_config.root_dir = nil
         new_config.workspace_folders = nil
       end
@@ -291,7 +291,7 @@ function M.server_per_root_dir_manager(_make_config)
         return
       end
 
-      if single_file_mode then
+      if single_file_support then
         single_file_clients[root_dir] = client_id
       else
         clients[root_dir] = client_id


### PR DESCRIPTION
Remove invalid references to `single_file_mode`

<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->
