### PR TITLE
docs: add an entry about the setup-hook

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -267,6 +267,28 @@ The global defaults for all servers can be overridden by extending the
 `setup {}` can additionally override these defaults in subsequent calls.
 
 ==============================================================================
+SETUP HOOK                                                *lspconfig-setup-hook*
+
+`lspconfig` will execute the `on_setup` hook for each setup call to a server after
+validating its configuration, and before attempting to launch the server
+itself. One typical usage is to allow ad-hoc substitution for any
+configuration entry, such as `cmd`.
+
+>
+  local lspconfig = require 'lspconfig'
+  lspconfig.util.on_setup = util.add_hook_before(lspconfig.util.on_setup, function(config)
+    if some_condition and config.name == "clangd" then
+      local custom_server_prefix = "/my/custom/server/prefix"
+      config.cmd = { custom_server_prefix .. "/bin/clangd" }
+    end
+  end)
+
+
+Note: This is primarily targeted at plugins developers, so make sure to use
+`util.add_hook_before()` as a wrapper instead of overriding the original function
+completely, to void breaking external integrations with lspconfig.
+
+==============================================================================
 SERVER CONFIGURATIONS                                 *lspconfig-configurations*
 
 See |lspconfig-server-configurations| by typing `K` over it for the complete


### PR DESCRIPTION
<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->

The `on_setup` hook is currently undocumented, and it should gain some attention after https://github.com/williamboman/nvim-lsp-installer/pull/631
