### PR TITLE
docs(lua): simplify cmd documentation

### DIFF
--- a/lua/lspconfig/server_configurations/sumneko_lua.lua
+++ b/lua/lspconfig/server_configurations/sumneko_lua.lua
@@ -16,9 +16,7 @@ https://github.com/sumneko/lua-language-server
 
 Lua language server.
 
-`lua-language-server` can be installed by following the instructions [here](https://github.com/sumneko/lua-language-server/wiki/Build-and-Run).
-
-**By default, lua-language-server doesn't have a `cmd` set.** This is because nvim-lspconfig does not make assumptions about your path. You must add the following to your init.vim or init.lua to set `cmd` to the absolute path ($HOME and ~ are not expanded) of your unzipped and compiled lua-language-server.
+`lua-language-server` can be installed by following the instructions [here](https://github.com/sumneko/lua-language-server/wiki/Build-and-Run). The default `cmd` assumes that the `lua-language-server` binary can be found in `$PATH`.
 
 ```lua
 local runtime_path = vim.split(package.path, ';')
@@ -26,7 +24,6 @@ table.insert(runtime_path, "lua/?.lua")
 table.insert(runtime_path, "lua/?/init.lua")
 
 require'lspconfig'.sumneko_lua.setup {
-  cmd = { "/path/to/lua-language-server" }, -- full path to the binary
   settings = {
     Lua = {
       runtime = {


### PR DESCRIPTION
`lua-language-server` can now be started with a simple call to the
eponymous binary. assume that can be found in `$PATH`.