### PR TITLE
fix: fix for using no-argument `:LspStop` and `:LspRestart` with standalone files

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -88,6 +88,7 @@ function configs.__newindex(t, config_name, config_def)
       end
 
       if root_dir then
+        -- Lazy-launching: attach when a buffer in this directory is opened.
         api.nvim_command(
           string.format(
             "autocmd BufReadPost %s/* unsilent lua require'lspconfig'[%q].manager.try_add_wrapper()",
@@ -95,6 +96,7 @@ function configs.__newindex(t, config_name, config_def)
             config.name
           )
         )
+        -- Attach for all existing buffers in this directory.
         for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
           local bufname = api.nvim_buf_get_name(bufnr)
           if util.bufname_valid(bufname) then
@@ -159,7 +161,7 @@ function configs.__newindex(t, config_name, config_def)
           client.offset_encoding = result.offsetEncoding
         end
 
-        -- Send `settings to server via workspace/didChangeConfiguration
+        -- Send `settings` to server via workspace/didChangeConfiguration
         function client.workspace_did_change_configuration(settings)
           if not settings then
             return
@@ -208,6 +210,8 @@ function configs.__newindex(t, config_name, config_def)
       return make_config(_root_dir)
     end)
 
+    -- Try to attach the buffer `bufnr` to a client using this config, creating
+    -- a new client if one doesn't already exist for `bufnr`.
     function manager.try_add(bufnr)
       bufnr = bufnr or api.nvim_get_current_buf()
 
@@ -240,6 +244,8 @@ function configs.__newindex(t, config_name, config_def)
       end
     end
 
+    -- Check that the buffer `bufnr` has a valid filetype according to
+    -- `config.filetypes`, then do `manager.try_add(bufnr)`.
     function manager.try_add_wrapper(bufnr)
       bufnr = bufnr or api.nvim_get_current_buf()
       local buf_filetype = vim.api.nvim_buf_get_option(bufnr, 'filetype')
@@ -250,6 +256,7 @@ function configs.__newindex(t, config_name, config_def)
             return
           end
         end
+      -- `config.filetypes = nil` means all filetypes are valid.
       else
         manager.try_add(bufnr)
       end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -291,9 +291,10 @@ function M.server_per_root_dir_manager(_make_config)
     return client_id
   end
 
-  function manager.clients()
+  function manager.clients(single_file)
     local res = {}
-    for _, id in pairs(clients) do
+    local client_list = single_file and single_file_clients or clients
+    for _, id in pairs(client_list) do
       local client = lsp.get_client_by_id(id)
       if client then
         table.insert(res, client)
@@ -418,6 +419,7 @@ function M.get_managed_clients()
   for _, config in pairs(configs) do
     if config.manager then
       vim.list_extend(clients, config.manager.clients())
+      vim.list_extend(clients, config.manager.clients(true))
     end
   end
   return clients


### PR DESCRIPTION
The no-argument versions of `:LspStop` and `:LspRestart` currently only apply to buffers that have a valid root directory. It seems that these commands should stop/restart all clients, including those associated with standalone files.

Closes #1784.