### PR TITLE
fix(clarity_lsp): remove .cmd suffix for Windows

### DIFF
--- a/lua/lspconfig/server_configurations/clarity_lsp.lua
+++ b/lua/lspconfig/server_configurations/clarity_lsp.lua
@@ -1,13 +1,8 @@
 local util = require 'lspconfig.util'
 
-local bin_name = 'clarity-lsp'
-if vim.fn.has 'win32' == 1 then
-  bin_name = bin_name .. '.cmd'
-end
-
 return {
   default_config = {
-    cmd = { bin_name },
+    cmd = { 'clarity-lsp' },
     filetypes = { 'clar', 'clarity' },
     root_dir = util.root_pattern '.git',
   },


### PR DESCRIPTION
The prebuilt executables distributed via GitHub releases (https://github.com/hirosystems/clarity-lsp/releases) are binaries - with the Windows variant being `clarity-lsp.exe`. If building from source (Rust), it will also produce a `clarity-lsp.exe` binary.