### PR TITLE
fix(gradle-language-server): set init_options.settings.gradleWrapperEnabled=true

### DIFF
--- a/lua/lspconfig/server_configurations/gradle_ls.lua
+++ b/lua/lspconfig/server_configurations/gradle_ls.lua
@@ -20,6 +20,12 @@ return {
       return util.root_pattern(unpack(root_files))(fname) or util.root_pattern(unpack(fallback_root_files))(fname)
     end,
     cmd = { bin_name },
+    -- gradle-language-server expects init_options.settings to be defined
+    init_options = {
+      settings = {
+        gradleWrapperEnabled = true,
+      },
+    },
   },
   docs = {
     description = [[
@@ -32,6 +38,11 @@ If you're setting this up manually, build vscode-gradle using `./gradlew install
     default_config = {
       root_dir = [[root_pattern("settings.gradle")]],
       cmd = { 'gradle-language-server' },
+      init_options = {
+        settings = {
+          gradleWrapperEnabled = true,
+        },
+      },
     },
   },
 }


### PR DESCRIPTION
gradle-language-server doesn't work well without some kind of `init_options.settings` parameters. There's some important stuff in

https://github.com/microsoft/vscode-gradle/blob/a0151761aa2a6a07b64ced0dda5f6e9f01e77fd9/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java#L162-L169

that won't get called unless `init_options.settings` is at least defined. In particular if `settings == null`, gradleWrapperEnabled will be `null` as well and

https://github.com/microsoft/vscode-gradle/blob/a0151761aa2a6a07b64ced0dda5f6e9f01e77fd9/gradle-language-server/src/main/java/com/microsoft/gradle/resolver/GradleLibraryResolver.java#L106

`libFolder` won't be resolved.

I propose `init_options.settings.gradleWrapperEnabled=true` because it's a sensible default and so `init_options.settings` doesn't have to be empty.
