### PR TITLE
fix(psalm): use .bat on Windows

### DIFF
--- a/lua/lspconfig/server_configurations/psalm.lua
+++ b/lua/lspconfig/server_configurations/psalm.lua
@@ -1,8 +1,14 @@
 local util = require 'lspconfig.util'
 
+local bin_name = 'psalm-language-server'
+
+if vim.fn.has 'win32' == 1 then
+  bin_name = bin_name .. '.bat'
+end
+
 return {
   default_config = {
-    cmd = { 'psalm-language-server' },
+    cmd = { bin_name },
     filetypes = { 'php' },
     root_dir = util.root_pattern('psalm.xml', 'psalm.xml.dist'),
   },


### PR DESCRIPTION
The `psalm-language-server` that gets installed via `composer require` is a shebang executable. For Windows, there's a `.bat` version.