### PR TITLE
fix(purescript-language-server): update root directory pattern for Nix-related files + doc cleanup

### DIFF
--- a/lua/lspconfig/server_configurations/purescriptls.lua
+++ b/lua/lspconfig/server_configurations/purescriptls.lua
@@ -11,18 +11,19 @@ return {
   default_config = {
     cmd = cmd,
     filetypes = { 'purescript' },
-    root_dir = util.root_pattern('bower.json', 'psc-package.json', 'spago.dhall'),
+    root_dir = util.root_pattern('bower.json', 'psc-package.json', 'spago.dhall', 'flake.nix', 'shell.nix'),
   },
   docs = {
     description = [[
 https://github.com/nwolverson/purescript-language-server
-`purescript-language-server` can be installed via `npm`
-```sh
-npm install -g purescript-language-server
-```
+
+The `purescript-language-server` can be added to your project and `$PATH` via
+
+* JavaScript package manager such as npm, pnpm, Yarn, et al.
+* Nix under the `nodePackages` and `nodePackages_latest` package sets
 ]],
     default_config = {
-      root_dir = [[root_pattern("spago.dhall, 'psc-package.json', bower.json")]],
+      root_dir = [[root_pattern('spago.dhall', 'psc-package.json', 'bower.json', 'flake.nix', 'shell.nix'),]],
     },
   },
 }


### PR DESCRIPTION
As seen in the [source code](https://github.com/nwolverson/purescript-language-server/blob/db5584d79e698b02e3df12a1299d5f93262bd5ee/src/LanguageServer/IdePurescript/Main.purs#L391), Nix-related files were added to the Language server to establish the root. This commit looks to mimic that behavior. The PureScript community has a lot of Nix-positive users and tooling.

Additionally the docs were updated:

* Reflect the new `root_dir` + `root_pattern` list
* Include a list of ways to install the language server to your project
* Remove the specific, problematic npm install command because
  * Globally installing these tools is a bad practice as teams should maintain consistent versions in their projects and users are less likely to remember to upgrade global packages; new documentation suggests to add it to your project, but it doesn’t _not_ say to install it globally if desired
  * npm is _not_ the only JavaScript package manager
  * JavaScript package managers are not the only way to get the language server
  * Unrelated but technically incorrect: the block was labeled as a shell script despite it being a shell session (code block syntax `sh` should be `console`)