### PR TITLE
fix(ccls): remove .git from root_dir

### DIFF
--- a/lua/lspconfig/server_configurations/ccls.lua
+++ b/lua/lspconfig/server_configurations/ccls.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'ccls' },
     filetypes = { 'c', 'cpp', 'objc', 'objcpp' },
-    root_dir = util.root_pattern('compile_commands.json', '.ccls', '.git'),
+    root_dir = util.root_pattern('compile_commands.json', '.ccls'),
     offset_encoding = 'utf-32',
     -- ccls does not support sending a null root directory
     single_file_support = false,


### PR DESCRIPTION
CCLS does not use .git to identify the root of a project. In addition, it
causes issues with projects that are based on the repo tool (e.g. AOSP),
which generates `.git` symlinks in many places in the source tree. In
such cases, CCLS incorrectly identifies subdirectories as the root.