### PR TITLE
fix(yamlls): add yaml.docker-compose to filetypes

### DIFF
--- a/lua/lspconfig/server_configurations/yamlls.lua
+++ b/lua/lspconfig/server_configurations/yamlls.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'yaml-language-server', '--stdio' },
-    filetypes = { 'yaml' },
+    filetypes = { 'yaml', 'yaml.docker-compose' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
     settings = {


### PR DESCRIPTION
This is a filetype used by for example:
 - https://github.com/ekalinin/Dockerfile.vim
 - https://github.com/sheerun/vim-polyglot