### PR TITLE
fix(solargraph): correct subcommand name

### DIFF
--- a/lua/lspconfig/server_configurations/solargraph.lua
+++ b/lua/lspconfig/server_configurations/solargraph.lua
@@ -1,7 +1,7 @@
 local util = require 'lspconfig.util'
 
 local bin_name = 'solargraph'
-local cmd = { bin_name, '--stdio' }
+local cmd = { bin_name, 'stdio' }
 
 if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }


### PR DESCRIPTION
<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->
Fix regression introduced in a2719a8723e503f1be89d9b1c334846de405eb23. Running
`solargraph --stdio` is causing the following error on Linux.

```
Could not find command "__stdio".
Did you mean?  "stdio"
Deprecation warning: Thor exit with status 0 on errors. To keep this behavior, you must define `exit_on_failure?` in `Solargraph::Shell`
You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION.
```
