### PR TITLE
fix(ccls): .git as fallback when detecting project root

### DIFF
--- a/lua/lspconfig/server_configurations/ccls.lua
+++ b/lua/lspconfig/server_configurations/ccls.lua
@@ -1,10 +1,17 @@
 local util = require 'lspconfig.util'
 
+local root_files = {
+  'compile_commands.json',
+  '.ccls',
+}
+
 return {
   default_config = {
     cmd = { 'ccls' },
     filetypes = { 'c', 'cpp', 'objc', 'objcpp' },
-    root_dir = util.root_pattern('compile_commands.json', '.ccls', '.git'),
+    root_dir = function(fname)
+      return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
+    end,
     offset_encoding = 'utf-32',
     -- ccls does not support sending a null root directory
     single_file_support = false,
@@ -37,7 +44,9 @@ lspconfig.ccls.setup {
 
 ]],
     default_config = {
-      root_dir = [[root_pattern("compile_commands.json", ".ccls", ".git")]],
+      root_dir = function(fname)
+        return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
+      end,
     },
   },
 }


### PR DESCRIPTION
Use `.git` as fallback for detecting the project root in ccls, while preferring folders with `compile_commands.json` or `.ccls`. Behavior is identical to that from `clangd.lua`.