### PR TITLE
fix(tailwindcss): Add default classAttributes

### DIFF
--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -6,6 +6,7 @@ local class_attributes = {
   'class',
   'className',
   'classList',
+  'ngClass',
 }
 
 return {

--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -2,13 +2,6 @@ local util = require 'lspconfig.util'
 
 local bin_name = 'tailwindcss-language-server'
 
-local class_attributes = {
-  'class',
-  'className',
-  'classList',
-  'ngClass',
-}
-
 return {
   default_config = {
     cmd = { bin_name, '--stdio' },
@@ -82,7 +75,12 @@ return {
           invalidTailwindDirective = 'error',
           recommendedVariantOrder = 'warning',
         },
-        classAttributes = class_attributes
+        classAttributes = {
+          'class',
+          'className',
+          'classList',
+          'ngClass',
+        }
       },
     },
     on_new_config = function(new_config)

--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -80,7 +80,7 @@ return {
           'className',
           'classList',
           'ngClass',
-        }
+        },
       },
     },
     on_new_config = function(new_config)

--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -2,6 +2,12 @@ local util = require 'lspconfig.util'
 
 local bin_name = 'tailwindcss-language-server'
 
+local class_attributes = {
+  'class',
+  'className',
+  'classList',
+}
+
 return {
   default_config = {
     cmd = { bin_name, '--stdio' },
@@ -75,6 +81,7 @@ return {
           invalidTailwindDirective = 'error',
           recommendedVariantOrder = 'warning',
         },
+        classAttributes = class_attributes
       },
     },
     on_new_config = function(new_config)


### PR DESCRIPTION
Version `0.0.5` of [`@tailwindcss/language-server`](https://www.npmjs.com/package/@tailwindcss/language-server) requires setting `classAttriubtes` during LSP setup.
nvim-lspconfig didn't set any class atributes by default, so the LSP failed to initialize.

This fix adds these default classAttributes to tailwindcss:
- `class`
- `className`
- `classList`

This change passes all tests ran by `make lint` and `make test`.

Fixes neovim/nvim-lspconfig#1504