### PR TITLE
feat(pasls): add lpi and lpk to root dir detection

### DIFF
--- a/lua/lspconfig/server_configurations/pasls.lua
+++ b/lua/lspconfig/server_configurations/pasls.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'pasls' },
     filetypes = { 'pascal' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern('*.lpi', '*.lpk', '.git'),
     single_file_support = true,
   },
   docs = {


### PR DESCRIPTION
Hello,

Pascal projects using [lazbuild](https://wiki.freepascal.org/lazbuild) use [lpi/lpk](https://wiki.freepascal.org/File_extensions) file extensions.
This PR adds them to detect the project root for pasls.