### PR TITLE
Wgsl analyzer custom imports

### DIFF
--- a/lua/lspconfig/server_configurations/wgsl_analyzer.lua
+++ b/lua/lspconfig/server_configurations/wgsl_analyzer.lua
@@ -6,6 +6,32 @@ local cmd = { bin_name }
 if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name }
 end
+local localSettings = {
+    customImports = {},
+    shaderDefs = {},
+    trace = {
+        extension = true,
+        server = true,
+    },
+    inlayHints = {
+        enabled = true,
+        typeHints = true,
+        parameterHints = true,
+        structLayoutHints = true,
+        typeVerbosity = "compact",
+    },
+    diagnostics = {
+        typeErrors = true,
+        nagaParsingErrors = true,
+        nagaValidationErrors = true,
+        nagaVersion = "main",
+    }
+}
+
+vim.lsp.handlers['wgsl-analyzer/requestConfiguration'] = function(err, result, ctx, config) 
+    return localSettings, nil
+end
+
 
 return {
   default_config = {

--- a/lua/lspconfig/server_configurations/wgsl_analyzer.lua
+++ b/lua/lspconfig/server_configurations/wgsl_analyzer.lua
@@ -7,39 +7,44 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name }
 end
 local localSettings = {
-    customImports = {},
-    shaderDefs = {},
-    trace = {
-        extension = true,
-        server = true,
-    },
-    inlayHints = {
-        enabled = true,
-        typeHints = true,
-        parameterHints = true,
-        structLayoutHints = true,
-        typeVerbosity = "compact",
-    },
-    diagnostics = {
-        typeErrors = true,
-        nagaParsingErrors = true,
-        nagaValidationErrors = true,
-        nagaVersion = "main",
-    }
+  customImports = {}, -- ['import'] = [[code to be imported]] or io.open("path to code")
+  shaderDefs = {},
+  trace = {
+    extension = true,
+    server = true,
+  },
+  inlayHints = {
+    enabled = true,
+    typeHints = true,
+    parameterHints = true,
+    structLayoutHints = true,
+    typeVerbosity = "compact", -- "full", "inner"
+  },
+  diagnostics = {
+    typeErrors = true,
+    nagaParsingErrors = true,
+    nagaValidationErrors = true,
+    nagaVersion = "main", -- "0.8", "0.9"
+  }
 }
+
 
 vim.lsp.handlers['wgsl-analyzer/requestConfiguration'] = function(err, result, ctx, config) 
     return localSettings, nil
 end
-
 
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'wgsl' },
     root_dir = util.root_pattern '.git',
-    settings = {},
+    settings = localSettings ,
   },
