### PR TITLE
docs: update GraphQL instructions

### DIFF
--- a/lua/lspconfig/server_configurations/graphql.lua
+++ b/lua/lspconfig/server_configurations/graphql.lua
@@ -23,6 +23,8 @@ https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service-
 ```sh
 npm install -g graphql-language-service-cli
 ```
+
+Note that you must also have [the graphql package](https://github.com/graphql/graphql-js) installed and create a [GraphQL config file](https://www.graphql-config.com/docs/user/user-introduction).
 ]],
     default_config = {
       root_dir = [[root_pattern('.git', '.graphqlrc*', '.graphql.config.*')]],


### PR DESCRIPTION
Hi there! Thank you for all of your work helping make neovim a powerful tool for developers.

I'm proposing an update to the GraphQL section of the docs. My experience was that the GraphQL language server would exit with an error when I opened a GraphQL file until I made two changes:

1. Globally installed the `graphql` package
2. Created a GraphQL config file in my project's root folder

Adding a note about these needs might help others who run into the same thing.

If it's helpful context, below are the errors I was receiving.

---

Missing module:

```
[ERROR][2022-02-26 17:20:55] .../vim/lsp/rpc.lua:420    "rpc"   "graphql-lsp"   "stderr"        "node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module 'graphql'
Require stack:
- /home/mmirus/.config/yarn/global/node_modules/graphql-language-service-cli/dist/client.js
- /home/mmirus/.config/yarn/global/node_modules/graphql-language-service-cli/dist/cli.js
- /home/mmirus/.config/yarn/global/node_modules/graphql-language-service-cli/bin/graphql.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/home/mmirus/.config/yarn/global/node_modules/graphql-language-service-cli/dist/client.js:8:19)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/mmirus/.config/yarn/global/node_modules/graphql-language-service-cli/dist/client.js',
    '/home/mmirus/.config/yarn/global/node_modules/graphql-language-service-cli/dist/cli.js',
    '/home/mmirus/.config/yarn/global/node_modules/graphql-language-service-cli/bin/graphql.js'
  ]
}
"
```

Missing config:

```
[ERROR][2022-02-26 17:32:20] .../vim/lsp/rpc.lua:420    "rpc"   "graphql-lsp"   "stderr"        "2/26/2022, 5:32:20 PM [1] (pid: 2059291) graphql-language-service-usage-logs: ConfigNotFoundError: GraphQL Config file is not available in the provided config directory: /home/mmirus/git/the-project-folder
Please check the config directory.
"
```