### PR TITLE
fix(glint): detect project dir inside `on_new_config` hook rather than at module import

### DIFF
--- a/lua/lspconfig/server_configurations/glint.lua
+++ b/lua/lspconfig/server_configurations/glint.lua
@@ -1,15 +1,26 @@
 local util = require 'lspconfig.util'
 
 local bin_name = 'glint-language-server'
+local cmd = { bin_name }
 
--- Glint should not be installed globally.
-local path_to_node_modules = util.find_node_modules_ancestor(vim.fn.getcwd())
-
-local cmd = { path_to_node_modules .. '/node_modules/.bin/' .. bin_name }
+if vim.fn.has 'win32' == 1 then
+  cmd = { 'cmd.exe', '/C', bin_name }
+end
 
 return {
   default_config = {
     cmd = cmd,
+    on_new_config = function(config, new_root_dir)
+      local project_root = util.find_node_modules_ancestor(new_root_dir)
+      -- Glint should not be installed globally.
+      local node_bin_path = util.path.join(project_root, 'node_modules', '.bin')
+      local path = node_bin_path .. util.path.path_separator .. vim.env.PATH
+      if config.cmd_env then
+        config.cmd_env.PATH = path
+      else
+        config.cmd_env = { PATH = path }
+      end
+    end,
     filetypes = {
       'html.handlebars',
       'handlebars',

--- a/lua/lspconfig/server_configurations/glint.lua
+++ b/lua/lspconfig/server_configurations/glint.lua
@@ -29,7 +29,14 @@ return {
       'javascript',
       'javascript.glimmer',
     },
-    root_dir = util.root_pattern '.glintrc.yml',
+    root_dir = util.root_pattern(
+      '.glintrc.yml',
+      '.glintrc',
+      '.glintrc.json',
+      '.glintrc.js',
+      'glint.config.js',
+      'package.json'
+    ),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -207,6 +207,8 @@ M.path = (function()
     return dir == root
   end
 
+  local path_separator = is_windows and ';' or ':'
+
   return {
     is_dir = is_dir,
     is_file = is_file,
@@ -218,6 +220,7 @@ M.path = (function()
     traverse_parents = traverse_parents,
     iterate_parents = iterate_parents,
     is_descendant = is_descendant,
+    path_separator = path_separator,
   }
 end)()
 


### PR DESCRIPTION
This changes the configuration to detect the project's `node_modules` dir every time lspconfig detects a new workspace directory (so in short, allows the server to attach to multiple projects in one session).

Not sure if setting the `PATH` like this is desirable. I did it to get a normalized `cmd`, I think it makes it easier for users to customize the cmd should they want to.

Also updates the root_dir pattern according to https://github.com/typed-ember/glint/blob/main/packages/config/README.md#config-specification