### PR TITLE
fix: remove vim.lsp.util.close_preview_autocmd

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -203,7 +203,7 @@ return function()
   vim.api.nvim_buf_set_option(bufnr, 'filetype', 'lspinfo')
 
   vim.api.nvim_buf_set_keymap(bufnr, 'n', '<esc>', '<cmd>bd<CR>', { noremap = true })
-  vim.lsp.util.close_preview_autocmd({ 'BufHidden', 'BufLeave' }, win_id)
+  vim.api.nvim_command("autocmd BufHidden,BufLeave <buffer> ++once lua pcall(vim.api.nvim_win_close, "..win_id..", true)")
 
   vim.fn.matchadd(
     'Error',


### PR DESCRIPTION
Inline vim.lsp.util.close_preview_autocmd, it was removed from neovim.