### PR TITLE
fix(ccls): offset_encoding = utf-32

### DIFF
--- a/lua/lspconfig/server_configurations/ccls.lua
+++ b/lua/lspconfig/server_configurations/ccls.lua
@@ -5,6 +5,7 @@ return {
     cmd = { 'ccls' },
     filetypes = { 'c', 'cpp', 'objc', 'objcpp' },
     root_dir = util.root_pattern('compile_commands.json', '.ccls', '.git'),
+    offset_encoding = 'utf-32',
     -- ccls does not support sending a null root directory
     single_file_support = false,
   },


### PR DESCRIPTION
ccls use codepoint as offset_encoding

check this https://github.com/MaskRay/ccls/commit/66e9cbd9a6fbbc239af1c1014a11bea4ed25ce33
<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->
