### PR TITLE
fix(jedi-language-server) add package_json

### DIFF
--- a/lua/lspconfig/server_configurations/jedi_language_server.lua
+++ b/lua/lspconfig/server_configurations/jedi_language_server.lua
@@ -16,7 +16,7 @@ return {
     single_file_support = true,
   },
   docs = {
-    package_json = 'https://github.com/pappasam/coc-jedi/blob/main/package.json',
+    package_json = 'https://raw.githubusercontent.com/pappasam/coc-jedi/main/package.json',
     description = [[
 https://github.com/pappasam/jedi-language-server
 

--- a/lua/lspconfig/server_configurations/jedi_language_server.lua
+++ b/lua/lspconfig/server_configurations/jedi_language_server.lua
@@ -16,6 +16,7 @@ return {
     single_file_support = true,
   },
   docs = {
+    package_json = 'https://github.com/pappasam/coc-jedi/blob/main/package.json',
     description = [[
 https://github.com/pappasam/jedi-language-server
 


### PR DESCRIPTION
👉 This change should (re-)enable compatibility with dependents, [LunarVim](https://github.com/LunarVim/LunarVim) and [`nlsp-settings.nvim`](https://github.com/tamago324/nlsp-settings.nvim).

I followed a winding path here. 🛣️ 

LunarVim relies on this repo to install LSP clients, as it should. It also [relies](https://www.lunarvim.org/languages/#server-settings) on `nlsp-settings.nvim` to _configure_ those LSP clients.

`nlsp-settings.nvim` [currently does not support](https://github.com/tamago324/nlsp-settings.nvim/blob/main/schemas/README.md) Jedi 😢 which is sad because I love Jedi.

🙏 **But thankfully**, much of the LSP support in `nlsp-settings.nvim` comes from autogenerated schemas based on _this_ repo. And (it looks to me like) `jedi-language-server` is [not getting picked up due to](https://github.com/tamago324/nlsp-settings.nvim/blob/main/scripts/gen_schemas.lua#L58) a missing `package_json`.