### PR TITLE
Fix eslint/openDoc on Linux

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -110,6 +110,8 @@ return {
         local sysname = vim.loop.os_uname().sysname
         if sysname:match 'Windows' then
           os.execute(string.format('start %q', result.url))
+        elseif sysname:match 'Linux' then
+          os.execute(string.format('xdg-open %q', result.url))
         else
           os.execute(string.format('open %q', result.url))
         end


### PR DESCRIPTION
`xdg-open` is a generic 'open' command on Linux platform
<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->
