### PR TITLE
fix(lspstop): make LspStop behave as described in the docs

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -395,7 +395,7 @@ end
 
 function M.get_clients_from_cmd_args(arg)
   local result = {}
-  for id in (arg or ''):gmatch '(%d+) %((%w+)%)' do
+  for id in (arg or ''):gmatch '(%d+)' do
     result[id] = vim.lsp.get_client_by_id(tonumber(id))
   end
   if vim.tbl_isempty(result) then


### PR DESCRIPTION
This bug was introduced in #1324.

When calling `:LspStop <args>`, the current code tries to match a string with the format "123 (blablabla)", which will result in terminating the server with ID 123. This is fine when using autocompletion, but if doing this programmatically (or just following the docs) something like `:LspStop 1` will not match anything, resulting in terminating *all* managed servers.

This should be enough to fix the bug, allow terminating multiple servers at once and keeping the nice UX provided by the autocompletion.