### PR TITLE
Allow autostart to be a callback

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -134,11 +134,18 @@ listed in `:help vim.lsp.start_client()` with the following unique entries:
 
 - {autostart}
 
-    `bool` (default: true)
+    `bool | function(root_dir, path_utils) (default: true)`
 
     Controls if the `FileType` autocommand that launches a language server is
     created. If `false`, allows for deferring language servers until manually
     launched with `:LspStart` (|lspconfig-commands|).
+
+    If a callback function is given instead of a boolean, the `FileType`
+    autocommand is created as if the value was true. However the callback will
+    run on matching filetypes with the calculated root directory and a small
+    collection of path utilities. They can be used to determine if the
+    language server is sutible for the current project. The server will only
+    be started if this function returns `true`.
 
 - {single_file_support}
 

--- a/lua/lspconfig/server_configurations/sorbet.lua
+++ b/lua/lspconfig/server_configurations/sorbet.lua
@@ -5,6 +5,9 @@ return {
     cmd = { 'srb', 'tc', '--lsp' },
     filetypes = { 'ruby' },
     root_dir = util.root_pattern('Gemfile', '.git'),
+    autostart = function(root_dir, path_utils)
+      return path_utils.exists(path_utils.sanitize(root_dir .. '/sorbet'))
+    end,
   },
   docs = {
     description = [[
@@ -20,7 +23,10 @@ gem install sorbet
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("Gemfile", ".git")]],
+      root_dir = [[root_pattern('Gemfile', '.git')]],
+      autostart = [[function(root_dir, path_utils)
+  return path_utils.exists(path_utils.sanitize(root_dir .. '/sorbet'))
+end]],
     },
   },
 }

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -47,7 +47,9 @@ local function make_config_info(config)
 
   local buffer_dir = vim.fn.expand '%:p:h'
   config_info.root_dir = config.get_root_dir(buffer_dir) or 'NA'
-  config_info.autostart = (config.autostart and 'true') or 'false'
+  config_info.autostart = (type(config.autostart) == 'function' and 'function')
+    or (config.autostart and 'true')
+    or 'false'
   config_info.handlers = table.concat(vim.tbl_keys(config.handlers), ', ')
   config_info.filetypes = table.concat(config.filetypes or {}, ', ')
 


### PR DESCRIPTION
**Motivation:**
Unlike Solargraph (and probably most other servers), Sorbet is not a general-purpose Ruby language server. A project must have a `sorbet` directory at the root for the server to start, otherwise it will error out. It's very nice when the server autostarts on my projects that use sorbet! But it's annoying when it fails and prints error messages on other random ruby projects that do not.

So it would be nice if the server only was auto started on suitable projects. It would also be nice if checking for suitability was done only in ruby projects, and not all the time. I don’t know much about all the different language servers, but I figure that there may also be other servers that may benefit from deferring the decision to auto start based on the project. 

**This PR has two patches:**

The first adds the ability for `autostart` to be a callback in addition to the boolean it has been. The function is called with the calculated root directly. I also pass in the path section of the utils functions since it seems like it will often be needed to poke around in the root directory to see if it's a good project for the language server or not.

The second patch uses this new callback feature on the sorbet server so that it only autostarts appropriately. 