### PR TITLE
fix(sumneko_lua): Add stylua.toml

### DIFF
--- a/lua/lspconfig/server_configurations/sumneko_lua.lua
+++ b/lua/lspconfig/server_configurations/sumneko_lua.lua
@@ -4,6 +4,7 @@ local root_files = {
   '.luarc.json',
   '.luacheckrc',
   '.stylua.toml',
+  'stylua.toml',
   'selene.toml',
 }
 return {
@@ -66,7 +67,7 @@ See `lua-language-server`'s [documentation](https://github.com/sumneko/lua-langu
 
 ]],
     default_config = {
-      root_dir = [[root_pattern(".luarc.json", ".luacheckrc", ".stylua.toml", "selene.toml", ".git")]],
+      root_dir = [[root_pattern(".luarc.json", ".luacheckrc", ".stylua.toml", "stylua.toml", "selene.toml", ".git")]],
     },
   },
 }


### PR DESCRIPTION
https://github.com/JohnnyMorganz/StyLua#finding-the-configuration

> The CLI looks for stylua.toml or .stylua.toml in the directory where the tool was executed. If not found, the default configuration is used.

It should be included in the default option. Many plugins use `stylua.toml` such as [packer.nvim](https://github.com/wbthomason/packer.nvim) or [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)