### PR TITLE
Use client.request for unique calls (clangd & texlab)

### DIFF
--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -2,10 +2,15 @@ local util = require 'lspconfig.util'
 
 -- https://clangd.llvm.org/extensions.html#switch-between-sourceheader
 local function switch_source_header(bufnr)
+  local clangd_client = nil
+  for _, v in ipairs(vim.lsp.buf_get_clients(0)) do
+    if v.name == 'clangd' then
+      clangd_client = v
+    end
+  end
   bufnr = util.validate_bufnr(bufnr)
   local params = { uri = vim.uri_from_bufnr(bufnr) }
-  vim.lsp.buf_request(
-    bufnr,
+  clangd_client.request(
     'textDocument/switchSourceHeader',
     params,
     util.compat_handler(function(err, result)
@@ -17,7 +22,8 @@ local function switch_source_header(bufnr)
         return
       end
       vim.api.nvim_command('edit ' .. vim.uri_to_fname(result))
-    end)
+    end),
+    bufnr
   )
 end
 

--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -3,28 +3,32 @@ local util = require 'lspconfig.util'
 -- https://clangd.llvm.org/extensions.html#switch-between-sourceheader
 local function switch_source_header(bufnr)
   local clangd_client = nil
-  for _, v in ipairs(vim.lsp.buf_get_clients(0)) do
+  for _, v in ipairs(vim.lsp.buf_get_clients(bufnr)) do
     if v.name == 'clangd' then
       clangd_client = v
     end
   end
   bufnr = util.validate_bufnr(bufnr)
   local params = { uri = vim.uri_from_bufnr(bufnr) }
-  clangd_client.request(
-    'textDocument/switchSourceHeader',
-    params,
-    util.compat_handler(function(err, result)
-      if err then
-        error(tostring(err))
-      end
-      if not result then
-        print 'Corresponding file cannot be determined'
-        return
-      end
-      vim.api.nvim_command('edit ' .. vim.uri_to_fname(result))
-    end),
-    bufnr
-  )
+  if clangd_client then
+    clangd_client.request(
+      'textDocument/switchSourceHeader',
+      params,
+      util.compat_handler(function(err, result)
+        if err then
+          error(tostring(err))
+        end
+        if not result then
+          print 'Corresponding file cannot be determined'
+          return
+        end
+        vim.api.nvim_command('edit ' .. vim.uri_to_fname(result))
+      end),
+      bufnr
+    )
+  else
+    print 'method textDocument/switchSourceHeader is not supported by any servers active on the current buffer'
+  end
 end
 
 local root_pattern = util.root_pattern('compile_commands.json', 'compile_flags.txt', '.git')

--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -2,8 +2,8 @@ local util = require 'lspconfig.util'
 
 -- https://clangd.llvm.org/extensions.html#switch-between-sourceheader
 local function switch_source_header(bufnr)
-  local clangd_client = util.get_active_client_by_name(bufnr, 'clangd')
   bufnr = util.validate_bufnr(bufnr)
