### PR TITLE
fix: only consider servers that have been set up as available

### DIFF
--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -7,7 +7,13 @@ local M = {
 M._root = {}
 
 function M.available_servers()
-  return vim.tbl_keys(configs)
+  local servers = {}
+  for server, config in pairs(configs) do
+    if config.manager ~= nil then
+      table.insert(servers, server)
+    end
+  end
+  return servers
 end
 
 -- Called from plugin/lspconfig.vim because it requires knowing that the last

--- a/test/lspconfig_spec.lua
+++ b/test/lspconfig_spec.lua
@@ -251,5 +251,19 @@ describe('lspconfig', function()
         }
       )
     end)
+
+    it("excludes indexed server configs that haven't been set up", function()
+      eq(
+        exec_lua [[
+        local lspconfig = require("lspconfig")
+        local actual = nil
+        local _ = lspconfig.sumneko_lua
+        local _ = lspconfig.tsserver
+        lspconfig.rust_analyzer.setup {}
+        return lspconfig.available_servers()
+      ]],
+        { 'rust_analyzer' }
+      )
+    end)
   end)
 end)


### PR DESCRIPTION
Currently, as soon as a server configuration is indexed it will be considered
"available". I'm not entirely sure if this is indeed intended behavior, all I
know is that it creates some confusion.

I figured I'd open a PR with a suggested solution immediately, to get the ball
rolling. Another solution would be to keep "available servers" as-is, and
instead introduce a new function `.configured_servers()`, and replace usage of
`.available_servers()` where appropriate (e.g., the server list at the bottom
of the `:LspInfo` window).