### PR TITLE
fix(docs): Updating duplicated functions (formatting) in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ local on_attach = function(client, bufnr)
   vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, bufopts)
   vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
   vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
-  vim.keymap.set('n', '<space>f', vim.lsp.buf.formatting, bufopts)
+  vim.keymap.set('n', '<space>f', function()
+    vim.lsp.buf.format{ async = true }
+  end, bufopts)
 end
 
 local lsp_flags = {

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -509,7 +509,9 @@ attached to a given buffer.
     vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, bufopts)
     vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
     vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
-    vim.keymap.set('n', '<space>f', vim.lsp.buf.formatting, bufopts)
+    vim.keymap.set('n', '<space>f', function()
+      vim.lsp.buf.format{ async = true }
+    end, bufopts)
   end
 
   local lsp_flags = {


### PR DESCRIPTION
When using the immediate code formatting function: `vim.lsp.buf.formatting`, we get a warning notify like this
```
vim.lsp.buf.formatting is deprecated. Use vim.lsp.buf.format { async = true } instead
```

This PR replaces `vim.lsp.buf.formatting` in doc/lspconfig.txt and README.md with `function() vim.lsp.buf.format{ async = true } end`.