### PR TITLE
fix(ccls): delete invalid root directory pattern

### DIFF
--- a/lua/lspconfig/server_configurations/ccls.lua
+++ b/lua/lspconfig/server_configurations/ccls.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'ccls' },
     filetypes = { 'c', 'cpp', 'objc', 'objcpp' },
-    root_dir = util.root_pattern('compile_commands.json', '.ccls', 'compile_flags.txt', '.git'),
+    root_dir = util.root_pattern('compile_commands.json', '.ccls', '.git'),
     -- ccls does not support sending a null root directory
     single_file_support = false,
   },
@@ -13,7 +13,7 @@ return {
 https://github.com/MaskRay/ccls/wiki
 
 ccls relies on a [JSON compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html) specified
-as compile_commands.json or, for simpler projects, a compile_flags.txt.
+as compile_commands.json or, for simpler projects, a .ccls.
 For details on how to automatically generate one using CMake look [here](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html). Alternatively, you can use [Bear](https://github.com/rizsotto/Bear).
 
 Customization options are passed to ccls at initialization time via init_options, a list of available options can be found [here](https://github.com/MaskRay/ccls/wiki/Customization#initialization-options). For example:
@@ -36,7 +36,7 @@ lspconfig.ccls.setup {
 
 ]],
     default_config = {
-      root_dir = [[root_pattern("compile_commands.json", ".ccls", "compile_flags.txt", ".git") or dirname]],
+      root_dir = [[root_pattern("compile_commands.json", ".ccls", ".git")]],
     },
   },
 }


### PR DESCRIPTION
ccls doesn't support compile_flags.txt, see
https://github.com/MaskRay/ccls/wiki/FAQ#does-ccls-support-compile_flagstxt