### PR TITLE
feat: add grammarly support

### DIFF
--- a/lua/lspconfig/server_configurations/grammarly.lua
+++ b/lua/lspconfig/server_configurations/grammarly.lua
@@ -7,7 +7,9 @@ return {
   },
   docs = {
     description = [[
-Grammarly in an LSP, using the Grammarly API.
+https://github.com/znck/grammarly
+
+A language server which provides access to Grammarly analysis via the API.
 
 Requires some manual installation:
 

--- a/lua/lspconfig/server_configurations/grammarly.lua
+++ b/lua/lspconfig/server_configurations/grammarly.lua
@@ -22,7 +22,7 @@ https://github.com/emacs-grammarly/unofficial-grammarly-language-server
 npm i -g @emacs-grammarly/unofficial-grammarly-language-server
 ```
 
-WARNING: Since this language server uses Grammarly's API, any document you open with it running is shared with them. Please evaluate their [privacy policy](https://www.grammarly.com/privacy-policy) before you use this.
+WARNING: Since this language server uses Grammarly's API, any document you open with it running is shared with them. Please evaluate their [privacy policy](https://www.grammarly.com/privacy-policy) before using this.
 ]],
     default_config = {
       root_dir = [[util.find_git_ancestor]],

--- a/lua/lspconfig/server_configurations/grammarly.lua
+++ b/lua/lspconfig/server_configurations/grammarly.lua
@@ -1,0 +1,33 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    filetypes = { 'markdown' },
+    root_dir = util.find_git_ancestor,
+  },
+  docs = {
+    description = [[
+Grammarly in an LSP, using the Grammarly API.
+
+Requires some manual installation:
+
+1. Clone the Grammarly repo, the upstream is [here](https://github.com/znck/grammarly), it's designed to work with a custom client though, so it requires some modifications. I'd recommend using [this branch of my fork](https://github.com/mtoohey31/grammarly/tree/generic-client-compat) might work for you.
+2. Build the server:
+
+```bash
+pnpm run build:packages && pnpm run build:server
+```
+
+(you can install pnpm with `npm install -g pnpm`)
+
+3. Configure the server, by adding the path to the server's `index.js`, you'll need to modify this to point to where you cloned the Grammarly repo.
+
+```lua
+cmd = { "node", ".../grammarly/extension/dist/server/index.js", "--stdio" }
+```
+]],
+    default_config = {
+      root_dir = [[current directory]],
+    },
+  },
+}

--- a/lua/lspconfig/server_configurations/grammarly.lua
+++ b/lua/lspconfig/server_configurations/grammarly.lua
@@ -11,23 +11,23 @@ Grammarly in an LSP, using the Grammarly API.
 
 Requires some manual installation:
 
-1. Clone the Grammarly repo, the upstream is [here](https://github.com/znck/grammarly), it's designed to work with a custom client though, so it requires some modifications. I'd recommend using [this branch of my fork](https://github.com/mtoohey31/grammarly/tree/generic-client-compat) might work for you.
+1. Clone the Grammarly repo, the upstream is [here](https://github.com/znck/grammarly), it's designed to work with a custom client though, so it requires some modifications. Using [this fork's `generic-client-compat` branch](https://github.com/mtoohey31/grammarly/tree/generic-client-compat) is recommended.
 2. Build the server:
 
 ```bash
 pnpm install && pnpm run build:packages && pnpm run build:server
 ```
 
-(you can install pnpm with `npm install -g pnpm`)
+(pnpm can be installed with `npm install -g pnpm`)
 
-3. Configure the server, by adding the path to the server's `index.js`, you'll need to modify this to point to where you cloned the Grammarly repo.
+3. Configure the server, by adding the path to the server's `index.js`. The example below will need to be modified to point to the location of the Grammarly repo.
 
 ```lua
 cmd = { "node", ".../grammarly/extension/dist/server/index.js", "--stdio" }
 ```
 ]],
     default_config = {
-      root_dir = [[current directory]],
+      root_dir = [[util.find_git_ancestor]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/grammarly.lua
+++ b/lua/lspconfig/server_configurations/grammarly.lua
@@ -15,7 +15,7 @@ Requires some manual installation:
 2. Build the server:
 
 ```bash
-pnpm run build:packages && pnpm run build:server
+pnpm install && pnpm run build:packages && pnpm run build:server
 ```
 
 (you can install pnpm with `npm install -g pnpm`)

--- a/lua/lspconfig/server_configurations/grammarly.lua
+++ b/lua/lspconfig/server_configurations/grammarly.lua
@@ -25,7 +25,7 @@ See [this heading](https://github.com/mtoohey31/grammarly#differences-between-up
 pnpm install && pnpm run build:packages && pnpm run build:server
 ```
 
-(pnpm can be installed with `npm install -g pnpm`)
+(pnpm can be installed with `npm install -g pnpm`, note that it should be used as opposed to npm or yarn because the upstream lockfile is a pnpm lockfile.)
 
 3. Configure the server, by adding the path to the server's `index.js`. The example below will need to be modified to point to the location of the Grammarly repo.
 

--- a/lua/lspconfig/server_configurations/grammarly.lua
+++ b/lua/lspconfig/server_configurations/grammarly.lua
@@ -5,6 +5,7 @@ return {
     cmd = { 'unofficial-grammarly-language-server', '--stdio' },
     filetypes = { 'markdown' },
     root_dir = util.find_git_ancestor,
+    single_file_support = true,
     handlers = {
       ['$/updateDocumentState'] = function()
         return ''

--- a/lua/lspconfig/server_configurations/grammarly.lua
+++ b/lua/lspconfig/server_configurations/grammarly.lua
@@ -9,11 +9,16 @@ return {
     description = [[
 https://github.com/znck/grammarly
 
+(Note: this upstream repo requires a custom language client, see the instructions for a fork which works with any client.)
+
 A language server which provides access to Grammarly analysis via the API.
 
 Requires some manual installation:
 
-1. Clone the Grammarly repo, the upstream is [here](https://github.com/znck/grammarly), it's designed to work with a custom client though, so it requires some modifications. Using [this fork's `generic-client-compat` branch](https://github.com/mtoohey31/grammarly/tree/generic-client-compat) is recommended.
+1. Clone [this fork](https://github.com/mtoohey31/grammarly) with `git clone https://github.com/mtoohey31/grammarly`.
+
+See [this heading](https://github.com/mtoohey31/grammarly#differences-between-upstream) for a full list of differences between the upstream repo and the fork.
+
 2. Build the server:
 
 ```bash

--- a/lua/lspconfig/server_configurations/grammarly.lua
+++ b/lua/lspconfig/server_configurations/grammarly.lua
@@ -2,35 +2,23 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
+    cmd = { 'unofficial-grammarly-language-server', '--stdio' },
     filetypes = { 'markdown' },
     root_dir = util.find_git_ancestor,
+    handlers = {
+      ['$/updateDocumentState'] = function()
+        return ''
+      end,
+    },
   },
   docs = {
     description = [[
-https://github.com/znck/grammarly
+https://github.com/emacs-grammarly/unofficial-grammarly-language-server
 
-(Note: this upstream repo requires a custom language client, see the instructions for a fork which works with any client.)
+`unofficial-grammarly-language-server` can be installed via `npm`:
 
-A language server which provides access to Grammarly analysis via the API.
-
-Requires some manual installation:
-
-1. Clone [this fork](https://github.com/mtoohey31/grammarly) with `git clone https://github.com/mtoohey31/grammarly`.
-
-See [this heading](https://github.com/mtoohey31/grammarly#differences-between-upstream) for a full list of differences between the upstream repo and the fork.
-
-2. Build the server:
-
-```bash
-pnpm install && pnpm run build:packages && pnpm run build:server
-```
-
-(pnpm can be installed with `npm install -g pnpm`, note that it should be used as opposed to npm or yarn because the upstream lockfile is a pnpm lockfile.)
-
-3. Configure the server, by adding the path to the server's `index.js`. The example below will need to be modified to point to the location of the Grammarly repo.
-
-```lua
-cmd = { "node", ".../grammarly/extension/dist/server/index.js", "--stdio" }
+```sh
+npm i -g @emacs-grammarly/unofficial-grammarly-language-server
 ```
 ]],
     default_config = {

--- a/lua/lspconfig/server_configurations/grammarly.lua
+++ b/lua/lspconfig/server_configurations/grammarly.lua
@@ -21,6 +21,8 @@ https://github.com/emacs-grammarly/unofficial-grammarly-language-server
 ```sh
 npm i -g @emacs-grammarly/unofficial-grammarly-language-server
 ```
+
+WARNING: Since this language server uses Grammarly's API, any document you open with it running is shared with them. Please evaluate their [privacy policy](https://www.grammarly.com/privacy-policy) before you use this.
 ]],
     default_config = {
       root_dir = [[util.find_git_ancestor]],


### PR DESCRIPTION
Hello! This pull request adds a tiny config for the [lsp version of grammarly](https://github.com/znck/grammarly). The original is built to work with a custom language client though, so I had to make some modifications to resolve errors that made it crash. The branch of my fork with those modifications is [here](https://github.com/mtoohey31/grammarly/tree/generic-client-compat), and there's instructions for building it in the docs for the configuration. There are still some references to features provided by the custom client in my fork, but the basic functionality of displaying diagnostics and applying simple text edit code actions works without errors. The use of some code actions might result in errors though, I haven't run into any yet but I have not done extensive testing. The modifications I made also removed the support for premium accounts, which I think is fine since, as far as I know, there's no way to handle the login prompt through the LSP alone without turning this into an extension.

Of note: this uses the Grammarly API, so every document that you open with this LSP running is seen by Grammarly. Would you like me to add a warning about this in the configuration docs?

Oh, and one last thing, the CONTRIBUTING.md file said not to use `vim.fn.cwd`, so I have the git ancestor helper in there right now, as far as my testing indicates though, the server does not care what the root dir is, even a function that always returns `"."` seems to work. I'd prefer to use something other than the git ancestor helper so that users aren't limited to using it in a git repository. If anyone has recommendations, let me know!

Thanks!