### PR TITLE
fix(lspinfo): use the active buffer when opening the window for diagnostics

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -36,7 +36,7 @@ local function remove_newlines(cmd)
   return cmd
 end
 
-local function make_config_info(config)
+local function make_config_info(config, bufnr)
   local config_info = {}
   config_info.name = config.name
   config_info.helptags = {}
@@ -52,7 +52,9 @@ local function make_config_info(config)
     config_info.cmd_is_executable = 'NA'
   end
 
-  local buffer_dir = vim.fn.expand '%:p:h'
+  local buffer_dir = vim.api.nvim_buf_call(bufnr, function()
+    return vim.fn.expand '%:p:h'
+  end)
   local root_dir = config.get_root_dir(buffer_dir)
   if root_dir then
     config_info.root_dir = root_dir
@@ -148,6 +150,7 @@ return function()
   local buf_clients = vim.lsp.buf_get_clients()
   local clients = vim.lsp.get_active_clients()
   local buffer_filetype = vim.bo.filetype
+  local original_bufnr = vim.api.nvim_get_current_buf()
 
   local win_info = windows.percentage_range_window(0.8, 0.7)
   local bufnr, win_id = win_info.bufnr, win_info.win_id
@@ -214,7 +217,7 @@ return function()
   if not vim.tbl_isempty(other_matching_configs) then
     vim.list_extend(buf_lines, other_matching_configs_header)
     for _, config in pairs(other_matching_configs) do
-      vim.list_extend(buf_lines, make_config_info(config))
+      vim.list_extend(buf_lines, make_config_info(config, original_bufnr))
     end
   end
 


### PR DESCRIPTION
The `vim.fn.expand '%:p:h'` used to acquire the directory of the opened buffer would actually be executed in the context of the floating `:LspInfo` - causing it to return the current working directory instead of the actual buffer directory (the one that was active when opening the `:LspInfo` window).