### PR TITLE
feat(lua-language-server): add cmd for window when using mason

### DIFF
--- a/lua/lspconfig/server_configurations/sumneko_lua.lua
+++ b/lua/lspconfig/server_configurations/sumneko_lua.lua
@@ -7,9 +7,17 @@ local root_files = {
   'stylua.toml',
   'selene.toml',
 }
+
+local bin_name = 'lua-language-server'
+local cmd = { bin_name }
+
+if vim.fn.has 'win32' == 1 then
+  cmd = { 'cmd.exe', '/C', bin_name }
+end
+
 return {
   default_config = {
-    cmd = { 'lua-language-server' },
+    cmd = cmd,
     filetypes = { 'lua' },
     root_dir = function(fname)
       return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)


### PR DESCRIPTION
mason bin using all cmd file so need to update check for one using mason
( not affect old nvim-lsp-installer )