### PR TITLE
fix(ui): update default `LspInfoBorder` link to `FloatBorder`

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -49,7 +49,7 @@ local get_clients_from_cmd_args = function(arg)
 end
 
 for group, hi in pairs {
-  LspInfoBorder = { link = 'Label', default = true },
+  LspInfoBorder = { link = 'FloatBorder', default = true },
   LspInfoList = { link = 'Function', default = true },
   LspInfoTip = { link = 'Comment', default = true },
   LspInfoTitle = { link = 'Title', default = true },


### PR DESCRIPTION
#2081 sets the default link for the `LspInfoBorder` highlight group to `Label`, but it makes more sense (especially with pre-defined colorschemes and themes) to use `FloatBorder` since it is a border of a floating window.