### PR TITLE
Add `antlersls` server config for Statamic's Antlers templating language

### DIFF
--- a/lua/lspconfig/server_configurations/antlersls.lua
+++ b/lua/lspconfig/server_configurations/antlersls.lua
@@ -1,0 +1,26 @@
+local util = require 'lspconfig.util'
+
+local bin_name = 'antlersls'
+local cmd = { bin_name, '--stdio' }
+
+if vim.fn.has 'win32' == 1 then
+  cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
+end
+
+return {
+  default_config = {
+    cmd = cmd,
+    filetypes = { 'html', 'antlers' },
+    root_dir = util.root_pattern('composer.json'),
+  },
+  docs = {
+    description = [[
+https://www.npmjs.com/package/antlers-language-server
+
+`antlersls` can be installed via `npm`:
+```sh
+npm install -g antlers-language-server
+```
+]],
+  },
+}

--- a/lua/lspconfig/server_configurations/antlersls.lua
+++ b/lua/lspconfig/server_configurations/antlersls.lua
@@ -11,7 +11,7 @@ return {
   default_config = {
     cmd = cmd,
     filetypes = { 'html', 'antlers' },
-    root_dir = util.root_pattern('composer.json'),
+    root_dir = util.root_pattern 'composer.json',
   },
   docs = {
     description = [[


### PR DESCRIPTION
Add [antlersls](https://www.npmjs.com/package/antlers-language-server) server config for [Statamic's Antlers templating language](https://statamic.dev/antlers) 🦌

Looks like the docs auto-generate off this; Not sure if I should be adding anything else to this PR ❓

PS. Special thank you to @JohnathonKoster for his work on the parser and language server implementation! 🔥