### PR TITLE
fix(eslint): add missing root_pattern

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -63,6 +63,7 @@ return {
     },
     -- https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats
     root_dir = util.root_pattern(
+      '.eslintrc',
       '.eslintrc.js',
       '.eslintrc.cjs',
       '.eslintrc.yaml',


### PR DESCRIPTION
Even though this file name was removed from the official docs
https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats

Eslint still supports the older `.eslintrc` and it is used in tests
https://github.com/eslint/eslint/blob/9ecd42f36462331a0d697e74323a4d24f0cf02fc/tests/fixtures/.eslintrc

The loading is done by the legacy package `@eslint/eslintrc` that is
still used by eslint itself

```
~/Documents/repositories/eslint
$ npm instll && rg '".eslintrc"' ./node_modules/@eslint/eslintrc/lib -B 6
./node_modules/@eslint/eslintrc/lib/config-array-factory.js
66-const configFilenames = [
67-    ".eslintrc.js",
68-    ".eslintrc.cjs",
69-    ".eslintrc.yaml",
70-    ".eslintrc.yml",
71-    ".eslintrc.json",
72:    ".eslintrc",
```