### PR TITLE
fix(graphql): add typescriptreact, javascriptreact filetypes

### DIFF
--- a/lua/lspconfig/server_configurations/graphql.lua
+++ b/lua/lspconfig/server_configurations/graphql.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'graphql-lsp', 'server', '-m', 'stream' },
-    filetypes = { 'graphql' },
+    filetypes = { 'graphql', 'typescriptreact', 'javascriptreact' },
     root_dir = util.root_pattern('.git', '.graphqlrc*', '.graphql.config.*', 'graphql.config.*'),
   },
 


### PR DESCRIPTION
It's not uncommon to have GraphQL documents inside `.jsx/.tsx` files, like so:

```tsx
const Component = () => {
  const {data} = useMyPageQuery()
}

gql`
  query MyPage {
    stuff { here }
  }
`
```