### PR TITLE
feat: add :LspLog command

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ vim.lsp.set_log_level("debug")
 Attempt to run the language server, and open the log with:
 
 ```
-:lua vim.cmd('e'..vim.lsp.get_log_path())
+:LspLog
 ```
 Most of the time, the reason for failure is present in the logs.
 

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -608,7 +608,7 @@ the built-in client, specifically considering the RPC logs. Example:
 Attempt to run the language server, and open the log with:
 
 >
-    :lua vim.cmd('e'..vim.lsp.get_log_path())
+    :LspLog
 <
 Note that `ERROR` messages containing `stderr` only indicate that the log was
 sent to `stderr`. Many servers counter-intuitively send harmless messages

--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -21,6 +21,13 @@ function M._root._setup()
       '-nargs=0',
       description = '`:LspInfo` Displays attached, active, and configured language servers',
     },
+    LspLog = {
+      function()
+        vim.cmd(string.format('tabnew %s', vim.lsp.get_log_path()))
+      end,
+      '-nargs=0',
+      description = "`:LspLog` Opens neovim's LSP client log in a new tab window.",
+    },
     LspStart = {
       function(server_name)
         if server_name then

--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -26,7 +26,7 @@ function M._root._setup()
         vim.cmd(string.format('tabnew %s', vim.lsp.get_log_path()))
       end,
       '-nargs=0',
-      description = "`:LspLog` Opens neovim's LSP client log in a new tab window.",
+      description = "`:LspLog` Opens the Nvim LSP client log.",
     },
     LspStart = {
       function(server_name)


### PR DESCRIPTION
I haven't seen any previous discussions about a command like this, so
figured I'd start one by opening this PR.

From having done user support in nvim-lsp-installer for a while now, I
feel like this log file is not being reviewed by users to the extent it
should be. Although it is mentioned in the README & `:h lspconfig`, as
well as being visible in the `:LspInfo` window, I feel like a large
portion of users don't consider reviewing it while troubleshooting
issues.

I figured by providing a user command to open the log would help make it
more accessible & discoverable.
