### PR TITLE
docs(metals): update metals instructions

### DIFF
--- a/lua/lspconfig/server_configurations/metals.lua
+++ b/lua/lspconfig/server_configurations/metals.lua
@@ -22,21 +22,11 @@ Scala language server with rich IDE features.
 
 See full instructions in the Metals documentation:
 
-https://scalameta.org/metals/docs/editors/vim.html#using-an-alternative-lsp-client
+https://scalameta.org/metals/docs/editors/vim#using-an-alternative-lsp-client
 
 Note: that if you're using [nvim-metals](https://github.com/scalameta/nvim-metals), that plugin fully handles the setup and installation of Metals, and you shouldn't set up Metals both with it and `lspconfig`.
 
-To install Metals, make sure to have [coursier](https://get-coursier.io/docs/cli-installation) installed, and once you do you can install the latest Metals with `cs install metals`. You can also manually bootstrap Metals with the following command.
-
-```bash
-cs bootstrap \
-  --java-opt -Xss4m \
-  --java-opt -Xms100m \
-  org.scalameta:metals_2.12:<enter-version-here> \
-  -r bintray:scalacenter/releases \
-  -r sonatype:snapshots \
-  -o /usr/local/bin/metals -f
-```
+To install Metals, make sure to have [coursier](https://get-coursier.io/docs/cli-installation) installed, and once you do you can install the latest Metals with `cs install metals`.
 ]],
     default_config = {
       root_dir = [[util.root_pattern("build.sbt", "build.sc", "build.gradle", "pom.xml")]],


### PR DESCRIPTION
- Updates link to the metals website
- Removes the instructions about manual bootstrapping

I removed these instructions because with `cs install metals` there is
no reason to manually bootstrap it, we actually discourage it.
Especially now that we are on a new Scala version (2.13), the old
instructions including Scala 2.12 will fail. When using `cs install`,
all of this is just handled for you.

`nvim-metals` is still the path we recommend for any metals users.