### PR TITLE
fix(beancount): fix beancount start command and config

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -524,28 +524,18 @@ require'lspconfig'.beancount.setup{}
 **Default values:**
   - `cmd` : 
   ```lua
-  { "beancount-langserver", "--stdio" }
+  { "beancount-language-server", "--stdio" }
   ```
   - `filetypes` : 
   ```lua
-  { "beancount" }
+  { "beancount", "bean" }
   ```
   - `init_options` : 
   ```lua
   {
-    journalFile = "",
-    pythonPath = "python3"
+    journal_file = ""
   }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("elm.json")
-  ```
-  - `single_file_support` : 
-  ```lua
-  true
-  ```
-
 
 ## bicep
 

--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -524,26 +524,21 @@ require'lspconfig'.beancount.setup{}
 **Default values:**
   - `cmd` : 
   ```lua
-  { "beancount-langserver", "--stdio" }
+  { "beancount-language-server", "--stdio" }
   ```
   - `filetypes` : 
   ```lua
-  { "beancount" }
+  { "beancount", "bean" }
   ```
   - `init_options` : 
   ```lua
   {
-    journalFile = "",
-    pythonPath = "python3"
+    journel_file = "",
   }
   ```
   - `root_dir` : 
   ```lua
   root_pattern("elm.json")
-  ```
-  - `single_file_support` : 
-  ```lua
-  true
   ```
 
 

--- a/lua/lspconfig/server_configurations/beancount.lua
+++ b/lua/lspconfig/server_configurations/beancount.lua
@@ -2,15 +2,12 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'beancount-langserver', '--stdio' },
-    filetypes = { 'beancount' },
+    cmd = { 'beancount-language-server', '--stdio' },
+    filetypes = { 'beancount', 'bean' },
     root_dir = util.find_git_ancestor,
-    single_file_support = true,
     init_options = {
       -- this is the path to the beancout journal file
-      journalFile = '',
-      -- this is the path to the python binary with beancount installed
-      pythonPath = 'python3',
+      journel_file = '',
     },
   },
   docs = {


### PR DESCRIPTION
The start up command and default config has changed a lot since the owner has refactored the code using rust. This pr will cover the change below.

1. Start up command change, should be `beancount-language-server` now.
2. Some config is not used anymore. And the only config used is `journal_file`(Previously it's camel case).