### PR TITLE
feat: add glsl-language-server support

### DIFF
--- a/lua/lspconfig/server_configurations/glslls.lua
+++ b/lua/lspconfig/server_configurations/glslls.lua
@@ -1,0 +1,28 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'glslls', '--stdin' },
+    filetypes = { 'glsl' },
+    root_dir = util.find_git_ancestor,
+    single_file_support = true,
+    capabilities = {
+      textDocument = {
+        completion = {
+          editsNearCursor = true,
+        },
+      },
+      offsetEncoding = { 'utf-8', 'utf-16' },
+    },
+  },
+  docs = {
+    description = [[
+https://github.com/svenstaro/glsl-language-server
+
+Language server implementation for GLSL
+
+`glslls` can be compiled and installed manually, or, if your distribution has access to the AUR,
+via the `glsl-language-server` AUR package
+    ]],
+  },
+}


### PR DESCRIPTION
Works, but it looks like the server and/or vim lsp are doing something wrong for the unsupported methods. From what I understand, this isn't something that would be handled here, but correct me if I'm wrong:
```log
[ERROR][2022-07-14 13:55:11] .../lua/vim/lsp.lua:824    "LSP[glslls]"   "on_error"  {  code = "INVALID_SERVER_MESSAGE",  err = {    error = {      code = -32601,      message = "Method 'textDocument/completion' not supported."    },    jsonrpc = "2.0"  }}
[ERROR][2022-07-14 13:56:31] .../lua/vim/lsp.lua:824    "LSP[glslls]"   "on_error"  {  code = "INVALID_SERVER_MESSAGE",  err = {    error = {      code = -32601,      message = "Method 'textDocument/didSave' not supported."    },    jsonrpc = "2.0"  }}
[ERROR][2022-07-14 13:56:44] .../lua/vim/lsp.lua:824    "LSP[glslls]"   "on_error"  {  code = "INVALID_SERVER_MESSAGE",  err = {    error = {      code = -32601,      message = "Method 'shutdown' not supported."    },    jsonrpc = "2.0"  }}
```