### PR TITLE
docs: fix link to section header

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Neovim provides an interface for all of these features, and the language server 
     nvim main.py
     ```
 
-4. See [Keybindings and completion](#Keybindings-and-completion) for mapping useful functions and enabling omnifunc completion
+4. See [Suggested configuration](#Suggested-configuration) for mapping useful functions and enabling omnifunc completion
 
 For a full list of servers, see [server_configurations.md](doc/server_configurations.md) or `:help lspconfig-server-configurations`. This document contains installation instructions and additional, optional, customization suggestions for each language server. For some servers that are not on your system path (e.g., `jdtls`, `elixirls`), you will be required to manually add `cmd` as an entry in the table passed to `setup`. Most language servers can be installed in less than a minute.
 


### PR DESCRIPTION
A heading was renamed in 48f08c10. That broke a link to it from point 4 in the Quickstart section.