### PR TITLE
feat(als): Show GPS project file in LspInfo

### DIFF
--- a/lua/lspconfig/server_configurations/als.lua
+++ b/lua/lspconfig/server_configurations/als.lua
@@ -10,6 +10,31 @@ return {
     cmd = { bin_name },
     filetypes = { 'ada' },
     root_dir = util.root_pattern('Makefile', '.git', '*.gpr', '*.adc'),
+    lspinfo = function(cfg)
+      local extra = {}
+      local function find_gpr_project()
+        local function split(inputstr, sep)
+          if sep == nil then
+            sep = '%s'
+          end
+          local t = {}
+          for str in string.gmatch(inputstr, '([^' .. sep .. ']+)') do
+            table.insert(t, str)
+          end
+          return t
+        end
+        local projectfiles = split(vim.fn.glob(cfg.root_dir .. '/*.gpr'))
+        if #projectfiles == 0 then
+          return 'None (error)'
+        elseif #projectfiles == 1 then
+          return projectfiles[1]
+        else
+          return 'Ambiguous (error)'
+        end
+      end
+      table.insert(extra, 'GPR project:     ' .. ((cfg.settings.ada or {}).projectFile or find_gpr_project()))
+      return extra
+    end,
   },
   docs = {
     package_json = 'https://raw.githubusercontent.com/AdaCore/ada_language_server/master/integration/vscode/ada/package.json',


### PR DESCRIPTION
Add extra info to the als LspInfo to show which GPR project is being used. When there is none or more than one, LspInfo shows this. In that case, als will not work.

![gpr_display](https://user-images.githubusercontent.com/5008897/151693859-4c3d75cf-e10b-4e20-b2c9-d04b33696fc2.png)