### PR TITLE
Correct server configuration docs for settings.workspace.library on sumneko lua server

### DIFF
--- a/lua/lspconfig/server_configurations/sumneko_lua.lua
+++ b/lua/lspconfig/server_configurations/sumneko_lua.lua
@@ -38,7 +38,7 @@ require'lspconfig'.sumneko_lua.setup {
       },
       workspace = {
         -- Make the server aware of Neovim runtime files
-        library = vim.api.nvim_get_runtime_file("", true),
+        library = {vim.api.nvim_get_runtime_file("", true)},
       },
       -- Do not send telemetry data containing a randomized but unique identifier
       telemetry = {


### PR DESCRIPTION
Checking on the examples provided on https://github.com/sumneko/lua-language-server/wiki/Setting#different-clients-load-settingjson-in-different-ways , I noticed that `settings.workspace.library` must be a list, this particular thing was causing me some problems.