### PR TITLE
feat: add golangcilsp support

### DIFF
--- a/lua/lspconfig/server_configurations/golangci_lint_ls.lua
+++ b/lua/lspconfig/server_configurations/golangci_lint_ls.lua
@@ -1,0 +1,34 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'golangci-lint-langserver' },
+    filetypes = { 'go', 'gomod' },
+    init_options = {
+      command = { 'golangci-lint', 'run', '--enable-all', '--disable', 'lll', '--out-format', 'json' },
+    },
+    root_dir = function(fname)
+      return util.root_pattern 'go.work'(fname) or util.root_pattern('go.mod', '.git')(fname)
+    end,
+  },
+  docs = {
+    description = [[
+Combination of both lint server and client
+
+https://github.com/nametake/golangci-lint-langserver
+https://github.com/golangci/golangci-lint
+
+
+Installation of binaries needed is done via
+
+```
+go install github.com/nametake/golangci-lint-langserver@latest
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+```
+
+]],
+    default_config = {
+      root_dir = [[root_pattern('go.mod', '.git')]],
+    },
+  },
+}


### PR DESCRIPTION
Combination of both lint server and client

https://github.com/nametake/golangci-lint-langserver
https://github.com/golangci/golangci-lint

once/if merged I'll create a pull request on nvim-lsp-installer to make it easy to install