### PR TITLE
the funtion formatting is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ local on_attach = function(client, bufnr)
   vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, bufopts)
   vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
   vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
-  vim.keymap.set('n', '<space>f', vim.lsp.buf.formatting, bufopts)
+  vim.keymap.set('n', '<space>f',function() vim.lsp.buf.format { async = true } end, bufopts)
 end
 
 local lsp_flags = {


### PR DESCRIPTION
I think we should use the 
```lua
vim.lsp.buf.format { async = true }
```