### PR TITLE
fix(ccls): provide a string in docs.default_config.root_dir

### DIFF
--- a/lua/lspconfig/server_configurations/ccls.lua
+++ b/lua/lspconfig/server_configurations/ccls.lua
@@ -44,9 +44,7 @@ lspconfig.ccls.setup {
 
 ]],
     default_config = {
-      root_dir = function(fname)
-        return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
-      end,
+      root_dir = [[root_pattern('compile_commands.json', '.ccls', '.git')]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/denols.lua
+++ b/lua/lspconfig/server_configurations/denols.lua
@@ -20,22 +20,23 @@ local function virtual_text_document_handler(uri, result)
   for client_id, res in pairs(result) do
     -- Error might be present because of race, deno server will eventually send a result. #1995
     if res.error ~= nil then
-        require('vim.lsp.log').warn('deno/virtual_text_document handler failed (might be a temporary issue), error: '
-            .. tostring(res.error))
+      require('vim.lsp.log').warn(
+        'deno/virtual_text_document handler failed (might be a temporary issue), error: ' .. tostring(res.error)
+      )
     else
-        local lines = vim.split(res.result, '\n')
-        local bufnr = vim.uri_to_bufnr(uri)
+      local lines = vim.split(res.result, '\n')
+      local bufnr = vim.uri_to_bufnr(uri)
 
-        local current_buf = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-        if #current_buf ~= 0 then
-          return nil
-        end
+      local current_buf = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      if #current_buf ~= 0 then
+        return nil
+      end
 
-        vim.api.nvim_buf_set_lines(bufnr, 0, -1, nil, lines)
-        vim.api.nvim_buf_set_option(bufnr, 'readonly', true)
-        vim.api.nvim_buf_set_option(bufnr, 'modified', false)
-        vim.api.nvim_buf_set_option(bufnr, 'modifiable', false)
-        lsp.buf_attach_client(bufnr, client_id)
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, nil, lines)
+      vim.api.nvim_buf_set_option(bufnr, 'readonly', true)
+      vim.api.nvim_buf_set_option(bufnr, 'modified', false)
+      vim.api.nvim_buf_set_option(bufnr, 'modifiable', false)
+      lsp.buf_attach_client(bufnr, client_id)
     end
   end
 end


### PR DESCRIPTION
Pretty sure only strings are allowed here. Currently the :LspInfo
window crashes if the `ccls` server has been set up but no root
directory was found (it tries to parse, and display, it as a string).

The docgen script doesn't seem too happy about it either:

<img width="177" alt="Screenshot 2022-07-16 at 15 48 28" src="https://user-images.githubusercontent.com/6705160/179357636-282629f2-c6ec-40aa-9a81-56d16ef9a443.png">

