### PR TITLE
fix(dartls): explicitly pass the protocol to dartls

### DIFF
--- a/lua/lspconfig/server_configurations/dartls.lua
+++ b/lua/lspconfig/server_configurations/dartls.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'dart', 'language-server' },
+    cmd = { 'dart', 'language-server', '--protocol=lsp' },
     filetypes = { 'dart' },
     root_dir = util.root_pattern 'pubspec.yaml',
     init_options = {


### PR DESCRIPTION
Fixes https://github.com/neovim/nvim-lspconfig/issues/1942
Works around upstream issue https://github.com/dart-lang/sdk/issues/49157