### PR TITLE
only lists are valid for cmd

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -1274,7 +1274,7 @@ require'lspconfig'.erlangls.setup{}
   Commands:
   
   Default Values:
-    cmd = "erlang_ls"
+    cmd = { "erlang_ls" }
     filetypes = { "erlang" }
     root_dir = root_pattern('rebar.config', 'erlang.mk', '.git')
     single_file_support = true

--- a/lua/lspconfig/server_configurations/erlangls.lua
+++ b/lua/lspconfig/server_configurations/erlangls.lua
@@ -7,7 +7,7 @@ end
 
 return {
   default_config = {
-    cmd = cmd,
+    cmd = { cmd },
     filetypes = { 'erlang' },
     root_dir = util.root_pattern('rebar.config', 'erlang.mk', '.git'),
     single_file_support = true,


### PR DESCRIPTION
Running the latest pre-release build of neovim I noticed that erlangls stopped working, due to an error validating cmd. It exclusively accepts lists now. This change in this PR is compatible with nvim 0.6 stable since lists were already allowed in case the cmd needed to be run with options/flags. 