### PR TITLE
Update the URL of taplo homepage

### DIFF
--- a/lua/lspconfig/server_configurations/taplo.lua
+++ b/lua/lspconfig/server_configurations/taplo.lua
@@ -11,7 +11,7 @@ return {
   },
   docs = {
     description = [[
-https://taplo.tamasfe.dev/lsp/
+https://taplo.tamasfe.dev/cli/usage/language-server.html
 
 Language server for Taplo, a TOML toolkit.
 


### PR DESCRIPTION
The current link is 404, so replaced with a relevant and existing page.