### PR TITLE
fix: solargraph server setting

### DIFF
--- a/lua/lspconfig/server_configurations/solargraph.lua
+++ b/lua/lspconfig/server_configurations/solargraph.lua
@@ -1,10 +1,10 @@
 local util = require 'lspconfig.util'
 
 local bin_name = 'solargraph'
-local cmd = { bin_name, '--stdio' }
+local cmd = { bin_name, 'stdio' }
 
 if vim.fn.has 'win32' == 1 then
-  cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
+  cmd = { 'cmd.exe', '/C', bin_name, 'stdio' }
 end
 
 return {


### PR DESCRIPTION
I found the bug related with solargraph setting.

## before bug fix
`:LspInfo` out is
<img width="572" alt="スクリーンショット 2021-12-12 0 02 40" src="https://user-images.githubusercontent.com/38848223/145681507-a9bec8dd-85e4-4485-8aac-934506861638.png">


The error log in .cache/nvim.lsp.log is
<img width="744" alt="スクリーンショット 2021-12-12 0 03 04" src="https://user-images.githubusercontent.com/38848223/145681511-4048a5b8-8f78-41c3-857d-038bdfcd3a94.png">


## after fix
`:LspInfo` out is
<img width="559" alt="スクリーンショット 2021-12-12 0 04 25" src="https://user-images.githubusercontent.com/38848223/145681519-9ccf0862-c5bc-40f9-bd10-e6705942e5d7.png">


