### PR TITLE
docs(ansible): fix install link and switch to npm

### DIFF
--- a/lua/lspconfig/server_configurations/ansiblels.lua
+++ b/lua/lspconfig/server_configurations/ansiblels.lua
@@ -37,9 +37,10 @@ https://github.com/ansible/ansible-language-server
 
 Language server for the ansible configuration management tool.
 
-`ansible-language-server` can be installed via `yarn`:
+`ansible-language-server` can be installed via `npm`:
+
 ```sh
-yarn global add ansible-language-server
+npm install -g @ansible/ansible-language-server
 ```
 ]],
   },


### PR DESCRIPTION
The [`ansible-language-server`](https://www.npmjs.com/package/ansible-language-server) package is 6 months old and deprecated, because it has been moved to [`@ansible/ansible-language-server`](https://www.npmjs.com/package/@ansible/ansible-language-server), so this fixes the installation instructions to use the new package name. Also, while I was at it I switched the installation instructions to use npm, becuase yarn isn't required as of [ansible/ansible-language-server#22](https://github.com/ansible/ansible-language-server/pull/22), and npm is installed with node by default so we should prefer that when possible.