### PR TITLE
fix(beancount): fix beancount start command and config

### DIFF
--- a/lua/lspconfig/server_configurations/beancount.lua
+++ b/lua/lspconfig/server_configurations/beancount.lua
@@ -7,7 +7,7 @@ return {
     root_dir = util.find_git_ancestor,
     init_options = {
       -- this is the path to the beancout journal file
-      journel_file = '',
+      journalFile = '',
     },
   },
   docs = {
@@ -17,7 +17,7 @@ https://github.com/polarmutex/beancount-language-server#installation
 See https://github.com/polarmutex/beancount-language-server#configuration for configuration options
 ]],
     default_config = {
-      root_dir = [[root_pattern("elm.json")]],
+      root_dir = [[root_pattern(".git")]]
     },
   },
 }

--- a/lua/lspconfig/server_configurations/beancount.lua
+++ b/lua/lspconfig/server_configurations/beancount.lua
@@ -18,7 +18,7 @@ https://github.com/polarmutex/beancount-language-server#installation
 See https://github.com/polarmutex/beancount-language-server#configuration for configuration options
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git")]]
+      root_dir = [[root_pattern(".git")]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/beancount.lua
+++ b/lua/lspconfig/server_configurations/beancount.lua
@@ -5,6 +5,7 @@ return {
     cmd = { 'beancount-language-server', '--stdio' },
     filetypes = { 'beancount', 'bean' },
     root_dir = util.find_git_ancestor,
+    single_file_support = true,
     init_options = {
       -- this is the path to the beancout journal file
       journalFile = '',

--- a/lua/lspconfig/server_configurations/beancount.lua
+++ b/lua/lspconfig/server_configurations/beancount.lua
@@ -2,15 +2,12 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'beancount-langserver', '--stdio' },
-    filetypes = { 'beancount' },
+    cmd = { 'beancount-language-server', '--stdio' },
+    filetypes = { 'beancount', 'bean' },
     root_dir = util.find_git_ancestor,
-    single_file_support = true,
     init_options = {
       -- this is the path to the beancout journal file
-      journalFile = '',
-      -- this is the path to the python binary with beancount installed
-      pythonPath = 'python3',
+      journel_file = '',
     },
   },
   docs = {


### PR DESCRIPTION
The start up command and default config has changed a lot since the owner has refactored the code using rust. This pr will cover the change below.

Start up command change, should be beancount-language-server now.
Some config is not used anymore. And the only config used is journal_file(Previously it's camel case).