### PR TITLE
fix: lspstart should be work without arg

### DIFF
--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -5,12 +5,7 @@ local M = {
 }
 
 function M.available_servers()
-  vim.deprecate(
-    'lspconfig.available_servers',
-    'lspconfig.util.available_servers',
-    '0.1.4',
-    'lspconfig'
-  )
+  vim.deprecate('lspconfig.available_servers', 'lspconfig.util.available_servers', '0.1.4', 'lspconfig')
   return M.util.available_servers()
 end
 

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -55,17 +55,18 @@ end, {
 })
 
 vim.api.nvim_create_user_command('LspStart', function(info)
-  local server_name = info.args[1] ~= '' and info.args
+  local server_name = string.len(info.args) > 0 and info.args or nil
   if server_name then
     local config = require('lspconfig.configs')[server_name]
     if config then
       config.launch()
+      return
     end
-  else
-    local other_matching_configs = require('lspconfig.util').get_other_matching_providers(vim.bo.filetype)
-    for _, config in ipairs(other_matching_configs) do
-      config.launch()
-    end
+  end
+
+  local other_matching_configs = require('lspconfig.util').get_other_matching_providers(vim.bo.filetype)
+  for _, config in ipairs(other_matching_configs) do
+    config.launch()
   end
 end, {
   desc = 'Manually launches a language server',


### PR DESCRIPTION
`LspStart` should be work without client name args. when there is no arg passed , it should start the client which the filetypes match current buffer filetype