### PR TITLE
fix: do not attach server to buffers with nil or missing name

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -79,7 +79,11 @@ function configs.__newindex(t, config_name, config_def)
     function M.launch()
       local root_dir
       if get_root_dir then
-        root_dir = get_root_dir(util.path.sanitize(api.nvim_buf_get_name(0)), api.nvim_get_current_buf())
+        local buf_name = api.nvim_buf_get_name(0)
+        if buf_name == '' or not buf_name then
+          return
+        end
+        root_dir = get_root_dir(util.path.sanitize(buf_name), api.nvim_get_current_buf())
       end
 
       if root_dir then
@@ -91,7 +95,11 @@ function configs.__newindex(t, config_name, config_def)
           )
         )
         for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-          local buf_dir = util.path.sanitize(api.nvim_buf_get_name(bufnr))
+          local buf_name = api.nvim_buf_get_name(bufnr)
+          if buf_name == '' or not buf_name then
+            return
+          end
+          local buf_dir = util.path.sanitize(buf_name)
           if buf_dir:sub(1, root_dir:len()) == root_dir then
             M.manager.try_add_wrapper(bufnr)
           end
@@ -101,7 +109,11 @@ function configs.__newindex(t, config_name, config_def)
         -- Effectively this is the root from lspconfig's perspective, as we use
         -- this to attach additional files in the same parent folder to the same server.
         -- We just no longer send rootDirectory or workspaceFolders during initialization.
-        local pseudo_root = util.path.dirname(util.path.sanitize(api.nvim_buf_get_name(0)))
+        local buf_name = api.nvim_buf_get_name(0)
+        if buf_name == '' or not buf_name then
+          return
+        end
+        local pseudo_root = util.path.dirname(util.path.sanitize(buf_name))
         M.manager.add(pseudo_root, true)
       else
         vim.notify(
@@ -209,7 +221,11 @@ function configs.__newindex(t, config_name, config_def)
       local id
       local root_dir
 
-      local buf_path = util.path.sanitize(api.nvim_buf_get_name(bufnr))
+      local buf_name = api.nvim_buf_get_name(bufnr)
+      if buf_name == '' or not buf_name then
+        return
+      end
+      local buf_path = util.path.sanitize(buf_name)
 
       if get_root_dir then
         root_dir = get_root_dir(buf_path, bufnr)


### PR DESCRIPTION
Closes https://github.com/neovim/nvim-lspconfig/issues/1524

I want to refactor `launch()` at some point, as in retrospect it's a hacky bolt-on.

I'm going to follow-up this PR with a more generic utility function which also handles #1540 