### PR TITLE
feat: add glint-language-server support

### DIFF
--- a/lua/lspconfig/server_configurations/glint.lua
+++ b/lua/lspconfig/server_configurations/glint.lua
@@ -1,0 +1,36 @@
+local util = require 'lspconfig.util'
+
+local bin_name = 'glint-language-server'
+
+-- Glint should not be installed globally.
+local path_to_node_modules = util.find_node_modules_ancestor(vim.fn.getcwd())
+
+local cmd = { path_to_node_modules .. '/node_modules/.bin/' .. bin_name }
+
+return {
+  default_config = {
+    cmd = cmd,
+    filetypes = {
+      'html.handlebars',
+      'handlebars',
+      'typescript',
+      'typescript.glimmer',
+      'javascript',
+      'javascript.glimmer',
+    },
+    root_dir = util.root_pattern '.glintrc.yml',
+  },
+  docs = {
+    description = [[
+  https://github.com/typed-ember/glint
+
+  https://typed-ember.gitbook.io/glint/
+
+  `glint-language-server` is installed when adding `@glint/core` to your project's devDependencies:
+
+  ```sh
+  yarn add -D @glint/core
+  ```
+]],
+  },
+}

--- a/lua/lspconfig/server_configurations/glint.lua
+++ b/lua/lspconfig/server_configurations/glint.lua
@@ -29,7 +29,19 @@ return {
   `glint-language-server` is installed when adding `@glint/core` to your project's devDependencies:
 
   ```sh
+  npm install @glint/core --save-dev
+  ```
+
+  or
+
+  ```sh
   yarn add -D @glint/core
+  ```
+
+  or
+
+  ```sh
+  pnpm add -D @glint/core
   ```
 ]],
   },


### PR DESCRIPTION
I've tried to implement glint-language-server support. It's a little tricky, because the glint documentation advises _against_ installing glint globally, so I had to come up with a different way to find the binary.