### PR TITLE
fix(lemminx): Change documented binary download location

### DIFF
--- a/lua/lspconfig/server_configurations/lemminx.lua
+++ b/lua/lspconfig/server_configurations/lemminx.lua
@@ -11,9 +11,9 @@ return {
     description = [[
 https://github.com/eclipse/lemminx
 
-The easiest way to install the server is to get a binary at https://download.jboss.org/jbosstools/vscode/stable/lemminx-binary/ and place it in your PATH.
+The easiest way to install the server is to get a binary from https://github.com/redhat-developer/vscode-xml/releases and place it on your PATH.
 
-NOTE to macOS users: Binaries from unidentified developers are blocked by default. If you trust the downloaded binary from jboss.org, run it once, cancel the prompt, then remove the binary from Gatekeeper quarantine with `xattr -d com.apple.quarantine lemminx`. It should now run without being blocked.
+NOTE to macOS users: Binaries from unidentified developers are blocked by default. If you trust the downloaded binary, run it once, cancel the prompt, then remove the binary from Gatekeeper quarantine with `xattr -d com.apple.quarantine lemminx`. It should now run without being blocked.
 
 ]],
     default_config = {


### PR DESCRIPTION
We no longer publish the lemminx binaries to download.jboss.org as a part of our release process for vscode-xml, so the binaries for the latest releases of lemminx are not there. However, they are available on the [vscode-xml GitHub](https://github.com/redhat-developer/vscode-xml), under releases.

Signed-off-by: David Thompson <davthomp@redhat.com>