### PR TITLE
fix: tsserver detached false in windows

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -38,6 +38,7 @@ function configs.__newindex(t, config_name, config_def)
       on_new_config = { config.on_new_config, 'f', true },
       on_attach = { config.on_attach, 'f', true },
       commands = { config.commands, 't', true },
+      detached = { config.detached, 'b', true },
     }
     if config.commands then
       for k, v in pairs(config.commands) do

--- a/lua/lspconfig/server_configurations/tsserver.lua
+++ b/lua/lspconfig/server_configurations/tsserver.lua
@@ -2,9 +2,11 @@ local util = require 'lspconfig.util'
 
 local bin_name = 'typescript-language-server'
 local cmd = { bin_name, '--stdio' }
+local detached = true
 
 if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
+  detached = false
 end
 
 return {
@@ -23,6 +25,7 @@ return {
       return util.root_pattern 'tsconfig.json'(fname)
         or util.root_pattern('package.json', 'jsconfig.json', '.git')(fname)
     end,
+    detached = detached,
   },
   docs = {
     description = [[


### PR DESCRIPTION
It seemed that I needed to set detached to false on Windows, as in https://github.com/neovim/nvim-lspconfig/issues/1907.
I think I will set detached to false for all other servers as well, but I would appreciate your input.