### PR TITLE
feat(denols): Auto complete import from deno.land registery

### DIFF
--- a/lua/lspconfig/server_configurations/denols.lua
+++ b/lua/lspconfig/server_configurations/denols.lua
@@ -63,7 +63,7 @@ local function denols_handler(err, result, ctx)
   lsp.handlers[ctx.method](err, result, ctx)
 end
 
-return {
+local denols = {
   default_config = {
     cmd = { 'deno', 'lsp' },
     -- single file support is required for now to make the lsp work correctly, see #2000
@@ -80,6 +80,7 @@ return {
     init_options = {
       enable = true,
       unstable = false,
+      suggest = { imports = { hosts = {} } },
     },
     handlers = {
       ['textDocument/definition'] = denols_handler,
@@ -122,3 +123,9 @@ vim.g.markdown_fenced_languages = {
     },
   },
 }
+
+local deno_land_host = {}
+deno_land_host['https://deno.land'] = true
+denols.default_config.init_options.suggest.imports.hosts = deno_land_host
+
+return denols


### PR DESCRIPTION
![import](https://user-images.githubusercontent.com/22427111/180643988-98323c84-f0ba-4d4d-8e3d-57b16f2ac0c1.gif)

The correct way to do this would be similar to https://github.com/denoland/vscode_deno/blob/main/client/src/notification_handlers.ts#L10

- listen to registry state notification
- ask the user if they want to enable completion suggestions
- update the configuration settings

The problem is with that last step I couldn't find a way to update settings at runtime in vim lsp, doing something like `client.config.init_options... = newvalue`, doesn't seem to get noticed by the server even after using `didchangeconfiguration` method.

It seems like `init_options` is something that is not in the spec ? and specific to vim lsp ? it seems to not be update-able

This pr propose to enable suggestions unconditionally form `deno.land`, it is the official provider so it can be trusted and I don't see a disadvantage for enabling it.

This is not a new thing, we already enable some options unconditionally https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/denols.lua#L81 the official vscode plugin actually asks the user before settings those.