### PR TITLE
ci: fix new v0.26.0 luacheck errors

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -136,7 +136,7 @@ function configs.__newindex(t, config_name, config_def)
       M.manager = nil
     end
 
-    local make_config = function(_root_dir)
+    local make_config = function(root_dir)
       local new_config = vim.tbl_deep_extend('keep', vim.empty_dict(), config)
       new_config = vim.tbl_deep_extend('keep', new_config, default_config)
       new_config.capabilities = new_config.capabilities or lsp.protocol.make_client_capabilities()
@@ -147,10 +147,10 @@ function configs.__newindex(t, config_name, config_def)
       })
 
       if config_def.on_new_config then
-        pcall(config_def.on_new_config, new_config, _root_dir)
+        pcall(config_def.on_new_config, new_config, root_dir)
       end
       if config.on_new_config then
-        pcall(config.on_new_config, new_config, _root_dir)
+        pcall(config.on_new_config, new_config, root_dir)
       end
 
       new_config.on_init = util.add_hook_after(new_config.on_init, function(client, result)
@@ -194,18 +194,18 @@ function configs.__newindex(t, config_name, config_def)
         end
       end)
 
-      new_config.root_dir = _root_dir
+      new_config.root_dir = root_dir
       new_config.workspace_folders = {
         {
-          uri = vim.uri_from_fname(_root_dir),
-          name = string.format('%s', _root_dir),
+          uri = vim.uri_from_fname(root_dir),
+          name = string.format('%s', root_dir),
         },
       }
       return new_config
     end
 
-    local manager = util.server_per_root_dir_manager(function(_root_dir)
-      return make_config(_root_dir)
+    local manager = util.server_per_root_dir_manager(function(root_dir)
+      return make_config(root_dir)
     end)
 
     function manager.try_add(bufnr)
@@ -257,7 +257,7 @@ function configs.__newindex(t, config_name, config_def)
 
     M.manager = manager
     M.make_config = make_config
-    if reload and not (config.autostart == false) then
+    if reload and config.autostart ~= false then
       for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
         manager.try_add_wrapper(bufnr)
       end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -222,7 +222,7 @@ end)()
 
 -- Returns a function(root_dir), which, when called with a root_dir it hasn't
 -- seen before, will call make_config(root_dir) and start a new client.
-function M.server_per_root_dir_manager(_make_config)
+function M.server_per_root_dir_manager(make_config)
   local clients = {}
   local single_file_clients = {}
   local manager = {}
@@ -242,7 +242,7 @@ function M.server_per_root_dir_manager(_make_config)
 
     -- Check if we have a client already or start and store it.
     if not client_id then
-      local new_config = _make_config(root_dir)
+      local new_config = make_config(root_dir)
       -- do nothing if the client is not enabled
       if new_config.enabled == false then
         return


### PR DESCRIPTION
This was seemingly added in v0.26.0 (released 4 days ago) of luacheck: https://github.com/lunarmodules/luacheck/releases/tag/v0.26.0

    lua/lspconfig/util.lua:225:40: used variable _make_config
    lua/lspconfig/configs.lua:207:63: used variable _root_dir