### PR TITLE
chore: fix vim.notify prefix to use the [lspconfig] format

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -220,7 +220,7 @@ function configs.__newindex(t, config_name, config_def)
         id = manager.add(pseudo_root, true)
       else
         vim.notify(
-          string.format('lspconfig: Autostart for %s failed: matching root directory not detected.', config_name)
+          string.format('[lspconfig] Autostart for %s failed: matching root directory not detected.', config_name)
         )
       end
 


### PR DESCRIPTION
Really minor, but I noticed this in https://github.com/williamboman/nvim-lsp-installer/issues/312 🙈 