### PR TITLE
fix: add vim.deprecate in old function

### DIFF
--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -6,8 +6,8 @@ local M = {
 
 function M.available_servers()
   vim.deprecate(
-    'require("lspconfig").available_servers',
-    'require("lspconfig.util").available_servers',
+    'lspconfig.available_servers',
+    'lspconfig.util.available_servers',
     '0.1.4',
     'lspconfig'
   )

--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -4,6 +4,16 @@ local M = {
   util = require 'lspconfig.util',
 }
 
+function M.available_servers()
+  vim.deprecate(
+    'require("lspconfig").available_servers',
+    'require("lspconfig.util").available_servers',
+    '0.1.4',
+    'lspconfig'
+  )
+  return M.util.available_servers()
+end
+
 local mt = {}
 function mt:__index(k)
   if configs[k] == nil then


### PR DESCRIPTION
not remove deprecate function . add vim.deprecate in it.
cc @justinmk 