### PR TITLE
fix(hoon-language-server): update cmd and docs

### DIFF
--- a/lua/lspconfig/server_configurations/hoon_ls.lua
+++ b/lua/lspconfig/server_configurations/hoon_ls.lua
@@ -1,10 +1,10 @@
 local util = require 'lspconfig.util'
 
 local bin_name = 'hoon-language-server'
-local cmd = { bin_name, '-p', '8080' }
+local cmd = { bin_name }
 
 if vim.fn.has 'win32' == 1 then
-  cmd = { 'cmd.exe', '/C', bin_name, '-p', '8080' }
+  cmd = { 'cmd.exe', '/C', bin_name }
 end
 
 return {
@@ -20,11 +20,10 @@ https://github.com/urbit/hoon-language-server
 
 A language server for Hoon.
 
-The language server can be installed via `npm install -g hoon-language-server`
+The language server can be installed via `npm install -g @hoon-language-server`
 
-Install and build Urbit. Then, start a fake ~zod with `urbit -lF zod -c zod`.
-And start the language server at the Urbit Dojo prompt with: `|start %language-server`
-```
+Start a fake ~zod with `urbit -F zod`.
+Start the language server at the Urbit Dojo prompt with: `|start %language-server`
 ]],
   },
 }


### PR DESCRIPTION
Remove CMD parameters for which the language server provides defaults.
Make docs simpler.
Remove markdown code fences.