### PR TITLE
fix: remove the config.commands

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -278,29 +278,6 @@ where the structure of the docs table is as follows:
     }
 <
 
-Custom commands only work for servers
-
-Example:
->
-  local function organize_imports()
-    local params = {
-      command = 'pyright.organizeimports',
-      arguments = { vim.uri_from_bufnr(0) },
-    }
-    vim.lsp.buf.execute_command(params)
-  end
-
-  local on_attach = function(client, bufnr)
-    if client.name == "pyright" then
-      vim.api.nvim_create_user_command("PyrightOrganizeImports", organize_imports, {desc = 'Organize Imports'})
-    end
-  end
-
-  require("lspconfig")['pyright'].setup({
-    on_attach = on_attach
-  })
-<
-
 The `configs.__newindex` metamethod consumes the config definition and returns
 an object with a `setup()` method, to be invoked by users:
 >

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -267,7 +267,6 @@ validating using `vim.validate` is:
       default_config = {'t'},
       on_new_config = {'f', true},
       on_attach = {'f', true},
-      commands = {'t', true},
       docs = {'t', true},
     }
 <
@@ -278,13 +277,8 @@ where the structure of the docs table is as follows:
       default_config = {'t', true},
     }
 <
-`commands` is a map of `name:definition` key:value pairs, where `definition`
-is a list whose first value is a function implementing the command, and the
-rest are either array values which will be formed into flags for the command,
-or special keys like `description`.
 
-Warning: Commands is deprecated and will be removed in future releases.
-It is recommended to use `vim.api.nvim_create_user_command()` instead in an `on_attach` function.
+Custom commands only work for servers
 
 Example:
 >

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -10,18 +10,7 @@ function configs.__newindex(t, config_name, config_def)
     default_config = { config_def.default_config, 't' },
     on_new_config = { config_def.on_new_config, 'f', true },
     on_attach = { config_def.on_attach, 'f', true },
-    commands = { config_def.commands, 't', true },
   }
-  if config_def.commands then
-    for k, v in pairs(config_def.commands) do
-      validate {
-        ['command.name'] = { k, 's' },
-        ['command.fn'] = { v[1], 'f' },
-      }
-    end
-  else
-    config_def.commands = {}
-  end
 
   local M = {}
 
@@ -39,16 +28,7 @@ function configs.__newindex(t, config_name, config_def)
       filetypes = { config.filetype, 't', true },
       on_new_config = { config.on_new_config, 'f', true },
       on_attach = { config.on_attach, 'f', true },
-      commands = { config.commands, 't', true },
     }
-    if config.commands then
-      for k, v in pairs(config.commands) do
-        validate {
-          ['command.name'] = { k, 's' },
-          ['command.fn'] = { v[1], 'f' },
-        }
-      end
-    end
 
     config = tbl_deep_extend('keep', config, default_config)
 
@@ -287,15 +267,8 @@ function configs.__newindex(t, config_name, config_def)
     if client.config._on_attach then
       client.config._on_attach(client, bufnr)
     end
-    if client.config.commands and not vim.tbl_isempty(client.config.commands) then
-      M.commands = vim.tbl_deep_extend('force', M.commands, client.config.commands)
-    end
-    if not M.commands_created and not vim.tbl_isempty(M.commands) then
-      util.create_module_commands(config_name, M.commands)
-    end
   end
 
-  M.commands = config_def.commands
   M.name = config_name
   M.document_config = config_def
 

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -62,9 +62,9 @@ end
 
 ---@deprecated
 function M.create_module_commands(module_name, commands)
-  vim.deprecate('util.create_module_commands',nil,'0.1.4','vim.api.nvim_create_user_command')
+  vim.deprecate('util.create_module_commands', nil, '0.1.4', 'vim.api.nvim_create_user_command')
   for command_name, def in pairs(commands) do
-    local _,opts = unpack(def)
+    local _, opts = unpack(def)
     api.nvim_create_user_command(command_name, function(info)
       require('lspconfig')[module_name].commands[command_name][1](unpack(info.fargs))
     end, opts)

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -60,17 +60,6 @@ function M.add_hook_after(func, new_fn)
   end
 end
 
