### PR TITLE
fix(angularls): remove `.git` from `root_dir`

### DIFF
--- a/lua/lspconfig/server_configurations/angularls.lua
+++ b/lua/lspconfig/server_configurations/angularls.lua
@@ -30,10 +30,10 @@ return {
   default_config = {
     cmd = cmd,
     filetypes = { 'typescript', 'html', 'typescriptreact', 'typescript.tsx' },
-    -- Check for angular.json or .git first since that is the root of the project.
+    -- Check for angular.json since that is the root of the project.
     -- Don't check for tsconfig.json or package.json since there are multiple of these
     -- in an angular monorepo setup.
-    root_dir = util.root_pattern('angular.json', '.git'),
+    root_dir = util.root_pattern 'angular.json',
   },
   on_new_config = function(new_config, new_root_dir)
     local new_probe_dir = get_probe_dir(new_root_dir)
@@ -69,7 +69,7 @@ require'lspconfig'.angularls.setup{
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("angular.json", ".git")]],
+      root_dir = [[root_pattern("angular.json")]],
     },
   },
 }


### PR DESCRIPTION
Having `.git` as a pattern also enables `angularls` for non-angular projects which is not desired. Checking for only `angular.json` should be enough as every angular project must have a `angular.json`.