### PR TITLE
fix(svlangserver): don't use custom project setting resolution

### DIFF
--- a/lua/lspconfig/server_configurations/svlangserver.lua
+++ b/lua/lspconfig/server_configurations/svlangserver.lua
@@ -26,7 +26,9 @@ return {
   default_config = {
     cmd = cmd,
     filetypes = { 'verilog', 'systemverilog' },
-    root_dir = util.find_git_ancestor,
+    root_dir = function(fname)
+      return util.root_pattern '.svlangserver'(fname) or util.find_git_ancestor(fname)
+    end,
     single_file_support = true,
     settings = {
       systemverilog = {
@@ -57,7 +59,7 @@ $ npm install -g @imc-trading/svlangserver
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git")]],
+      root_dir = [[root_pattern(".svlangserver", ".git")]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/svlangserver.lua
+++ b/lua/lspconfig/server_configurations/svlangserver.lua
@@ -26,25 +26,13 @@ return {
   default_config = {
     cmd = cmd,
     filetypes = { 'verilog', 'systemverilog' },
-    root_dir = function(fname)
-      return util.root_pattern '.nvim'(fname) or util.find_git_ancestor(fname)
-    end,
+    root_dir = util.find_git_ancestor,
     single_file_support = true,
     settings = {
       systemverilog = {
         includeIndexing = { '*.{v,vh,sv,svh}', '**/*.{v,vh,sv,svh}' },
       },
     },
-    on_init = function(client)
-      local json = ''
-      for line in io.lines(client.config.root_dir .. '/.nvim/lspconfig.json') do
-        json = json .. line
-      end
-      json = vim.json.decode(json)
-      client.config.cmd = { json.languageserver.svlangserver.command }
-      client.config.filetypes = json.languageserver.svlangserver.filetypes
-      client.config.settings = json.languageserver.svlangserver.settings
-    end,
   },
   commands = {
     SvlangserverBuildIndex = {
@@ -60,7 +48,16 @@ return {
     description = [[
 https://github.com/imc-trading/svlangserver
 
-`svlangserver`, a language server for systemverilog
+Language server for SystemVerilog.
+
+`svlangserver` can be installed via `npm`:
+
+```sh
+$ npm install -g @imc-trading/svlangserver
+```
 ]],
+    default_config = {
+      root_dir = [[root_pattern(".git")]],
+    },
   },
 }


### PR DESCRIPTION
@henry-hsieh 👋 It seems like the server configuration for `svlangserver` included some custom `exrc`-as-json-style project settings loader, which I don't think should be part of the stock configuration provided by lspconfig, but instead provided by users themselves.