### PR TITLE
Set ALS root dir to / and show current GPR project file

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -169,6 +169,11 @@ require'lspconfig'.als.setup{}
   Default Values:
     cmd = { "ada_language_server" }
     filetypes = { "ada" }
+    lspinfo = function(cfg)
+          local extra = {}
+          table.insert(extra, 'GPR project:     ' .. cfg.settings.ada.projectFile)
+          return extra
+        end,
     root_dir = util.root_pattern("Makefile", ".git", "*.gpr", "*.adc")
 ```
 

--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -169,6 +169,11 @@ require'lspconfig'.als.setup{}
   Default Values:
     cmd = { "ada_language_server" }
     filetypes = { "ada" }
+    lspinfo = function(cfg)
+          local extra = {}
+          table.insert(extra, 'GPR project:     ' .. cfg.settings.ada.projectFile)
+          return extra
+        end,
     root_dir = util.root_pattern("Makefile", ".git", "*.gpr", "*.adc")
 ```
 

--- a/lua/lspconfig/server_configurations/als.lua
+++ b/lua/lspconfig/server_configurations/als.lua
@@ -9,7 +9,12 @@ return {
   default_config = {
     cmd = { bin_name },
     filetypes = { 'ada' },
-    root_dir = util.root_pattern('Makefile', '.git', '*.gpr', '*.adc'),
+    root_dir = function() return '/' end,
+    lspinfo = function(cfg)
+      local extra = {}
+      table.insert(extra, 'GPR project:     ' .. cfg.settings.ada.projectFile)
+      return extra
+    end,
   },
   docs = {
     package_json = 'https://raw.githubusercontent.com/AdaCore/ada_language_server/master/integration/vscode/ada/package.json',


### PR DESCRIPTION
This fixes the problem that when you jump into a system library following a definition, a new ALS instance is started which doesn't know which gpr file to use and hence throws an error and stops working. Instead, we keep the GPR project file that you started with.

If you combine that with [this gpr selector plugin](https://github.com/TamaMcGlinn/nvim-lsp-gpr-selector) to allow switching out the selected GPR project, then you can even use ALS from projects that have multiple gpr files.