### PR TITLE
Update Volar package name in README

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -5199,14 +5199,14 @@ require'lspconfig'.vls.setup{}
 
 ## volar
 
-https://github.com/johnsoncodehk/volar/tree/master/packages/server
+https://github.com/johnsoncodehk/volar/tree/master/packages/vue-language-server
 
 Volar language server for Vue
 
 Volar can be installed via npm:
 
 ```sh
-npm install -g @volar/server
+npm install -g @volar/vue-language-server
 ```
 
 Volar by default supports Vue 3 projects. Vue 2 projects need [additional configuration](https://github.com/johnsoncodehk/volar/blob/master/extensions/vscode-vue-language-features/README.md?plain=1#L28-L63).


### PR DESCRIPTION
The [`@volar/server`](https://github.com/neovim/nvim-lspconfig/pull/1770) NPM package has been renamed to [`@volar/vue-language-server`](https://www.npmjs.com/package/@volar/vue-language-server).

The change to the server config was already made in https://github.com/neovim/nvim-lspconfig/pull/1770 so this is just updating the README.