### PR TITLE
fix: lspconfig.util is required with different names

### DIFF
--- a/lua/lspconfig/server_configurations/sourcery.lua
+++ b/lua/lspconfig/server_configurations/sourcery.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig/util'
+local util = require 'lspconfig.util'
 
 local root_files = {
   'pyproject.toml',


### PR DESCRIPTION
sourcery configuration requires 'lspconfig/util', where everything else uses 'lspconfig.util'.