### PR TITLE
fix(hoon-language-server): remove example

### DIFF
--- a/lua/lspconfig/server_configurations/hoon_ls.lua
+++ b/lua/lspconfig/server_configurations/hoon_ls.lua
@@ -24,13 +24,6 @@ The language server can be installed via `npm install -g hoon-language-server`
 
 Install and build Urbit. Then, start a fake ~zod with `urbit -lF zod -c zod`.
 And start the language server at the Urbit Dojo prompt with: `|start %language-server`
-
-If your ship does not run on port 8080 change the `cmd` setting:
-
-```lua
-require'lspconfig'.elixirls.setup{
-    cmd = { 'hoon-language-server', '-p', '80' }
-}
 ```
 ]],
   },


### PR DESCRIPTION
Example of how to use the 'cmd' setting is not needed.
Also the name of the language server in this example is wrong.