### PR TITLE
fix: lspstop should close the client by given client

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -101,9 +101,18 @@ end, {
 
 api.nvim_create_user_command('LspStop', function(info)
   local current_buf = vim.api.nvim_get_current_buf()
-  for _, client in ipairs(get_clients_from_cmd_args(info.args)) do
-    local filetypes = client.config.filetypes
-    if filetypes and vim.tbl_contains(filetypes, vim.bo[current_buf].filetype) then
+  local server_name = string.len(info.args) > 0 and info.args or nil
+
+  if not server_name then
+    local servers_on_buffer = vim.lsp.get_active_clients { buffer = current_buf }
+    for _, client in ipairs(servers_on_buffer) do
+      local filetypes = client.config.filetypes
+      if filetypes and vim.tbl_contains(filetypes, vim.bo[current_buf].filetype) then
+        client.stop()
+      end
+    end
+  else
+    for _, client in ipairs(get_clients_from_cmd_args(server_name)) do
       client.stop()
     end
   end


### PR DESCRIPTION
`LspStop` should be work when pass client from cmdline. if no args stop the all the clients which filetypes match current buffer filetype

@kabouzeid  can you test this patch ?