### PR TITLE
change installation strategy for `pyright`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See also `:help lspconfig`.
 
 1. Install a language server, e.g. [pyright](doc/server_configurations.md#pyright)
    ```bash
-   pip3 install pyright
+   pip install pyright
    ```
 2. Add the language server setup to your init.lua.
    ```lua

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See also `:help lspconfig`.
 
 1. Install a language server, e.g. [pyright](doc/server_configurations.md#pyright)
    ```bash
-   npm i -g pyright
+   pip3 install pyright
    ```
 2. Add the language server setup to your init.lua.
    ```lua


### PR DESCRIPTION
Using npm to install a "python" language server might confuse new neovim/LSP users.
This PR changes the docs to use [`pip` for installing pyright](https://github.com/microsoft/pyright#command-line) which automatically takes care of installing node etc.