### PR TITLE
fix(taplo): add settings table to taplo

### DIFF
--- a/lua/lspconfig/server_configurations/taplo.lua
+++ b/lua/lspconfig/server_configurations/taplo.lua
@@ -7,6 +7,7 @@ return {
     root_dir = function(fname)
       return util.root_pattern '*.toml'(fname) or util.find_git_ancestor(fname)
     end,
+    settings = {},
     single_file_support = true,
   },
   docs = {


### PR DESCRIPTION
Without the settings table present, no use configuration of the server can be done. This has been causing a lot of issues for us Neovim Taplo users. See: https://github.com/tamasfe/taplo/issues/181 and https://github.com/tamasfe/taplo/issues/167