### PR TITLE
fix(single_file_support): single_file_support when autostart is unset

### DIFF
--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -44,6 +44,7 @@ function M._root._setup()
     LspStop = {
       function(cmd_args)
         for _, client in ipairs(M.util.get_clients_from_cmd_args(cmd_args)) do
+          vim.api.nvim_command(string.format("silent! autocmd! lspconfig-%s",client.name))
           client.stop()
         end
       end,

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -88,12 +88,18 @@ function configs.__newindex(t, config_name, config_def)
       end
 
       if root_dir then
-        api.nvim_command(
+        api.nvim_exec(
           string.format(
-            "autocmd BufReadPost %s/* unsilent lua require'lspconfig'[%q].manager.try_add_wrapper()",
+            [[
+            augroup lspconfig-%s
+                autocmd!
+                autocmd BufReadPost %s/* unsilent lua require'lspconfig'[%q].manager.try_add_wrapper()
+            augroup END
+            ]],
+            config.name,
             vim.fn.fnameescape(root_dir),
             config.name
-          )
+          ), false
         )
         for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
           local bufname = api.nvim_buf_get_name(bufnr)

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -299,6 +299,12 @@ function M.server_per_root_dir_manager(_make_config)
         table.insert(res, client)
       end
     end
+    for _, id in pairs(single_file_clients) do
+      local client = lsp.get_client_by_id(id)
+      if client then
+        table.insert(res, client)
+      end
+    end
     return res
   end
 


### PR DESCRIPTION
A few minor fixes:
- ~~Do not set `BufReadPost` autocmd when `single_file_support` is set.~~
- Unset per-server `BufReadPost` autocmd on `LspStop`;
- When requesting managed clients, return "single file" clients as well.

---

_Updated according to discussion below._