### PR TITLE
feat: allow attaching to paths inside archives

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -21,11 +21,13 @@ M.default_config = {
 M.on_setup = nil
 
 function M.bufname_valid(bufname)
-  if bufname and bufname ~= '' and (bufname:match '^([a-zA-Z]:).*' or bufname:match '^/') then
-    return true
-  else
+  if not bufname then
     return false
   end
+  if bufname:match '^/' or bufname:match '^[a-zA-Z]:' or bufname:match '^zipfile://' or bufname:match '^tarfile:' then
+    return true
+  end
+  return false
 end
 
 function M.validate_bufnr(bufnr)
@@ -341,6 +343,7 @@ function M.root_pattern(...)
     end
   end
   return function(startpath)
+    startpath = M.strip_archive_subpath(startpath)
     return M.search_ancestors(startpath, matcher)
   end
 end
@@ -435,6 +438,15 @@ function M.get_managed_clients()
     end
   end
   return clients
+end
+
+-- For zipfile: or tarfile: virtual paths, returns the path to the archive.
+-- Other paths are returned unaltered.
+function M.strip_archive_subpath(path)
+  -- Matches regex from zip.vim / tar.vim
+  path = vim.fn.substitute(path, 'zipfile://\\(.\\{-}\\)::[^\\\\].*$', '\\1', '')
+  path = vim.fn.substitute(path, 'tarfile:\\(.\\{-}\\)::.*$', '\\1', '')
+  return path
 end
 
 return M

--- a/test/lspconfig_spec.lua
+++ b/test/lspconfig_spec.lua
@@ -190,6 +190,29 @@ describe('lspconfig', function()
         ]])
       end)
     end)
+
+    describe('strip_archive_subpath', function()
+      it('strips zipfile subpaths', function()
+        ok(exec_lua [[
+          local lspconfig = require("lspconfig")
+          return lspconfig.util.strip_archive_subpath("zipfile:///one/two.zip::three/four") == "/one/two.zip"
+        ]])
+      end)
+
+      it('strips tarfile subpaths', function()
+        ok(exec_lua [[
+          local lspconfig = require("lspconfig")
+          return lspconfig.util.strip_archive_subpath("tarfile:/one/two.tgz::three/four") == "/one/two.tgz"
+        ]])
+      end)
+
+      it('returns non-archive paths as-is', function()
+        ok(exec_lua [[
+          local lspconfig = require("lspconfig")
+          return lspconfig.util.strip_archive_subpath("/one/two.zip") == "/one/two.zip"
+        ]])
+      end)
+    end)
   end)
   describe('config', function()
     it('normalizes user, server, and base default configs', function()


### PR DESCRIPTION
This change allows attaching to buffers with `zipfile:` or `tarfile:` virtual paths.

A function `util.strip_archive_subpath(path)` was added to extract the archive path from such a virtual path, and `root_dir` for `tsserver` is configured to use it by default. This means the `root_dir` search for TypeScript starts at the archive, instead of doing a real traversal starting from the file *inside* the archive. This is a compromise, because otherwise we'd have to provide a whole bunch of support functionality (currently provided by `vim.loop`) to do the necessary checks inside archives.

I targeted TypeScript for Yarn PnP support, which keeps project dependencies in zip files instead of `node_modules`. I imagine this may also be useful for other languages, like Java with JARs, but I'm really not familiar with those.

An alternative solution I considered was to add behaviour like `strip_archive_subpath` to existing utility functions to accomplish the same, but I'm worried about breaking existing code, and perhaps other language servers need different behaviour.