### PR TITLE
feat(texlab): support plaintex in texlab LSP

### DIFF
--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -66,7 +66,7 @@ end
 return {
   default_config = {
     cmd = { 'texlab' },
-    filetypes = { 'tex', 'bib' },
+    filetypes = { 'tex', 'plaintex', 'bib' },
     root_dir = function(fname)
       return util.root_pattern '.latexmkrc'(fname) or util.find_git_ancestor(fname)
     end,


### PR DESCRIPTION
Sometimes simple LaTeX documents are detected as plaintex rather than tex, meaning texlab will not be applied without a manual change of filetype.