### PR TITLE
fix(metals): disable capabilities.workspace.configuration

### DIFF
--- a/lua/lspconfig/server_configurations/metals.lua
+++ b/lua/lspconfig/server_configurations/metals.lua
@@ -13,6 +13,11 @@ return {
         snippetAutoIndent = false,
       },
     },
+    capabilities = {
+      workspace = {
+        configuration = false,
+      },
+    },
   },
   docs = {
     description = [[


### PR DESCRIPTION
The newest version of metals 0.11.8 does not work with the old metals config, because now metals sends the 'workspace/configuration' call to the client, which returns null and that crashes metals with not-a-valid-json error. I traced the error to the following commit https://github.com/scalameta/metals/commit/3e0b812095e48fe6e64fbafadaa46e7ea8b9533e

As I could not guess which configuration metals would actually accept, the easiest fix was to disable capabilities.workspace.configuration, which then prevents metals from sending the fatal request. As we don't have any configuration options anyway (at least by default) this seems like a ok solution for both new and old versions of metals. I tried this locally and it seems to work.