### PR TITLE
Revert "the function formatting is deprecated"

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ local on_attach = function(client, bufnr)
   vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, bufopts)
   vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
   vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
-  vim.keymap.set('n', '<space>f',function() vim.lsp.buf.format { async = true } end, bufopts)
+  vim.keymap.set('n', '<space>f', vim.lsp.buf.formatting, bufopts)
 end
 
 local lsp_flags = {


### PR DESCRIPTION
Reverts neovim/nvim-lspconfig#2074

`vim.lsp.buf.format()` is not in Nvim stable release yet.