### PR TITLE
fix(lspinfo): trim newlines in root_dir pattern

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -61,7 +61,10 @@ local function make_config_info(config)
     vim.list_extend(config_info.helptags, helptags[error_messages.root_dir_not_found])
     local root_dir_pattern = vim.tbl_get(config, 'document_config', 'docs', 'default_config', 'root_dir')
     if root_dir_pattern then
-      config_info.root_dir = config_info.root_dir .. ' Searched for: ' .. root_dir_pattern .. '.'
+      config_info.root_dir = config_info.root_dir
+        .. ' Searched for: '
+        .. remove_newlines(vim.split(root_dir_pattern, '\n'))
+        .. '.'
     end
   end
 


### PR DESCRIPTION
There are server configurations whose docs for root_dir include newlines, for example [clangd](https://github.com/williamboman/nvim-lspconfig/blob/6bffdbc3ce4b1ff31ac714f5ee3b43ab38870223/lua/lspconfig/server_configurations/clangd.lua#L69-L79). This causes the `:LspInfo` window to error during initial render (due to passing `\n` to `nvim_buf_set_lines`).