### PR TITLE
fix(denols): ignore virtual text error

### DIFF
--- a/lua/lspconfig/server_configurations/denols.lua
+++ b/lua/lspconfig/server_configurations/denols.lua
@@ -18,19 +18,21 @@ local function virtual_text_document_handler(uri, result)
   end
 
   for client_id, res in pairs(result) do
-    local lines = vim.split(res.result, '\n')
-    local bufnr = vim.uri_to_bufnr(uri)
+    if res.result ~= nil then
+        local lines = vim.split(res.result, '\n')
+        local bufnr = vim.uri_to_bufnr(uri)
 
-    local current_buf = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-    if #current_buf ~= 0 then
-      return nil
+        local current_buf = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        if #current_buf ~= 0 then
+          return nil
+        end
+
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, nil, lines)
+        vim.api.nvim_buf_set_option(bufnr, 'readonly', true)
+        vim.api.nvim_buf_set_option(bufnr, 'modified', false)
+        vim.api.nvim_buf_set_option(bufnr, 'modifiable', false)
+        lsp.buf_attach_client(bufnr, client_id)
     end
-
-    vim.api.nvim_buf_set_lines(bufnr, 0, -1, nil, lines)
-    vim.api.nvim_buf_set_option(bufnr, 'readonly', true)
-    vim.api.nvim_buf_set_option(bufnr, 'modified', false)
-    vim.api.nvim_buf_set_option(bufnr, 'modifiable', false)
-    lsp.buf_attach_client(bufnr, client_id)
   end
 end
 

--- a/lua/lspconfig/server_configurations/denols.lua
+++ b/lua/lspconfig/server_configurations/denols.lua
@@ -18,7 +18,11 @@ local function virtual_text_document_handler(uri, result)
   end
 
   for client_id, res in pairs(result) do
-    if res.result ~= nil then
+    -- Error might be present because of race, deno server will eventually send a result. #1995
+    if res.error ~= nil then
+        require('vim.lsp.log').warn('deno/virtual_text_document handler failed (might be a temporary issue), error: '
+            .. tostring(res.error))
+    else
         local lines = vim.split(res.result, '\n')
         local bufnr = vim.uri_to_bufnr(uri)
 


### PR DESCRIPTION
If you open a file and immediately try to go to definition this error happens:
![image](https://user-images.githubusercontent.com/22427111/178162287-8eff25c0-5fd6-44ce-9d39-00c8ffee835f.png)

It seems to be related to some race condition where the virtual text handling is not ready yet

The exact error is 
```
{["error"]={["message"]="Method not found: deno/virtualTextDocument",["code"]="-32601"}}{["error"]={["message"]="Method not found: deno/virtualTextDocument",["code"]="-32601"}}{["error"]={["code"]="-32601",["message"]="Method not found: deno/virtualTextDocument"}}{["error"]={["code"]="-32601",["message"]="Method not found: deno/virtualTextDocument"}}⏎  
```

Because this error is unhelpful and the gotodefinition works normally after a couple of seconds, this pr propose to just ignore it.