### PR TITLE
fix(ocamllsp): update install instructions

### DIFF
--- a/lua/lspconfig/server_configurations/ocamllsp.lua
+++ b/lua/lspconfig/server_configurations/ocamllsp.lua
@@ -28,7 +28,6 @@ https://github.com/ocaml/ocaml-lsp
 
 To install the lsp server in a particular opam switch:
 ```sh
-opam pin add ocaml-lsp-server https://github.com/ocaml/ocaml-lsp.git
 opam install ocaml-lsp-server
 ```
     ]],


### PR DESCRIPTION
There are stable releases of OCaml-LSP in the the Opam package manager now, it no longer has to be pinned from Git.