### PR TITLE
fix(remark_ls): change root_pattern to remark-specific project files

### DIFF
--- a/lua/lspconfig/server_configurations/remark_ls.lua
+++ b/lua/lspconfig/server_configurations/remark_ls.lua
@@ -11,8 +11,16 @@ return {
   default_config = {
     cmd = cmd,
     filetypes = { 'markdown' },
-    root_dir = util.find_git_ancestor,
-    single_file_support = true,
+    root_dir = util.root_pattern(
+      '.remarkc',
+      '.remarkc.json',
+      '.remarkc.cjs',
+      '.remarkc.mjs',
+      '.remarkc.js',
+      '.remarkc.yaml',
+      '.remarkc.yml',
+      'package.json'
+    ),
   },
   docs = {
     description = [[


### PR DESCRIPTION
From discussion here: https://github.com/neovim/nvim-lspconfig/pull/1606#discussion_r780224035