+  on_new_config = function(newConfig, _) 
+    vim.lsp.handlers['wgsl-analyzer/requestConfiguration'] = function(err, result, ctx, config) 
+      return newConfig.settings, nil
+    end
+  end,
   docs = {
     description = [[
 https://github.com/wgsl-analyzer/wgsl-analyzer

--- a/lua/lspconfig/server_configurations/wgsl_analyzer.lua
+++ b/lua/lspconfig/server_configurations/wgsl_analyzer.lua
@@ -29,7 +29,7 @@ local localSettings = {
 }
 
 
-vim.lsp.handlers['wgsl-analyzer/requestConfiguration'] = function(err, result, ctx, config) 
+vim.lsp.handlers['wgsl-analyzer/requestConfiguration'] = function(err, result, ctx, config)
     return localSettings, nil
 end
 
@@ -40,8 +40,8 @@ return {
     root_dir = util.root_pattern '.git',
     settings = localSettings ,
   },
-  on_new_config = function(newConfig, _) 
-    vim.lsp.handlers['wgsl-analyzer/requestConfiguration'] = function(err, result, ctx, config) 
+  on_new_config = function(newConfig, _)
+    vim.lsp.handlers['wgsl-analyzer/requestConfiguration'] = function(err, result, ctx, config)
       return newConfig.settings, nil
     end
   end,

--- a/lua/lspconfig/server_configurations/wgsl_analyzer.lua
+++ b/lua/lspconfig/server_configurations/wgsl_analyzer.lua
@@ -18,19 +18,18 @@ local localSettings = {
     typeHints = true,
     parameterHints = true,
     structLayoutHints = true,
-    typeVerbosity = "compact", -- "full", "inner"
+    typeVerbosity = 'compact', -- "full", "inner"
   },
   diagnostics = {
     typeErrors = true,
     nagaParsingErrors = true,
     nagaValidationErrors = true,
-    nagaVersion = "main", -- "0.8", "0.9"
-  }
+    nagaVersion = 'main', -- "0.8", "0.9"
+  },
 }
 
-
 vim.lsp.handlers['wgsl-analyzer/requestConfiguration'] = function(err, result, ctx, config)
-    return localSettings, nil
+  return localSettings, nil
 end
 
 return {
@@ -38,7 +37,7 @@ return {
     cmd = cmd,
     filetypes = { 'wgsl' },
     root_dir = util.root_pattern '.git',
-    settings = localSettings ,
+    settings = localSettings,
   },
   on_new_config = function(newConfig, _)
     vim.lsp.handlers['wgsl-analyzer/requestConfiguration'] = function(err, result, ctx, config)


### PR DESCRIPTION
# Summary
### What it does
Adds support for custom settings for wgsl-analyzer, e.g. for bevy support
### known Issues
* `luacheck` warns about modifying read only `vim.lsp.handlers`
* should this just be a dedicated plugin?

# Details
## Motivation

wgsl-analyzer supports loading custom imports for wgsl files e.g.
```wgsl
#import bevy_pbr::mesh_view_bindings

@group(1) @binding(0)
var texture: texture_2d<f32>;
...
```
but this is not supported by default with wgsl-analyzer
## Problem
It seems that wgsl-analyzer requires a custom handler for modifying settings: `wgsl-analyzer/requestConfiguration`, that it calls to get custom settings. The server calls this and receives those settings

## Solution
This pull request enables passing such custom settings, especially custom imports. 

## Example usage

With the following in my `init.lua` I'm able to load the custom imports for [bevy](https://github.com/bevyengine/bevy/blob/f0c512731b46723d1ab8ec9203d19891596f7f86/assets/shaders/custom_material_chromatic_aberration.wgsl#L1) and get e.g. autocomplete suggestions. I'm still getting some highlight errors.

```lua
local imports = {
}
imports["bevy_pbr::clustered_forward"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/clustered_forward.wgsl", "r"):read("*all")
imports["bevy_pbr::mesh_bindings"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/mesh_bindings.wgsl", "r"):read("*all")
imports["bevy_pbr::mesh_functions"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/mesh_functions.wgsl", "r"):read("*all")
imports["bevy_pbr::mesh_types"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/mesh_types.wgsl", "r"):read("*all") 
imports["bevy_pbr::mesh_vertex_output"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/mesh_vertex_output.wgsl", "r"):read("*all")
imports["bevy_pbr::mesh_view_bindings"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl", "r"):read("*all")
imports["bevy_pbr::mesh_view_types"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/mesh_view_types.wgsl", "r"):read("*all")
imports["bevy_pbr::pbr_bindings"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/pbr_bindings.wgsl", "r"):read("*all")
imports["bevy_pbr::pbr_functions"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/pbr_functions.wgsl", "r"):read("*all")
imports["bevy_pbr::lighting"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/pbr_lighting.wgsl", "r"):read("*all")
imports["bevy_pbr::pbr_types"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/pbr_types.wgsl", "r"):read("*all")
imports["bevy_pbr::shadows"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/shadows.wgsl", "r"):read("*all")
imports["bevy_pbr::skinning"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/skinning.wgsl", "r"):read("*all")
imports["bevy_pbr::utils"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_pbr/src/render/utils.wgsl", "r"):read("*all")
imports["bevy_sprite::mesh2d_bindings"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_sprite/src/mesh2d/mesh2d_bindings.wgsl", "r"):read("*all")
imports["bevy_sprite::mesh2d_functions"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_sprite/src/mesh2d/mesh2d_functions.wgsl", "r"):read("*all")
imports["bevy_sprite::mesh2d_types"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_sprite/src/mesh2d/mesh2d_types.wgsl", "r"):read("*all")
imports["bevy_sprite::mesh2d_vertex_output"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_sprite/src/mesh2d/mesh2d_vertex_output.wgsl", "r"):read("*all")
imports["bevy_sprite::mesh2d_view_bindings"] =io.open( "/Users/cristina/workspace/rust/bevy/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl", "r"):read("*all")  -- io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl", "r"):read("*all")
imports["bevy_sprite::mesh2d_view_types"] = io.open("/Users/cristina/workspace/rust/bevy/crates/bevy_sprite/src/mesh2d/mesh2d_view_types.wgsl", "r"):read("*all")

local nvim_lsp = require'lspconfig'

nvim_lsp.wgsl_analyzer.setup{
    settings = { 
	    customImports = imports,
    	shaderDefs = {
            "VERTEX_UVS",
            "VERTEX_TANGENTS",
            "VERTEX_COLORS",
            "SKINNED",
            "STANDARDMATERIAL_NORMAL_MAP",
	    } 
    }
}
nvim_lsp.rust_analyzer.setup{}
```
With these settings I'm able to get autocomplete and type definitions for objects defined in my custom import (n.b. `/Users/cristina` is my $HOME in the above)

## Potential issues
The contribution guidelines try to push custom functionality onto external plugins. But I would feel that actually modifying the configuration of the LSP server is basic functionality

Also my method of modifying the `handlers` table is flagged by luacheck.

## Misc
I do not have much experience with lua. Only hacking my nvim config. I just worked on this for myself to try to do some shader dev in bevy but staying in nvim, and thought it might be use to others. But am pretty sure this is faaaaaarr from optimal