### PR TITLE
Update server_configurations.md

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -1524,7 +1524,7 @@ npm i -g vscode-langservers-extracted
 
 vscode-eslint-language-server provides an EslintFixAll command that can be used to format document on save
 ```vim
-autocmd BufWritePre <buffer> <cmd>EslintFixAll<CR>
+autocmd BufWritePre <buffer> EslintFixAll
 ```
 
 See [vscode-eslint](https://github.com/microsoft/vscode-eslint/blob/55871979d7af184bf09af491b6ea35ebd56822cf/server/src/eslintServer.ts#L216-L229) for configuration options.


### PR DESCRIPTION
ESlint config for AutoLinting was wrong.

Neither CR nor CMD are needed and actually break the automatic invocation