### PR TITLE
fix(lua-language-server): check if root dir is home directory

### DIFF
--- a/lua/lspconfig/server_configurations/sumneko_lua.lua
+++ b/lua/lspconfig/server_configurations/sumneko_lua.lua
@@ -20,7 +20,11 @@ return {
     cmd = cmd,
     filetypes = { 'lua' },
     root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
+      local root = util.root_pattern(unpack(root_files))(fname)
+      if root and root ~= vim.env.HOME then
+        return root
+      end
+      return util.find_git_ancestor(fname)
     end,
     single_file_support = true,
     log_level = vim.lsp.protocol.MessageType.Warning,


### PR DESCRIPTION
There have been cases reported where the absence of this check causes the home directory to be set as the workspace, resulting in an error message. 
```
LSP[sumneko_lua] Your workspace is set to '/home/uga'. Lua language server refused to load this directory. Please check your configuration.[learn more here](https://github.com/sumneko/lua-language-server/wiki/Why-scanning-home-folder)
```