### PR TITLE
feat: allow attaching a client to unnamed buffer

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -144,6 +144,10 @@ listed in `:help vim.lsp.start_client()` with the following unique entries:
 
     `bool` (default: nil)
 
+- {unnamed_buffer_support}
+
+    `bool` (default: false)
+
     Determines if a server is started without a matching root directory.
     See |lspconfig-single-file-support|.
 
@@ -435,6 +439,7 @@ Browsing the source of the default configurations is recommended.
 
 ==============================================================================
 SINGLE FILE SUPPORT                              *lspconfig-single-file-support*
+                                              *lspconfig-unnamed-buffer-support*
 
 Language servers require each project to have a `root` in order to provide
 features that require cross-file indexing. 
@@ -448,6 +453,8 @@ mode under which cross-file features may be degraded.
 - then, if `single_file_support` is enabled for a given language server
   configuration, starting the server without sending `rootDirectory` or
   `workspaceFolders` during initialization.
+- If the buffer is unnamed and `unnamed_buffer_support` is enabled, the client
+  would attach with the `vim.fn.getcwd()`
 - attaching subsequent files in the parent directory to the same server
   instance, depending on filetype.
 

--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -2906,6 +2906,10 @@ require'lspconfig'.jsonls.setup{}
   ```lua
   util.find_git_ancestor
   ```
+  - `unnamed_buffer_support` : 
+  ```lua
+  true
+  ```
   - `single_file_support` : 
   ```lua
   true
@@ -6573,6 +6577,10 @@ require'lspconfig'.yamlls.setup{}
   - `root_dir` : 
   ```lua
   util.find_git_ancestor
+  ```
+  - `unnamed_buffer_support` : 
+  ```lua
+  true
   ```
   - `settings` : 
   ```lua

--- a/lua/lspconfig/server_configurations/jsonls.lua
+++ b/lua/lspconfig/server_configurations/jsonls.lua
@@ -16,6 +16,7 @@ return {
     },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
+    unnamed_buffer_support = true,
   },
   docs = {
     -- this language server config is in VSCode built-in package.json

--- a/lua/lspconfig/server_configurations/yamlls.lua
+++ b/lua/lspconfig/server_configurations/yamlls.lua
@@ -13,6 +13,7 @@ return {
     filetypes = { 'yaml', 'yaml.docker-compose' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
+    unnamed_buffer_support = true,
     settings = {
       -- https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting
       redhat = { telemetry = { enabled = false } },


### PR DESCRIPTION
Resolves #1926

This adds a boolean option to the config: `unnamed_buffer_support` with default of `false` that allows spawning the LSP server with `vim.fn.cwd()` so that we have linting and diagnostics even though we are in an unnamed buffer.
Relevant only if `single_file_support` is true