### PR TITLE
Use --locked for cargo install taplo-lsp

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -7571,7 +7571,7 @@ Language server for Taplo, a TOML toolkit.
 
 `taplo-lsp` can be installed via `cargo`:
 ```sh
-cargo install taplo-lsp
+cargo install --locked taplo-lsp
 ```
     
 


### PR DESCRIPTION
`cargo install taplo-lsp` fails for me. According to https://github.com/tamasfe/taplo/issues/197#issuecomment-997160846 the solution is to use `--locked`