### PR TITLE
refactor(info): don't show non-managed clients

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -115,8 +115,8 @@ end
 return function()
   -- These options need to be cached before switching to the floating
   -- buffer.
-  local buf_clients = vim.lsp.buf_get_clients()
-  local clients = vim.lsp.get_active_clients()
+  local buf_clients = util.buf_get_managed_clients()
+  local clients = util.get_managed_clients()
   local buffer_filetype = vim.bo.filetype
 
   local win_info = windows.percentage_range_window(0.8, 0.7)

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -405,11 +405,17 @@ function M.get_clients_from_cmd_args(arg)
 end
 
 function M.get_active_client_by_name(bufnr, servername)
-  for _, client in pairs(vim.lsp.buf_get_clients(bufnr)) do
+  for _, client in pairs(M.buf_get_managed_clients(bufnr)) do
     if client.name == servername then
       return client
     end
   end
+end
+
+function M.buf_get_managed_clients(bufnr)
+  return vim.tbl_filter(function(client)
+    return vim.lsp.buf_is_attached(bufnr, client.id)
+  end, M.get_managed_clients())
 end
 
 function M.get_managed_clients()


### PR DESCRIPTION
**breaking change**

`:LspInfo` will no longer display clients that are externally managed

<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->
