### PR TITLE
feat: Add slint_lsp

### DIFF
--- a/lua/lspconfig/server_configurations/slint_lsp.lua
+++ b/lua/lspconfig/server_configurations/slint_lsp.lua
@@ -1,0 +1,26 @@
+return {
+  default_config = {
+    cmd = { 'slint-lsp' },
+    filetypes = { 'slint' },
+    single_file_support = true,
+  },
+  docs = {
+    description = [=[
+https://github.com/slint-ui/slint
+`Slint`'s language server
+
+You can build and install `slint-lsp` binary with `cargo`:
+```sh
+cargo install slint-lsp
+```
+
+Vim does not have built-in syntax for the `slint` filetype at this time.
+
+This can be added via an autocmd:
+
+```lua
+vim.cmd [[ autocmd BufRead,BufNewFile *.slint set filetype=slint ]]
+```
+]=],
+  },
+}


### PR DESCRIPTION
We are in the process of renaming our project, so I would love to be able to get the sixtyfps lsp in under its new name.

We will unfortunately need to support both the old and the new one for a while longer, so I would like to get the new one added and will only send a PR to remove the "old" one once no users are left -- if that is OK on your side of course.

I used slint_lsp and not the plain slint since this would be too close to the existing eslint for my taste:-)