----@deprecated
-function M.create_module_commands(module_name, commands)
-  vim.deprecate('util.create_module_commands', nil, '0.1.4', 'vim.api.nvim_create_user_command')
-  for command_name, def in pairs(commands) do
-    local opts = def[2]
-    api.nvim_create_user_command(command_name, function(info)
-      require('lspconfig')[module_name].commands[command_name][1](unpack(info.fargs))
-    end, opts)
-  end
-end
-
 -- Some path utilities
 M.path = (function()
   local is_windows = uv.os_uname().version:match 'Windows'

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -64,7 +64,7 @@ end
 function M.create_module_commands(module_name, commands)
   vim.deprecate('util.create_module_commands', nil, '0.1.4', 'vim.api.nvim_create_user_command')
   for command_name, def in pairs(commands) do
-    local _, opts = unpack(def)
+    local opts = def[2]
     api.nvim_create_user_command(command_name, function(info)
       require('lspconfig')[module_name].commands[command_name][1](unpack(info.fargs))
     end, opts)

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -60,35 +60,11 @@ function M.add_hook_after(func, new_fn)
   end
 end
 
--- Maps lspconfig-style command options to nvim_create_user_command (i.e. |command-attributes|) option names.
-local opts_aliases = {
-  ['description'] = 'desc',
-}
-
----@param command_definition table<string | integer, any>
-function M._parse_user_command_options(command_definition)
-  ---@type table<string, string | boolean | number>
-  local opts = {}
-  for k, v in pairs(command_definition) do
-    if type(k) == 'string' then
-      local attribute = k.gsub(k, '^%-+', '')
-      opts[opts_aliases[attribute] or attribute] = v
-    elseif type(k) == 'number' and type(v) == 'string' and v:match '^%-' then
-      -- Splits strings like "-nargs=* -complete=customlist,v:lua.something" into { "-nargs=*", "-complete=customlist,v:lua.something" }
-      for _, command_attribute in ipairs(vim.split(v, '%s')) do
-        -- Splits attribute into a key-value pair, like "-nargs=*" to { "-nargs", "*" }
-        local attribute, value = unpack(vim.split(command_attribute, '=', { plain = true }))
-        attribute = attribute.gsub(attribute, '^%-+', '')
-        opts[opts_aliases[attribute] or attribute] = value or true
-      end
-    end
-  end
-  return opts
-end
-
+---@deprecated
 function M.create_module_commands(module_name, commands)
+  vim.deprecate('util.create_module_commands',nil,'0.1.4','vim.api.nvim_create_user_command')
   for command_name, def in pairs(commands) do
-    local opts = M._parse_user_command_options(def)
+    local _,opts = unpack(def)
     api.nvim_create_user_command(command_name, function(info)
       require('lspconfig')[module_name].commands[command_name][1](unpack(info.fargs))
     end, opts)

--- a/test/lspconfig_spec.lua
+++ b/test/lspconfig_spec.lua
@@ -213,41 +213,6 @@ describe('lspconfig', function()
         ]])
       end)
     end)
-
-    describe('user commands', function()
-      it('should translate command definition to nvim_create_user_command options', function()
-        eq(
-          {
-            nargs = '*',
-            complete = 'custom,v:lua.some_global',
-          },
-          exec_lua [[
-            local util = require("lspconfig.util")
-            return util._parse_user_command_options({
-              function () end,
-              "-nargs=* -complete=custom,v:lua.some_global"
-            })
-          ]]
-        )
-
-        eq(
-          {
-            desc = 'My awesome description.',
-            nargs = '*',
-            complete = 'custom,v:lua.another_global',
-          },
-          exec_lua [[
-            local util = require("lspconfig.util")
-            return util._parse_user_command_options({
-              function () end,
-              ["-nargs"] = "*",
-              "-complete=custom,v:lua.another_global",
-              description = "My awesome description."
-            })
-          ]]
-        )
-      end)
-    end)
   end)
 
   describe('config', function()


### PR DESCRIPTION
now we can use `vim.api.nvim_create_user_command` in `on_attach` field to create commands just work for this server. so 
there is no need this field `config.commands` .

Example:
```lua
  local function organize_imports()
    local params = {
      command = 'pyright.organizeimports',
      arguments = { vim.uri_from_bufnr(0) },
    }
    vim.lsp.buf.execute_command(params)
  end

  local on_attach = function(client, bufnr)
    if client.name == "pyright" then
      vim.api.nvim_create_user_command("PyrightOrganizeImports", organize_imports, {desc = 'Organize Imports'})
    end
  end

  require("lspconfig")['pyright'].setup({
    on_attach = on_attach
  })
```

Fix #1750 