### PR TITLE
Call try_add when the config.filetypes is nil

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -251,11 +251,15 @@ function configs.__newindex(t, config_name, config_def)
     function manager.try_add_wrapper(bufnr)
       bufnr = bufnr or api.nvim_get_current_buf()
       local buf_filetype = vim.api.nvim_buf_get_option(bufnr, 'filetype')
-      for _, filetype in ipairs(config.filetypes) do
-        if buf_filetype == filetype then
-          manager.try_add(bufnr)
-          return
+      if config.filetypes then
+        for _, filetype in ipairs(config.filetypes) do
+          if buf_filetype == filetype then
+            manager.try_add(bufnr)
+            return
+          end
         end
+      else
+        manager.try_add(bufnr)
       end
     end
 


### PR DESCRIPTION
When it reloads a server configured without "filetypes", it needs to call try_add without comparison with "filetypes".

fix: #1672
