### PR TITLE
feat(eslint): support yarn2 PnP projects

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -98,6 +98,13 @@ return {
         uri = new_root_dir,
         name = vim.fn.fnamemodify(new_root_dir, ':t'),
       }
+
+      -- Support Yarn2 (PnP) projects
+      local pnp_cjs = util.path.join(new_root_dir, '.pnp.cjs')
+      local pnp_js = util.path.join(new_root_dir, '.pnp.js')
+      if util.path.exists(pnp_cjs) or util.path.exists(pnp_js) then
+        config.cmd = { 'yarn', 'exec', unpack(cmd) }
+      end
     end,
     handlers = {
       ['eslint/openDoc'] = function(_, result)

--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -103,7 +103,7 @@ return {
       local pnp_cjs = util.path.join(new_root_dir, '.pnp.cjs')
       local pnp_js = util.path.join(new_root_dir, '.pnp.js')
       if util.path.exists(pnp_cjs) or util.path.exists(pnp_js) then
-        config.cmd = { 'yarn', 'exec', unpack(cmd) }
+        config.cmd = vim.list_extend({ 'yarn', 'exec' }, cmd)
       end
     end,
     handlers = {


### PR DESCRIPTION
https://yarnpkg.com/features/pnp

Yarn's PnP feature changes the way packages are installed. Instead of building on the `node_modules` resolution, it introduces a single `.pnp.*js` file in the project. This file is responsible for orchestrating and resolving dependencies. The eslint LSP server will assume that regular `node_modules` resolution applies when locating the `eslint` package - which will not work in Yarn PnP projects.

To work around this, Yarn provides the ability to run Node programs in "PnP-compat" mode via `yarn exec` and `yarn node`. My understanding is that this simply hooks into the `require()` function to resolve modules via PnP instead Node's builtin module resolution.