### PR TITLE
Fix wrong Neovim release link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See also `:help lspconfig`.
 
 ## Install
 
-* Requires [Neovim 0.7](https://github.com/neovim/neovim/releases/tag/v0.6.1) or [Nightly](https://github.com/neovim/neovim/releases/tag/nightly). Update Nvim and nvim-lspconfig before reporting an issue.
+* Requires [Neovim 0.7](https://github.com/neovim/neovim/releases/tag/v0.7.0) or [Nightly](https://github.com/neovim/neovim/releases/tag/nightly). Update Nvim and nvim-lspconfig before reporting an issue.
 * Install nvim-lspconfig like any other Vim plugin, e.g. with [packer.nvim](https://github.com/wbthomason/packer.nvim):
   ```lua
   local use = require('packer').use

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See also `:help lspconfig`.
 
 ## Install
 
-* Requires [Neovim 0.7](https://github.com/neovim/neovim/releases/tag/v0.7.0) or [Nightly](https://github.com/neovim/neovim/releases/tag/nightly). Update Nvim and nvim-lspconfig before reporting an issue.
+* Requires [Neovim latest stable release](https://github.com/neovim/neovim/releases/latest) or [Nightly](https://github.com/neovim/neovim/releases/tag/nightly). Update Nvim and nvim-lspconfig before reporting an issue.
 * Install nvim-lspconfig like any other Vim plugin, e.g. with [packer.nvim](https://github.com/wbthomason/packer.nvim):
   ```lua
   local use = require('packer').use


### PR DESCRIPTION
Text was updated in https://github.com/neovim/nvim-lspconfig/commit/4f94bf5ba90e97a9718e5a2eb57b0737e1bdd176#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R13 but the link remains unchanged.