### PR TITLE
fix(lua-server): update root-markers

### DIFF
--- a/lua/lspconfig/server_configurations/sumneko_lua.lua
+++ b/lua/lspconfig/server_configurations/sumneko_lua.lua
@@ -1,10 +1,18 @@
 local util = require 'lspconfig.util'
 
+local root_files = {
+  '.luarc.json',
+  '.luacheckrc',
+  '.stylua.toml',
+  'selene.toml',
+}
 return {
   default_config = {
     cmd = { 'lua-language-server' },
     filetypes = { 'lua' },
-    root_dir = util.find_git_ancestor,
+    root_dir = function(fname)
+      return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
+    end,
     single_file_support = true,
     log_level = vim.lsp.protocol.MessageType.Warning,
     settings = { Lua = { telemetry = { enable = false } } },
@@ -49,7 +57,7 @@ require'lspconfig'.sumneko_lua.setup {
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git") or bufdir]],
+      root_dir = [[root_pattern(".luarc.json", ".luacheckrc", ".stylua.toml", "selene.toml", ".git")]],
     },
   },
 }


### PR DESCRIPTION
Update root-markers for lua-language-server

- `.luarc.json`: https://github.com/sumneko/lua-language-server/wiki/Setting#sources
- [optional] `.luarcheckrc`: https://luacheck.readthedocs.io/en/stable/config.html
- [optional] `.stylua.toml`: https://github.com/JohnnyMorganz/StyLua#finding-the-configuration
- [optional] `selene.toml`: https://kampfkarren.github.io/selene/cli/usage.html

