### PR TITLE
include heex in tailwind filetypes

### DIFF
--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -31,6 +31,7 @@ return {
       -- 'HTML (Eex)',
       -- 'HTML (EEx)',
       'html-eex',
+      'heex',
       'jade',
       'leaf',
       'liquid',


### PR DESCRIPTION
Last year the [Elixir team introduced](https://github.com/phoenixframework/phoenix_live_view/pull/1440) the HEEx templating engine, along with `.heex` files.

They're a superset of EEx/html-eex