### PR TITLE
fix(ocamllsp): update install instructions

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -3623,7 +3623,6 @@ https://github.com/ocaml/ocaml-lsp
 
 To install the lsp server in a particular opam switch:
 ```sh
-opam pin add ocaml-lsp-server https://github.com/ocaml/ocaml-lsp.git
 opam install ocaml-lsp-server
 ```
     


### PR DESCRIPTION
There are stable releases of OCaml-LSP in the the Opam package manager now, it no longer has to be pinned from Git.