### PR TITLE
feat(csharp_ls): add '*.fsproj' to root_dir

### DIFF
--- a/lua/lspconfig/server_configurations/csharp_ls.lua
+++ b/lua/lspconfig/server_configurations/csharp_ls.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'csharp-ls' },
-    root_dir = util.root_pattern('*.sln', '*.csproj', '.git'),
+    root_dir = util.root_pattern('*.sln', '*.csproj', '*.fsproj', '.git'),
     filetypes = { 'cs' },
     init_options = {
       AutomaticWorkspaceInit = true,


### PR DESCRIPTION
Full disclaimer: I have not done any F# development myself.
This is based on the project file configuration found in the LSP server
implementation itself [1].

[1]: https://github.com/razzmatazz/csharp-language-server/blob/d887595f29af334aa2900381f5336644d9ce5e61/src/CSharpLanguageServer/RoslynHelpers.fs#L550-L554
