### PR TITLE
solc: Add hardhat.config.* to solc root detection

### DIFF
--- a/lua/lspconfig/server_configurations/solc.lua
+++ b/lua/lspconfig/server_configurations/solc.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'solc', '--lsp' },
     filetypes = { 'solidity' },
-    root_dir = util.root_pattern '.git',
+    root_dir = util.root_pattern('hardhat.config.*', '.git'),
   },
   docs = {
     description = [[
@@ -13,7 +13,7 @@ https://docs.soliditylang.org/en/latest/installing-solidity.html
 solc is the native language server for the Solidity language.
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git")]],
+      root_dir = [[root_pattern('hardhat.config.*', '.git')]],
     },
   },
 }


### PR DESCRIPTION
Hardhat users will experience a better root dir detection if the `hardhat.config.ts` (or `.js`) file takes precedence over the git repo dir, especially in monorepos, where this could lead to faulty import statements. Note that most Solidity projects are using hardhat.
