### PR TITLE
feat: elmls compatibility with elm-tooling

### DIFF
--- a/lua/lspconfig/server_configurations/elmls.lua
+++ b/lua/lspconfig/server_configurations/elmls.lua
@@ -25,9 +25,9 @@ return {
       end
     end,
     init_options = {
-      elmPath = 'elm',
-      elmFormatPath = 'elm-format',
-      elmTestPath = 'elm-test',
+      elmPath = '',
+      elmFormatPath = '',
+      elmTestPath = '',
       elmAnalyseTrigger = 'change',
     },
   },


### PR DESCRIPTION
As stated in the [elm-language-server docs](https://github.com/elm-tooling/elm-language-server#server-settings) – the default value of elm binaries should be an empty string so the language server searches for binaries as local project installs and only use global ones as fallback. If we specify it as the standard "global values" like this config is currently doing, we're just going straight to the fallback, breaking compatibility with local installs.

This change is essential for compatibility with tools like [elm-tooling](https://elm-tooling.github.io/elm-tooling-cli/) which is becoming the standard way of maintaining elm related tools with different versions per project.