### PR TITLE
fix(docs): fix the usage of ln to make symbolic links of compile_commands.json

### DIFF
--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -65,7 +65,7 @@ https://clangd.llvm.org/installation.html
 - If `compile_commands.json` lives in a build directory, you should
   symlink it to the root of your source tree.
   ```
-  ln -s ~/myproject/compile_commands.json ~/myproject/build/
+  ln -s /path/to/myproject/build/compile_commands.json /path/to/myproject/
   ```
 - clangd relies on a [JSON compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html)
   specified as compile_commands.json, see https://clangd.llvm.org/installation#compile_commandsjson


### PR DESCRIPTION
Usually the `compile_commands.json` is generated by CMake and lives in the build directory, I guess the previous author put the wrong order of `TARGET` and `LINK_NAME` of `ln(1)`.