### PR TITLE
fix(taplo): update cargo install command

### DIFF
--- a/lua/lspconfig/server_configurations/taplo.lua
+++ b/lua/lspconfig/server_configurations/taplo.lua
@@ -17,7 +17,7 @@ Language server for Taplo, a TOML toolkit.
 
 `taplo-cli` can be installed via `cargo`:
 ```sh
-cargo install --locked taplo-cli
+cargo install --features lsp --locked taplo-cli
 ```
     ]],
     default_config = {


### PR DESCRIPTION
The `lsp` feature was recently [removed](https://github.com/tamasfe/taplo/blob/1ccafc48a4e45fd16e816f087908059f6d36e0b2/crates/taplo-cli/Cargo.toml#L13) from the `default` features. The `cargo install` command snippet has been updated to specify that the additonal `lsp` feature should be installed as well.