### PR TITLE
Update pasls config

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -4624,13 +4624,7 @@ require'lspconfig'.pasls.setup{}
   Default Values:
     cmd = { "pasls" }
     filetypes = { "pascal" }
-    root_dir = function(path)
-        -- Support git directories and git files (worktrees)
-        if M.path.is_dir(M.path.join(path, '.git')) or M.path.is_file(M.path.join(path, '.git')) then
-          return path
-        end
-      end)
-    end
+    root_dir = root_pattern("*.lpi", "*.lpk", ".git")
     single_file_support = true
 ```
 

--- a/lua/lspconfig/server_configurations/pasls.lua
+++ b/lua/lspconfig/server_configurations/pasls.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'pasls' },
     filetypes = { 'pascal' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern('*.lpi', '*.lpk', '.git'),
     single_file_support = true,
   },
   docs = {


### PR DESCRIPTION
Hello,

this PR adds `*.lpi` and `*.lpk` files to root directory detection for pasls.
It also syncs the actual default configuration with the documented one.