### PR TITLE
Update Fortran's fortls

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -1840,10 +1840,11 @@ require'lspconfig'.foam_ls.setup{}
 
 ## fortls
 
-https://github.com/hansec/fortran-language-server
+https://github.com/gnikit/fortls
 
-Fortran Language Server for the Language Server Protocol
-    
+fortls is a Fortran Language Server, settings to the server can be passed either
+through `cmd` or through a local configuration file. For more information
+see the `fortls` [documentation](https://gnikit.github.io/fortls/options.html).
 
 
 **Snippet to enable the language server:**
@@ -1855,7 +1856,7 @@ require'lspconfig'.fortls.setup{}
 **Default values:**
   - `cmd` : 
   ```lua
-  { "fortls" }
+    { "fortls", "--notify_init", "--hover_signature", "--hover_language=fortran", "--use_signature_help" }
   ```
   - `filetypes` : 
   ```lua
@@ -1864,12 +1865,6 @@ require'lspconfig'.fortls.setup{}
   - `root_dir` : 
   ```lua
   root_pattern(".fortls")
-  ```
-  - `settings` : 
-  ```lua
-  {
-    nthreads = 1
-  }
   ```
 
 

--- a/lua/lspconfig/server_configurations/fortls.lua
+++ b/lua/lspconfig/server_configurations/fortls.lua
@@ -2,20 +2,24 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'fortls' },
+    cmd = {
+      'fortls',
+      '--notify_init',
+      '--hover_signature',
+      '--hover_language=fortran',
+      '--use_signature_help',
+    },
     filetypes = { 'fortran' },
     root_dir = function(fname)
       return util.root_pattern '.fortls'(fname) or util.find_git_ancestor(fname)
     end,
-    settings = {
-      nthreads = 1,
-    },
+    settings = {},
   },
   docs = {
     description = [[
-https://github.com/hansec/fortran-language-server
+https://github.com/gnikit/fortls
 
-Fortran Language Server for the Language Server Protocol
+fortls - Fortran Language Server
     ]],
     default_config = {
       root_dir = [[root_pattern(".fortls")]],


### PR DESCRIPTION
---
name: Pull Request
about: Submit a pull request
title: 'Update fortls server and arguments'
---

<!--
If you want to make changes to the README.md, do so in scripts/README_template.md.
The CONFIG.md is auto-generated with all the options from the various LSP configuration;
do not edit it manually
-->


As you can see `settings` and `init_options` are not currently supported (I will get to it at some point), so the arguments to the server have to be passed via the `cmd` option.

PS from what I could tell the docs are autogenerated so I did not edit them.