### PR TITLE
feat: add gotmpl to gopls

### DIFF
--- a/lua/lspconfig/server_configurations/gopls.lua
+++ b/lua/lspconfig/server_configurations/gopls.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'gopls' },
-    filetypes = { 'go', 'gomod' },
+    filetypes = { 'go', 'gomod', 'gotmpl' },
     root_dir = function(fname)
       return util.root_pattern 'go.work'(fname) or util.root_pattern('go.mod', '.git')(fname)
     end,


### PR DESCRIPTION
gopls introduced support for templates:
https://github.com/golang/tools/blob/master/gopls/doc/features.md#template-files

They look for 'tmpl' and 'gotmpl' extensions.
tmpl may be a tad too unspecific but adding gotmpl shouldn't hurt.