### PR TITLE
feat(leanls): add root dir as command-line arg

### DIFF
--- a/lua/lspconfig/server_configurations/leanls.lua
+++ b/lua/lspconfig/server_configurations/leanls.lua
@@ -19,6 +19,10 @@ return {
         or stdlib_dir
         or util.find_git_ancestor(fname)
     end,
+    on_new_config = function(config, root_dir)
+      -- add root dir as command-line argument for `ps aux`
+      table.insert(config.cmd, root_dir)
+    end,
     single_file_support = true,
   },
   docs = {


### PR DESCRIPTION
The argument is ignored by the server, but it is useful because it is shown by `htop`, `ps ax`, etc., so you can figure out which Lean servers are running.

The lean3ls doesn't require a corresponding change: we use the `lean-language-server` wrapper, which appends the root directory itself to the wrapped `lean --server` command.