### PR TITLE
fix(beancount): remove --stdio arg

### DIFF
--- a/lua/lspconfig/server_configurations/beancount.lua
+++ b/lua/lspconfig/server_configurations/beancount.lua
@@ -20,7 +20,7 @@ https://github.com/polarmutex/beancount-language-server#installation
 See https://github.com/polarmutex/beancount-language-server#configuration for configuration options
 ]],
     default_config = {
-      root_dir = [[root_pattern("elm.json")]],
+      root_dir = [[root_pattern(".git")]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/beancount.lua
+++ b/lua/lspconfig/server_configurations/beancount.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'beancount-langserver', '--stdio' },
+    cmd = { 'beancount-langserver' },
     filetypes = { 'beancount' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,


### PR DESCRIPTION
Seems like the `--stdio` arg is not needed:

```
[ERROR][2022-04-12 18:39:14] .../vim/lsp/rpc.lua:420	"rpc"	"beancount-langserver"	"stderr"	"error: Found argument '--stdio' which wasn't expected, or isn't valid in this context\n\n\tIf you tried to supply `--stdio` as a value rather than a flag, use `-- --stdio`\n\nUSAGE:\n    beancount-langserver\n\nFor more information try --help\n"
```

https://github.com/polarmutex/beancount-language-server#installation