### PR TITLE
chore(denols): Only send lsp requests to deno server

### DIFF
--- a/lua/lspconfig/server_configurations/denols.lua
+++ b/lua/lspconfig/server_configurations/denols.lua
@@ -1,48 +1,39 @@
 local util = require 'lspconfig.util'
 local lsp = vim.lsp
 
-local function buf_cache(bufnr)
+local function buf_cache(bufnr, client)
   local params = {}
   params['referrer'] = { uri = vim.uri_from_bufnr(bufnr) }
   params['uris'] = {}
-  lsp.buf_request(bufnr, 'deno/cache', params, function(_) end)
+  client.request_sync('deno/cache', params)
 end
 
-local function virtual_text_document_handler(uri, result)
-  if not result then
+local function virtual_text_document_handler(uri, res)
+  if not res then
     return nil
   end
 
-  for _, res in pairs(result) do
-    -- Error might be present because of race, deno server will eventually send a result. #1995
-    if res.error ~= nil then
-      require('vim.lsp.log').warn(
-        'deno/virtual_text_document handler failed (might be a temporary issue), error: ' .. tostring(res.error)
-      )
-    else
-      local lines = vim.split(res.result, '\n')
-      local bufnr = vim.uri_to_bufnr(uri)
+  local lines = vim.split(res.result, '\n')
+  local bufnr = vim.uri_to_bufnr(uri)
 
-      local current_buf = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-      if #current_buf ~= 0 then
-        return nil
-      end
-
-      vim.api.nvim_buf_set_lines(bufnr, 0, -1, nil, lines)
-      vim.api.nvim_buf_set_option(bufnr, 'readonly', true)
-      vim.api.nvim_buf_set_option(bufnr, 'modified', false)
-      vim.api.nvim_buf_set_option(bufnr, 'modifiable', false)
-    end
+  local current_buf = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  if #current_buf ~= 0 then
+    return nil
   end
+
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, nil, lines)
+  vim.api.nvim_buf_set_option(bufnr, 'readonly', true)
+  vim.api.nvim_buf_set_option(bufnr, 'modified', false)
+  vim.api.nvim_buf_set_option(bufnr, 'modifiable', false)
 end
 
-local function virtual_text_document(uri)
+local function virtual_text_document(uri, client)
   local params = {
     textDocument = {
       uri = uri,
     },
   }
-  local result = lsp.buf_request_sync(0, 'deno/virtualTextDocument', params)
+  local result = client.request_sync('deno/virtualTextDocument', params)
   virtual_text_document_handler(uri, result)
 end
 
@@ -51,10 +42,11 @@ local function denols_handler(err, result, ctx)
     return nil
   end
 
+  local client = vim.lsp.get_client_by_id(ctx.client_id)
   for _, res in pairs(result) do
     local uri = res.uri or res.targetUri
     if uri:match '^deno:' then
-      virtual_text_document(uri)
+      virtual_text_document(uri, client)
       res['uri'] = uri
       res['targetUri'] = uri
     end
@@ -86,7 +78,7 @@ return {
       ['textDocument/references'] = denols_handler,
       ['workspace/executeCommand'] = function(err, result, context)
         if context.params.command == 'deno.cache' then
-          buf_cache(context.bufnr)
+          buf_cache(context.bufnr, vim.lsp.get_client_by_id(context.client_id))
         else
           lsp.handlers[context.method](err, result, context)
         end
@@ -96,7 +88,13 @@ return {
   commands = {
     DenolsCache = {
       function()
-        buf_cache(0)
+        local clients = vim.lsp.get_active_clients()
+        for _, client in ipairs(clients) do
+          if client.name == 'denols' then
+            buf_cache(0, client)
+            break
+          end
+        end
       end,
       description = 'Cache a module and all of its dependencies.',
     },


### PR DESCRIPTION
This mainly changes `lsp.buf_request` to `client.request` that way we don't send needless requests for other active unrelated servers.