### PR TITLE
fix(cmake-ls): root pattern should allow nesting

### DIFF
--- a/lua/lspconfig/server_configurations/cmake.lua
+++ b/lua/lspconfig/server_configurations/cmake.lua
@@ -1,12 +1,12 @@
 local util = require 'lspconfig.util'
 
-local root_files = { 'CMakeLists.txt', 'cmake' }
+local root_files = { 'CMakePresets.json', 'CTestConfig.cmake', '.git', 'build', 'cmake' }
 return {
   default_config = {
     cmd = { 'cmake-language-server' },
     filetypes = { 'cmake' },
     root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
+      return util.root_pattern(unpack(root_files))(fname)
     end,
     single_file_support = true,
     init_options = {
@@ -20,7 +20,7 @@ https://github.com/regen100/cmake-language-server
 CMake LSP Implementation
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git", "compile_commands.json", "build")]],
+      root_dir = [[root_pattern('CMakePresets.json', 'CTestConfig.cmake', '.git', 'build', 'cmake')]],
     },
   },
 }


### PR DESCRIPTION
I made a mistake in #1826, it should be fine for a project to have another
`CMakeLists.txt`, e.g. (`CMakeLists.txt` and `src/nvim/CMakeLists.txt`)
