### PR TITLE
fix(denols):update settings for lint and tsconfig

### DIFF
--- a/lua/lspconfig/server_configurations/denols.lua
+++ b/lua/lspconfig/server_configurations/denols.lua
@@ -72,10 +72,9 @@ return {
       'typescriptreact',
       'typescript.tsx',
     },
-    root_dir = util.root_pattern('deno.json', 'deno.jsonc', 'tsconfig.json', '.git'),
+    root_dir = util.root_pattern('deno.json', 'deno.jsonc', '.git'),
     init_options = {
       enable = true,
-      lint = false,
       unstable = false,
     },
     handlers = {
@@ -106,7 +105,7 @@ vim.g.markdown_fenced_languages = {
 }
 ```
 
-]],
+]]   ,
     default_config = {
       root_dir = [[root_pattern("deno.json", "deno.jsonc", "tsconfig.json", ".git")]],
     },

--- a/lua/lspconfig/server_configurations/denols.lua
+++ b/lua/lspconfig/server_configurations/denols.lua
@@ -107,7 +107,7 @@ vim.g.markdown_fenced_languages = {
 
 ]]   ,
     default_config = {
-      root_dir = [[root_pattern("deno.json", "deno.jsonc", "tsconfig.json", ".git")]],
+      root_dir = [[root_pattern("deno.json", "deno.jsonc", ".git")]],
     },
   },
 }


### PR DESCRIPTION
- Linting is now enabled by default https://deno.com/blog/v1.22#linting-enabled-by-default-in-the-lsp so it should not be turned off in these settings
- `tsconfig` is an outdated way to make any config changes in Deno and should not be used:

https://deno.land/manual/typescript/configuration#configuring-typescript-in-deno

> ⚠️ Deno v1.14 started supporting a more general configuration file that is no longer confined to specifying TypeScript compiler settings. Using tsconfig.json as a file name will still work, but we recommend to use deno.json or deno.jsonc

@jason0x43 agreed in the previous thread: https://github.com/neovim/nvim-lspconfig/pull/1321#issuecomment-1024191242

> Currently, deno only looks for deno.json, deno.jsonc, tsconfig.json, or .git to determine the root. I think dropping tsconfig.json makes sense because Deno now has it's own preferred config file name. Having .git seems reasonable enough because projects will often be in git repos. I could even see enabling single_file mode by default for the Deno LS since making simple CLI tools is (theoretically) a standard use case.

If this pull request is accepted then the docs can also be simplified: https://deno.land/manual/getting_started/setup_your_environment#neovim-06-and-nvim-lspconfig