### PR TITLE
docs(reason_ls): remove invalid comment regarding cmd

### DIFF
--- a/lua/lspconfig/server_configurations/reason_ls.lua
+++ b/lua/lspconfig/server_configurations/reason_ls.lua
@@ -10,14 +10,7 @@ return {
     description = [[
 Reason language server
 
-**By default, reason_ls doesn't have a `cmd` set.** This is because nvim-lspconfig does not make assumptions about your path.
-You have to install the language server manually.
-
 You can install reason language server from [reason-language-server](https://github.com/jaredly/reason-language-server) repository.
-
-```lua
-cmd = {'<path_to_reason_language_server>'}
-```
 ]],
   },
 }


### PR DESCRIPTION
This server config does in fact provide a default `cmd`!