### PR TITLE
fix(fortls): update server and default cmd args

### DIFF
--- a/lua/lspconfig/server_configurations/fortls.lua
+++ b/lua/lspconfig/server_configurations/fortls.lua
@@ -2,20 +2,32 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'fortls' },
+    cmd = {
+      'fortls',
+      '--notify_init',
+      '--hover_signature',
+      '--hover_language=fortran',
+      '--use_signature_help',
+    },
     filetypes = { 'fortran' },
     root_dir = function(fname)
       return util.root_pattern '.fortls'(fname) or util.find_git_ancestor(fname)
     end,
-    settings = {
-      nthreads = 1,
-    },
+    settings = {},
   },
   docs = {
     description = [[
-https://github.com/hansec/fortran-language-server
+https://github.com/gnikit/fortls
 
-Fortran Language Server for the Language Server Protocol
+fortls is a Fortran Language Server, the server can be installed via pip
+
+```sh
+pip install fortls
+```
+
+Settings to the server can be passed either through the `cmd` option or through
+a local configuration file e.g. `.fortls`. For more information
+see the `fortls` [documentation](https://gnikit.github.io/fortls/options.html).
     ]],
     default_config = {
       root_dir = [[root_pattern(".fortls")]],


### PR DESCRIPTION
 `settings` and `init_options` are not currently supported in fortls, so the arguments to the server have to be passed via the `cmd` option or through our own config files.
