### PR TITLE
fix(leanls): only use lake serve if lakefile.lean exists

### DIFF
--- a/lua/lspconfig/server_configurations/leanls.lua
+++ b/lua/lspconfig/server_configurations/leanls.lua
@@ -12,6 +12,12 @@ return {
       fname = util.path.sanitize(fname)
       local stdlib_dir
       do
+        local _, endpos = fname:find '/src/lean'
+        if endpos then
+          stdlib_dir = fname:sub(1, endpos)
+        end
+      end
+      if not stdlib_dir then
         local _, endpos = fname:find '/lib/lean'
         if endpos then
           stdlib_dir = fname:sub(1, endpos)


### PR DESCRIPTION
This makes the Lean 4 LSP work again on the core lean4 project (which doesn't have a lakefile).

See comments on #1698. cc @Julian 