### PR TITLE
fix: use forward delineated paths in leanlsps

### DIFF
--- a/lua/lspconfig/server_configurations/lean3ls.lua
+++ b/lua/lspconfig/server_configurations/lean3ls.lua
@@ -14,10 +14,11 @@ return {
     filetypes = { 'lean3' },
     offset_encoding = 'utf-32',
     root_dir = function(fname)
+      fname = util.path.sanitize(fname)
       -- check if inside elan stdlib
       local stdlib_dir
       do
-        local _, endpos = fname:find(util.path.sep .. util.path.join('lean', 'library'))
+        local _, endpos = fname:find '/lean/library'
         if endpos then
           stdlib_dir = fname:sub(1, endpos)
         end

--- a/lua/lspconfig/server_configurations/leanls.lua
+++ b/lua/lspconfig/server_configurations/leanls.lua
@@ -6,9 +6,10 @@ return {
     filetypes = { 'lean' },
     root_dir = function(fname)
       -- check if inside elan stdlib
+      fname = util.path.sanitize(fname)
       local stdlib_dir
       do
-        local _, endpos = fname:find(util.path.sep .. util.path.join('lib', 'lean'))
+        local _, endpos = fname:find '/lib/lean'
         if endpos then
           stdlib_dir = fname:sub(1, endpos)
         end


### PR DESCRIPTION
Looks like util.path.sep is gone.

Refs: bba61ed