### PR TITLE
fix: emmet-ls missing supported filetypes

### DIFF
--- a/lua/lspconfig/server_configurations/emmet_ls.lua
+++ b/lua/lspconfig/server_configurations/emmet_ls.lua
@@ -10,7 +10,7 @@ end
 return {
   default_config = {
     cmd = cmd,
-    filetypes = { 'html', 'css' },
+    filetypes = { 'html', 'typescriptreact', 'javascriptreact', 'css', 'sass', 'scss', 'less' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
   },


### PR DESCRIPTION
Hello, the emmet-ls config was missing filetypes supported by the language server.