### PR TITLE
add .git to jdtls root_files

### DIFF
--- a/lua/lspconfig/server_configurations/jdtls.lua
+++ b/lua/lspconfig/server_configurations/jdtls.lua
@@ -81,6 +81,7 @@ local root_files = {
   {
     'build.xml', -- Ant
     'pom.xml', -- Maven
+    '.git', -- Git
     'settings.gradle', -- Gradle
     'settings.gradle.kts', -- Gradle
   },


### PR DESCRIPTION
I have added ".git" into the root_files from jdtls, so that projects without ant, maven or gradle also get recognized by jdtls as a project. With this change, I was able to fix it for myself, so I wanted to share that.

This is my first contribution, so please tell me if I should improve things in the future, when contributing.