### PR TITLE
refactor(clangd): Remove obsolete --background-index flag

### DIFF
--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -38,7 +38,7 @@ local default_capabilities = vim.tbl_deep_extend(
 
 return {
   default_config = {
-    cmd = { 'clangd', '--background-index' },
+    cmd = { 'clangd' },
     filetypes = { 'c', 'cpp', 'objc', 'objcpp' },
     root_dir = function(fname)
       local filename = util.path.is_absolute(fname) and fname or util.path.join(vim.loop.cwd(), fname)


### PR DESCRIPTION
Clangd background index is enabled by default for a very long while.
In the vast majority of modern versions, the flag is redundant, hence
I think it is better to remove it for clarity.