### PR TITLE
fix for tailwindcss v0.7.6

### DIFF
--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -87,6 +87,13 @@ return {
           'classList',
           'ngClass',
         },
+        files = {
+          exclude = {
+            '**/.git/**',
+            '**/node_modules/**',
+            '**/.hg/**',
+          },
+        },
       },
     },
     on_new_config = function(new_config)


### PR DESCRIPTION
Added `tailwindCSS.files.exclude` default setting, copied from the VSCode extension. Without this the server will crash. See https://github.com/tailwindlabs/tailwindcss-intellisense/issues/459
