### PR TITLE
feat: allow `:LspStop` and `:LspRestart` commands to apply to current buffer clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,10 @@ Most of the time, the reason for failure is present in the logs.
 
 * `:LspInfo` shows the status of active and configured language servers.
 * `:LspStart <config_name>` Start the requested server name. Will only successfully start if the command detects a root directory matching the current config. Pass `autostart = false` to your `.setup{}` call for a language server if you would like to launch clients solely with this command. Defaults to all servers matching current buffer filetype.
-* `:LspStop <client_id>` Defaults to stopping all buffer clients.
-* `:LspRestart <client_id>` Defaults to restarting all buffer clients.
+* `:LspStop <client_id>` Stops the given client(s), or those for the current buffer if none are given.
+* `:LspStop!` Stop all buffer clients.
+* `:LspRestart <client_id>` Restarts the given client(s), or those for the current buffer if none are given.
+* `:LspRestart!` Restarts all buffer clients.
 
 ## Wiki
 

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -76,10 +76,10 @@ function configs.__newindex(t, config_name, config_def)
 
     local get_root_dir = config.root_dir
 
-    function M.launch()
+    function M.launch(init_bufnr)
       local root_dir
       if get_root_dir then
-        local bufnr = api.nvim_get_current_buf()
+        local bufnr = init_bufnr or api.nvim_get_current_buf()
         local bufname = api.nvim_buf_get_name(bufnr)
         if not util.bufname_valid(bufname) then
           return


### PR DESCRIPTION
This makes the argument `0` mean to stop or restart all clients for the current buffer, which is useful since it would seem common to want to restrict these commands to a certain buffer, but you rarely know what the specific IDs of the clients are.

Closes #1781.