### PR TITLE
feat(gopls): added single_file_support config

### DIFF
--- a/lua/lspconfig/server_configurations/gopls.lua
+++ b/lua/lspconfig/server_configurations/gopls.lua
@@ -7,6 +7,7 @@ return {
     root_dir = function(fname)
       return util.root_pattern 'go.work'(fname) or util.root_pattern('go.mod', '.git')(fname)
     end,
+    single_file_support = true,
   },
   docs = {
     description = [[


### PR DESCRIPTION
gopls has supported single file mode as of [https://go-review.googlesource.com/c/tools/+/240099/](https://go-review.googlesource.com/c/tools/+/240099/)

I tested it locally and it works for me. The only weirdness I noticed was that it takes 10-20 seconds for the server to start returning information for single files. Startup is slow in vscode as well, so I assume it is a problem with gopls.