### PR TITLE
Ignore caching error

### DIFF
--- a/lua/lspconfig/server_configurations/denols.lua
+++ b/lua/lspconfig/server_configurations/denols.lua
@@ -5,7 +5,7 @@ local function buf_cache(bufnr)
   local params = {}
   params['referrer'] = { uri = vim.uri_from_bufnr(bufnr) }
   params['uris'] = {}
-  lsp.buf_request(bufnr, 'deno/cache', params, function(err) end)
+  lsp.buf_request(bufnr, 'deno/cache', params, function(_) end)
 end
 
 local function virtual_text_document_handler(uri, result)

--- a/lua/lspconfig/server_configurations/denols.lua
+++ b/lua/lspconfig/server_configurations/denols.lua
@@ -5,11 +5,7 @@ local function buf_cache(bufnr)
   local params = {}
   params['referrer'] = { uri = vim.uri_from_bufnr(bufnr) }
   params['uris'] = {}
-  lsp.buf_request(bufnr, 'deno/cache', params, function(err)
-    if err then
-      error(tostring(err))
-    end
-  end)
+  lsp.buf_request(bufnr, 'deno/cache', params, function(err) end)
 end
 
 local function virtual_text_document_handler(uri, result)


### PR DESCRIPTION
Caching actually works but it throws an error, vscode-deno also doesn't seem to care about errors https://github.com/denoland/vscode_deno/blob/196a11cead2d95c324cb772dd568ba7c2801b68a/client/src/commands.ts#L60

![cache](https://user-images.githubusercontent.com/22427111/179163835-94473c02-be79-4baf-a7b5-93f059b8c718.gif)