### PR TITLE
fix: remove call to close_preview_autocmd

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -203,7 +203,6 @@ return function()
   vim.api.nvim_buf_set_option(bufnr, 'filetype', 'lspinfo')
 
   vim.api.nvim_buf_set_keymap(bufnr, 'n', '<esc>', '<cmd>bd<CR>', { noremap = true })
-  vim.lsp.util.close_preview_autocmd({ 'BufHidden', 'BufLeave' }, win_id)
 
   vim.fn.matchadd(
     'Error',


### PR DESCRIPTION
Fixes https://github.com/neovim/nvim-lspconfig/issues/1579