### PR TITLE
Fix ESLintFixAll command not working when multiple eslint clients are open

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -1,20 +1,10 @@
 local util = require 'lspconfig.util'
 local lsp = vim.lsp
 
-local get_eslint_client = function()
-  local active_clients = lsp.get_active_clients()
-  for _, client in ipairs(active_clients) do
-    if client.name == 'eslint' then
-      return client
-    end
-  end
-  return nil
-end
-
 local function fix_all(opts)
   opts = opts or {}
 
-  local eslint_lsp_client = get_eslint_client()
+  local eslint_lsp_client = util.get_active_client_by_name(opts.bufnr, 'eslint')
   if eslint_lsp_client == nil then
     return
   end


### PR DESCRIPTION
In a yarn monorepo, one eslint client is opened by yarn workspace/microservice.

Currently, the ESLintFixAll had no effect except on the first eslint client that was opened. This PR uses the common util function to fetch the proper client.

This is my first time diving into lua, so let me know if it makes no sense. Cheers !