### PR TITLE
fix #1781: LspStop applies to current buffer

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -399,7 +399,7 @@ function M.get_clients_from_cmd_args(arg)
     result[id] = vim.lsp.get_client_by_id(tonumber(id))
   end
   if vim.tbl_isempty(result) then
-    return M.get_managed_clients()
+    result = vim.lsp.buf_get_clients()
   end
   return vim.tbl_values(result)
 end


### PR DESCRIPTION
As per documentation. Currently stopping all managed clients on all
buffers.