### PR TITLE
fix(ansiblels): remove Yaml from ansiblels Filetype

### DIFF
--- a/lua/lspconfig/server_configurations/ansiblels.lua
+++ b/lua/lspconfig/server_configurations/ansiblels.lua
@@ -27,7 +27,7 @@ return {
         },
       },
     },
-    filetypes = { 'yaml', 'yaml.ansible' },
+    filetypes = { 'yaml.ansible' },
     root_dir = util.root_pattern('ansible.cfg', '.ansible-lint'),
     single_file_support = true,
   },


### PR DESCRIPTION
to avoid ansible-lint to pop error on no ansible file (by example kubernetes deploiement)