### PR TITLE
ocamllsp: add support for the dune filetype

### DIFF
--- a/lua/lspconfig/server_configurations/ocamllsp.lua
+++ b/lua/lspconfig/server_configurations/ocamllsp.lua
@@ -6,6 +6,7 @@ local language_id_of = {
   ocamlinterface = 'ocaml.interface',
   ocamllex = 'ocaml.ocamllex',
   reason = 'reason',
+  dune = 'dune'
 }
 
 local get_language_id = function(_, ftype)
@@ -15,7 +16,7 @@ end
 return {
   default_config = {
     cmd = { 'ocamllsp' },
-    filetypes = { 'ocaml', 'ocaml.menhir', 'ocaml.interface', 'ocaml.ocamllex', 'reason' },
+    filetypes = { 'ocaml', 'ocaml.menhir', 'ocaml.interface', 'ocaml.ocamllex', 'reason', 'dune' },
     root_dir = util.root_pattern('*.opam', 'esy.json', 'package.json', '.git'),
     get_language_id = get_language_id,
   },

--- a/lua/lspconfig/server_configurations/ocamllsp.lua
+++ b/lua/lspconfig/server_configurations/ocamllsp.lua
@@ -17,7 +17,7 @@ return {
   default_config = {
     cmd = { 'ocamllsp' },
     filetypes = { 'ocaml', 'ocaml.menhir', 'ocaml.interface', 'ocaml.ocamllex', 'reason', 'dune' },
-    root_dir = util.root_pattern('*.opam', 'esy.json', 'package.json', '.git'),
+    root_dir = util.root_pattern('*.opam', 'esy.json', 'package.json', '.git', 'dune-project', 'dune-workspace'),
     get_language_id = get_language_id,
   },
   docs = {
@@ -33,7 +33,7 @@ opam install ocaml-lsp-server
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("*.opam", "esy.json", "package.json", ".git")]],
+      root_dir = [[root_pattern("*.opam", "esy.json", "package.json", ".git", "dune-project", "dune-workspace")]],
     },
   },
 }


### PR DESCRIPTION
https://github.com/ocaml/ocaml-lsp/blob/master/CHANGES.md#fixes-1 ocaml-lsp-server 1.11.3 supports the `dune` filetype.
One has to run `dune build --watch` in order to take advantage of it (and then you get diagnostics  about wrong syntax when you save the file, as usual for a language server) : the language server relies on an RPC with the build system for `dune` file support.

Also improve the dune filetype detection.

cc @undu 