### PR TITLE
fix(beancount-langserver): add stdio flag to cmd

### DIFF
--- a/lua/lspconfig/server_configurations/beancount.lua
+++ b/lua/lspconfig/server_configurations/beancount.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'beancount-langserver' },
+    cmd = { 'beancount-langserver', '--stdio' },
     filetypes = { 'beancount' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,


### PR DESCRIPTION
The Beancount language server requires the `--stdio` flag to work with Neovim. This should be the default, requiring less configuration by the user.

Fixes https://github.com/polarmutex/beancount-language-server/issues/49