+  local clangd_client = util.get_active_client_by_name(bufnr, 'clangd')
   local params = { uri = vim.uri_from_bufnr(bufnr) }
   if clangd_client then
     clangd_client.request(

--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -2,12 +2,7 @@ local util = require 'lspconfig.util'
 
 -- https://clangd.llvm.org/extensions.html#switch-between-sourceheader
 local function switch_source_header(bufnr)
-  local clangd_client = nil
-  for _, v in ipairs(vim.lsp.buf_get_clients(bufnr)) do
-    if v.name == 'clangd' then
-      clangd_client = v
-    end
-  end
+  local clangd_client = util.get_active_client_by_name(bufnr, 'clangd')
   bufnr = util.validate_bufnr(bufnr)
   local params = { uri = vim.uri_from_bufnr(bufnr) }
   if clangd_client then

--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -16,12 +16,7 @@ local texlab_forward_status = vim.tbl_add_reverse_lookup {
 }
 
 local function buf_build(bufnr)
-  local texlab_client = nil
-  for _, v in ipairs(vim.lsp.buf_get_clients(bufnr)) do
-    if v.name == 'texlab' then
-      texlab_client = v
-    end
-  end
+  local texlab_client = util.get_active_client_by_name(bufnr, 'texlab')
   bufnr = util.validate_bufnr(bufnr)
   local params = {
     textDocument = { uri = vim.uri_from_bufnr(bufnr) },
@@ -44,18 +39,12 @@ local function buf_build(bufnr)
 end
 
 local function buf_search(bufnr)
-  local texlab_client = nil
-  for _, v in ipairs(vim.lsp.buf_get_clients(bufnr)) do
-    if v.name == 'texlab' then
-      texlab_client = v
-    end
-  end
+  local texlab_client = util.get_active_client_by_name(bufnr, 'texlab')
   bufnr = util.validate_bufnr(bufnr)
   local params = {
     textDocument = { uri = vim.uri_from_bufnr(bufnr) },
     position = { line = vim.fn.line '.' - 1, character = vim.fn.col '.' },
   }
-
   if texlab_client then
     texlab_client.request(
       'textDocument/forwardSearch',

--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -16,8 +16,8 @@ local texlab_forward_status = vim.tbl_add_reverse_lookup {
 }
 
 local function buf_build(bufnr)
-  local texlab_client = util.get_active_client_by_name(bufnr, 'texlab')
   bufnr = util.validate_bufnr(bufnr)
+  local texlab_client = util.get_active_client_by_name(bufnr, 'texlab')
   local params = {
     textDocument = { uri = vim.uri_from_bufnr(bufnr) },
   }
@@ -39,8 +39,8 @@ local function buf_build(bufnr)
 end
 
 local function buf_search(bufnr)
-  local texlab_client = util.get_active_client_by_name(bufnr, 'texlab')
   bufnr = util.validate_bufnr(bufnr)
+  local texlab_client = util.get_active_client_by_name(bufnr, 'texlab')
   local params = {
     textDocument = { uri = vim.uri_from_bufnr(bufnr) },
     position = { line = vim.fn.line '.' - 1, character = vim.fn.col '.' },

--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -16,12 +16,17 @@ local texlab_forward_status = vim.tbl_add_reverse_lookup {
 }
 
 local function buf_build(bufnr)
+  local texlab_client = nil
+  for _, v in ipairs(vim.lsp.buf_get_clients(0)) do
+    if v.name == 'texlab' then
+      texlab_client = v
+    end
+  end
   bufnr = util.validate_bufnr(bufnr)
   local params = {
     textDocument = { uri = vim.uri_from_bufnr(bufnr) },
   }
-  lsp.buf_request(
-    bufnr,
+  texlab_client.request(
     'textDocument/build',
     params,
     util.compat_handler(function(err, result)
@@ -29,18 +34,24 @@ local function buf_build(bufnr)
         error(tostring(err))
       end
       print('Build ' .. texlab_build_status[result.status])
-    end)
+    end),
+    bufnr
   )
 end
 
 local function buf_search(bufnr)
+  local texlab_client = nil
+  for _, v in ipairs(vim.lsp.buf_get_clients(0)) do
+    if v.name == 'texlab' then
+      texlab_client = v
+    end
+  end
   bufnr = util.validate_bufnr(bufnr)
   local params = {
     textDocument = { uri = vim.uri_from_bufnr(bufnr) },
     position = { line = vim.fn.line '.' - 1, character = vim.fn.col '.' },
   }
-  lsp.buf_request(
-    bufnr,
+  texlab_client.request(
     'textDocument/forwardSearch',
     params,
     util.compat_handler(function(err, result)
@@ -48,7 +59,8 @@ local function buf_search(bufnr)
         error(tostring(err))
       end
       print('Search ' .. texlab_forward_status[result.status])
-    end)
+    end),
+    bufnr
   )
 end
 

--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -17,7 +17,7 @@ local texlab_forward_status = vim.tbl_add_reverse_lookup {
 
 local function buf_build(bufnr)
   local texlab_client = nil
-  for _, v in ipairs(vim.lsp.buf_get_clients(0)) do
+  for _, v in ipairs(vim.lsp.buf_get_clients(bufnr)) do
     if v.name == 'texlab' then
       texlab_client = v
     end
@@ -26,22 +26,26 @@ local function buf_build(bufnr)
   local params = {
     textDocument = { uri = vim.uri_from_bufnr(bufnr) },
   }
-  texlab_client.request(
-    'textDocument/build',
-    params,
-    util.compat_handler(function(err, result)
-      if err then
-        error(tostring(err))
-      end
-      print('Build ' .. texlab_build_status[result.status])
-    end),
-    bufnr
-  )
+  if texlab_client then
+    texlab_client.request(
+      'textDocument/build',
+      params,
+      util.compat_handler(function(err, result)
+        if err then
+          error(tostring(err))
+        end
+        print('Build ' .. texlab_build_status[result.status])
+      end),
+      bufnr
+    )
+  else
+    print 'method textDocument/build is not supported by any servers active on the current buffer'
+  end
 end
 
 local function buf_search(bufnr)
   local texlab_client = nil
-  for _, v in ipairs(vim.lsp.buf_get_clients(0)) do
+  for _, v in ipairs(vim.lsp.buf_get_clients(bufnr)) do
     if v.name == 'texlab' then
       texlab_client = v
     end
@@ -51,17 +55,22 @@ local function buf_search(bufnr)
     textDocument = { uri = vim.uri_from_bufnr(bufnr) },
     position = { line = vim.fn.line '.' - 1, character = vim.fn.col '.' },
   }
-  texlab_client.request(
-    'textDocument/forwardSearch',
-    params,
-    util.compat_handler(function(err, result)
-      if err then
-        error(tostring(err))
-      end
-      print('Search ' .. texlab_forward_status[result.status])
-    end),
-    bufnr
-  )
+
+  if texlab_client then
+    texlab_client.request(
+      'textDocument/forwardSearch',
+      params,
+      util.compat_handler(function(err, result)
+        if err then
+          error(tostring(err))
+        end
+        print('Search ' .. texlab_forward_status[result.status])
+      end),
+      bufnr
+    )
+  else
+    print 'method textDocument/forwardSearch is not supported by any servers active on the current buffer'
+  end
 end
 
 -- bufnr isn't actually required here, but we need a valid buffer in order to

--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -1,5 +1,4 @@
 local util = require 'lspconfig.util'
-local lsp = vim.lsp
 
 local texlab_build_status = vim.tbl_add_reverse_lookup {
   Success = 0,

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -415,7 +415,7 @@ function M.get_clients_from_cmd_args(arg)
 end
 
 function M.get_active_client_by_name(bufnr, servername)
-  for _, client in ipairs(vim.lsp.buf_get_clients(bufnr)) do
+  for _, client in pairs(vim.lsp.buf_get_clients(bufnr)) do
     if client.name == servername then
       return client
     end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -415,13 +415,13 @@ function M.get_clients_from_cmd_args(arg)
 end
 
 function M.get_active_client_by_name(bufnr, servername)
-  local client = nil
-  for _, v in ipairs(vim.lsp.buf_get_clients(bufnr)) do
-    if v.name == servername then
-      client = v
+  for _, client in ipairs(vim.lsp.buf_get_clients(bufnr)) do
+    if client.name == servername then
+      return client
+    else
+      return client
     end
   end
-  return client
 end
 
 return M

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -418,8 +418,6 @@ function M.get_active_client_by_name(bufnr, servername)
   for _, client in ipairs(vim.lsp.buf_get_clients(bufnr)) do
     if client.name == servername then
       return client
-    else
-      return client
     end
   end
 end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -414,4 +414,14 @@ function M.get_clients_from_cmd_args(arg)
   return vim.tbl_values(result)
 end
 
+function M.get_active_client_by_name(bufnr, servername)
+  local client = nil
+  for _, v in ipairs(vim.lsp.buf_get_clients(bufnr)) do
+    if v.name == servername then
+      client = v
+    end
+  end
+  return client
+end
+
 return M


### PR DESCRIPTION
This PR only addresses clangd and texlab
It uses client.request inplace of vim.lsp.buf_request to call methods
that are outside the lspSpec such as clangd's "textDocument/switchSourceHeader"
This is done to avoid conflicts when using multiple LSPs over the same
buffer.