### PR TITLE
Install --locked taplo

### DIFF
--- a/lua/lspconfig/server_configurations/taplo.lua
+++ b/lua/lspconfig/server_configurations/taplo.lua
@@ -17,7 +17,7 @@ Language server for Taplo, a TOML toolkit.
 
 `taplo-lsp` can be installed via `cargo`:
 ```sh
-cargo install taplo-lsp
+cargo install --locked taplo-lsp
 ```
     ]],
     default_config = {


### PR DESCRIPTION
Current instructions give an error (MacOS 12.1); Suggestion is to add `--locked` to the install command: https://github.com/tamasfe/taplo/issues/197#issuecomment-997160846