### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,6 @@ The following support tab-completion for all arguments:
 
 Please see the [wiki](https://github.com/neovim/nvim-lspconfig/wiki) for additional topics, including:
 
-* [Installing language servers automatically](https://github.com/neovim/nvim-lspconfig/wiki/Installing-language-servers-automatically)
 * [Snippets support](https://github.com/neovim/nvim-lspconfig/wiki/Snippets)
 * [Project local settings](https://github.com/neovim/nvim-lspconfig/wiki/Project-local-settings)
 * [Recommended plugins for enhanced language server features](https://github.com/neovim/nvim-lspconfig/wiki/Language-specific-plugins)


### PR DESCRIPTION
Removed the item *Installing language servers automatically*, for it was a broken link. This topic does not exist on the wiki.