### PR TITLE
fix(docs) vim.lsp.buf.format -> vim.lsp.buf.formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ local on_attach = function(client, bufnr)
   vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, bufopts)
   vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
   vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
-  vim.keymap.set('n', '<space>f', vim.lsp.buf.format, bufopts)
+  vim.keymap.set('n', '<space>f', vim.lsp.buf.formatting, bufopts)
 end
 
 -- Use a loop to conveniently call 'setup' on multiple servers and

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -517,7 +517,7 @@ attached to a given buffer.
     vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, bufopts)
     vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
     vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
-    vim.keymap.set('n', '<space>f', vim.lsp.buf.format, bufopts)
+    vim.keymap.set('n', '<space>f', vim.lsp.buf.formatting, bufopts)
   end
 
   -- Use a loop to conveniently call 'setup' on multiple servers and


### PR DESCRIPTION
There doesn't appear to actually be a function called `format`.
Instead, I believe what we actually want here is a call `formatting`.