### PR TITLE
[julials] Let root_dir fallback to the directory of the file

### DIFF
--- a/lua/lspconfig/server_configurations/julials.lua
+++ b/lua/lspconfig/server_configurations/julials.lua
@@ -45,7 +45,8 @@ return {
     cmd = cmd,
     filetypes = { 'julia' },
     root_dir = function(fname)
-      return util.root_pattern 'Project.toml'(fname) or util.find_git_ancestor(fname)
+      return util.root_pattern 'Project.toml'(fname) or util.find_git_ancestor(fname) or
+             util.path.dirname(fname)
     end,
     single_file_support = true,
   },


### PR DESCRIPTION
If the file is not in a git repository, and no Project.toml file is found, this sets root_dir to the directory of the file. Some functionality in LanguageServer.jl is limited to files inside ["workspace folders"](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceFolder). When [rootUri](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize) (`root_dir`) is passed as null to LS.jl this means that no such folders are identified.