### PR TITLE
chore: tag all vim.notify message with lspconfig

### DIFF
--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -76,7 +76,7 @@ function mt:__index(k)
     else
       vim.notify(
         string.format(
-          'lspconfig: Cannot access configuration for %s. Ensure this server is listed in '
+          '[lspconfig] Cannot access configuration for %s. Ensure this server is listed in '
             .. '`server_configurations.md` or added as a custom server.',
           k
         ),

--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -76,7 +76,7 @@ function mt:__index(k)
     else
       vim.notify(
         string.format(
-          'Cannot access configuration for %s. Ensure this server is listed in '
+          'lspconfig: Cannot access configuration for %s. Ensure this server is listed in '
             .. '`server_configurations.md` or added as a custom server.',
           k
         ),

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -104,7 +104,9 @@ function configs.__newindex(t, config_name, config_def)
         local pseudo_root = util.path.dirname(api.nvim_buf_get_name(0))
         M.manager.add(pseudo_root, true)
       else
-        vim.notify(string.format('Autostart for %s failed: matching root directory not detected.', config_name))
+        vim.notify(
+          string.format('lspconfig: Autostart for %s failed: matching root directory not detected.', config_name)
+        )
       end
     end
 
@@ -217,7 +219,9 @@ function configs.__newindex(t, config_name, config_def)
         local pseudo_root = util.path.dirname(api.nvim_buf_get_name(0))
         id = manager.add(pseudo_root, true)
       else
-        vim.notify(string.format('Autostart for %s failed: matching root directory not detected.', config_name))
+        vim.notify(
+          string.format('lspconfig: Autostart for %s failed: matching root directory not detected.', config_name)
+        )
       end
 
       if id then

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -105,7 +105,7 @@ function configs.__newindex(t, config_name, config_def)
         M.manager.add(pseudo_root, true)
       else
         vim.notify(
-          string.format('lspconfig: Autostart for %s failed: matching root directory not detected.', config_name)
+          string.format('[lspconfig] Autostart for %s failed: matching root directory not detected.', config_name)
         )
       end
     end

--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -124,11 +124,11 @@ return {
         return 4 -- approved
       end,
       ['eslint/probeFailed'] = function()
-        vim.notify('lspconfig: ESLint probe failed.', vim.log.levels.WARN)
+        vim.notify('[lspconfig] ESLint probe failed.', vim.log.levels.WARN)
         return {}
       end,
       ['eslint/noLibrary'] = function()
-        vim.notify('lspconfig: Unable to find ESLint library.', vim.log.levels.WARN)
+        vim.notify('[lspconfig] Unable to find ESLint library.', vim.log.levels.WARN)
         return {}
       end,
     },

--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -124,11 +124,11 @@ return {
         return 4 -- approved
       end,
       ['eslint/probeFailed'] = function()
-        vim.notify('ESLint probe failed.', vim.log.levels.WARN)
+        vim.notify('lspconfig: ESLint probe failed.', vim.log.levels.WARN)
         return {}
       end,
       ['eslint/noLibrary'] = function()
-        vim.notify('Unable to find ESLint library.', vim.log.levels.WARN)
+        vim.notify('lspconfig: Unable to find ESLint library.', vim.log.levels.WARN)
         return {}
       end,
     },

--- a/lua/lspconfig/server_configurations/rust_analyzer.lua
+++ b/lua/lspconfig/server_configurations/rust_analyzer.lua
@@ -43,8 +43,8 @@ return {
         cargo_workspace_dir = vim.fn.json_decode(cargo_metadata)['workspace_root']
       else
         vim.notify(
-          string.format('cmd [%q] failed:\n%s', table.concat(cmd, ' '), cargo_metadata_err),
-          vim.log.levels.Warning
+          string.format('lspconfig: cmd [%q] failed:\n%s', table.concat(cmd, ' '), cargo_metadata_err),
+          vim.log.levels.WARN
         )
       end
       return cargo_workspace_dir

--- a/lua/lspconfig/server_configurations/rust_analyzer.lua
+++ b/lua/lspconfig/server_configurations/rust_analyzer.lua
@@ -43,7 +43,7 @@ return {
         cargo_workspace_dir = vim.fn.json_decode(cargo_metadata)['workspace_root']
       else
         vim.notify(
-          string.format('lspconfig: cmd [%q] failed:\n%s', table.concat(cmd, ' '), cargo_metadata_err),
+          string.format('[lspconfig] cmd (%q) failed:\n%s', table.concat(cmd, ' '), cargo_metadata_err),
           vim.log.levels.WARN
         )
       end

--- a/lua/lspconfig/server_configurations/vdmj.lua
+++ b/lua/lspconfig/server_configurations/vdmj.lua
@@ -1,7 +1,7 @@
 local util = require 'lspconfig.util'
 
 if vim.fn.has 'nvim-0.5.1' == 0 then
-  vim.notify('The VDMJ language server requires nvim > 0.5', vim.log.levels.ERROR)
+  vim.notify('lspconfig: The VDMJ language server requires nvim > 0.5', vim.log.levels.ERROR)
   return
 end
 

--- a/lua/lspconfig/server_configurations/vdmj.lua
+++ b/lua/lspconfig/server_configurations/vdmj.lua
@@ -1,10 +1,5 @@
 local util = require 'lspconfig.util'
 
-if vim.fn.has 'nvim-0.5.1' == 0 then
-  vim.notify('lspconfig: The VDMJ language server requires nvim > 0.5', vim.log.levels.ERROR)
-  return
-end
-
 local mavenrepo = util.path.join(vim.env.HOME, '.m2', 'repository', 'com', 'fujitsu')
 
 local function get_jar_path(config, package, version)

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -260,9 +260,10 @@ function M.server_per_root_dir_manager(_make_config)
       if not new_config.cmd then
         vim.notify(
           string.format(
-            'Error: cmd not defined for %q. Manually set cmd in the setup {} call according to server_configurations.md, see :help lspconfig-index.',
+            'lspconfig: cmd not defined for %q. Manually set cmd in the setup {} call according to server_configurations.md, see :help lspconfig-index.',
             new_config.name
-          )
+          ),
+          vim.log.levels.ERROR
         )
         return
       end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -260,7 +260,7 @@ function M.server_per_root_dir_manager(_make_config)
       if not new_config.cmd then
         vim.notify(
           string.format(
-            'lspconfig: cmd not defined for %q. Manually set cmd in the setup {} call according to server_configurations.md, see :help lspconfig-index.',
+            '[lspconfig] cmd not defined for %q. Manually set cmd in the setup {} call according to server_configurations.md, see :help lspconfig-index.',
             new_config.name
           ),
           vim.log.levels.ERROR


### PR DESCRIPTION
I was playing around a bit with some stuff when I suddenly started getting the `Cannot access configuration for %s.` warning message and at first I had no idea where it originated from and had to grep for it in across all plugins. Figured it'd make sense to prepend the messages with a tag. I think this should be part of core, somehow? Maybe making use of the `opts` param, although that'd add a lot of boilerplate

```lua
vim.notify("This is my error message.", vim.log.levels.ERROR, {
  tag = "lspconfig"
})
```