### PR TITLE
fix: remove unused variables in `lspinfo.lua`

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -157,23 +157,16 @@ return function()
 
   local buf_lines = {}
 
-  local buf_client_names = {}
-  for _, client in pairs(buf_clients) do
-    table.insert(buf_client_names, client.name)
-  end
-
   local buf_client_ids = {}
   for _, client in pairs(buf_clients) do
     table.insert(buf_client_ids, client.id)
   end
 
   local other_active_clients = {}
-  local client_names = {}
   for _, client in pairs(clients) do
     if not vim.tbl_contains(buf_client_ids, client.id) then
       table.insert(other_active_clients, client)
     end
-    table.insert(client_names, client.name)
   end
 
   local header = {


### PR DESCRIPTION
```console
$ selene .
warning[unused_variable]: buf_client_names is assigned a value, but never used
    ┌─ lua/lspconfig/ui/lspinfo.lua:160:9
    │
160 │   local buf_client_names = {}
    │         ^^^^^^^^^^^^^^^^
161 │   for _, client in pairs(buf_clients) do
162 │     table.insert(buf_client_names, client.name)
    │                  ---------------- `table.insert` only writes to `buf_client_names`

warning[unused_variable]: client_names is assigned a value, but never used
    ┌─ lua/lspconfig/ui/lspinfo.lua:171:9
    │
171 │   local client_names = {}
    │         ^^^^^^^^^^^^
    ·
176 │     table.insert(client_names, client.name)
    │                  ------------ `table.insert` only writes to `client_names`
```