### PR TITLE
fix(eslint): openDoc function on Linux

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -110,6 +110,8 @@ return {
         local sysname = vim.loop.os_uname().sysname
         if sysname:match 'Windows' then
           os.execute(string.format('start %q', result.url))
+        elseif sysname:match 'Linux' then
+          os.execute(string.format('xdg-open %q', result.url))
         else
           os.execute(string.format('open %q', result.url))
         end


### PR DESCRIPTION
Now the `open` command is used to execute eslint's `openDoc` function,
but `xdg-open` is the default command in Linux used to open a file or
URL in the user's preferred application.