### PR TITLE
Added elixir filetype for tailwindcss server configuration.

### DIFF
--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -21,6 +21,7 @@ return {
       'htmldjango',
       'edge',
       'eelixir', -- vim ft
+      'elixir',
       'ejs',
       'erb',
       'eruby', -- vim ft


### PR DESCRIPTION
I've came across problem while working on Phoenix + Surface UI + TailwindCSS. Tailwindcss is not working for elixir filetypes. 