### PR TITLE
fix: use util.available_servers() instead of manually indexing configs

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -216,7 +216,7 @@ return function()
 
   local matching_config_header = {
     '',
-    'Configured servers list: ' .. table.concat(vim.tbl_keys(configs), ', '),
+    'Configured servers list: ' .. table.concat(util.available_servers(), ', '),
   }
   vim.list_extend(buf_lines, matching_config_header)
 

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -17,7 +17,7 @@ end
 local lsp_complete_configured_servers = function(arg)
   return vim.tbl_filter(function(s)
     return s:sub(1, #arg) == arg
-  end, vim.tbl_keys(require 'lspconfig.configs'))
+  end, require("lspconfig.util").available_servers())
 end
 
 local lsp_get_active_client_ids = function(arg)


### PR DESCRIPTION
See [#2066][2066] for more background.

[2066]: https://github.com/neovim/nvim-lspconfig/pull/2066
