### PR TITLE
fix(nimls): remove erroneous package_json entry

### DIFF
--- a/lua/lspconfig/server_configurations/nimls.lua
+++ b/lua/lspconfig/server_configurations/nimls.lua
@@ -10,7 +10,6 @@ return {
     single_file_support = true,
   },
   docs = {
-    package_json = 'https://raw.githubusercontent.com/pragmagic/vscode-nim/master/package.json',
     description = [[
 https://github.com/PMunch/nimlsp
 `nimlsp` can be installed via the `nimble` package manager:


### PR DESCRIPTION
They aren't really the same server, so I really don't believe these settings are valid. Also, https://github.com/williamboman/nvim-lsp-installer/issues/326#issuecomment-996065450 seems to confirm this.

- https://github.com/PMunch/nimlsp (this server)
- https://github.com/pragmagic/vscode-nim