### PR TITLE
refactor(clangd): Remove obsolete --background-index flag

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -520,7 +520,7 @@ require'lspconfig'.clangd.setup{}
   
   Default Values:
     capabilities = default capabilities, with offsetEncoding utf-8
-    cmd = { "clangd", "--background-index" }
+    cmd = { "clangd" }
     filetypes = { "c", "cpp", "objc", "objcpp" }
     root_dir = root_pattern("compile_commands.json", "compile_flags.txt", ".git") or dirname
     single_file_support = true

--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -520,7 +520,7 @@ require'lspconfig'.clangd.setup{}
   
   Default Values:
     capabilities = default capabilities, with offsetEncoding utf-8
-    cmd = { "clangd", "--background-index" }
+    cmd = { "clangd" }
     filetypes = { "c", "cpp", "objc", "objcpp" }
     root_dir = root_pattern("compile_commands.json", "compile_flags.txt", ".git") or dirname
     single_file_support = true

--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -38,7 +38,7 @@ local default_capabilities = vim.tbl_deep_extend(
 
 return {
   default_config = {
-    cmd = { 'clangd', '--background-index' },
+    cmd = { 'clangd' },
     filetypes = { 'c', 'cpp', 'objc', 'objcpp' },
     root_dir = function(fname)
       local filename = util.path.is_absolute(fname) and fname or util.path.join(vim.loop.cwd(), fname)


### PR DESCRIPTION
Clangd background index is enabled by default for a very long while.
In the vast majority of modern versions, the flag is redundant, hence
I think it is better to remove it for clarity.