### PR TITLE
Add proto to filetypes for clangd

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -861,7 +861,7 @@ require'lspconfig'.clangd.setup{}
   ```
   - `filetypes` : 
   ```lua
-  { "c", "cpp", "objc", "objcpp", "cuda" }
+  { "c", "cpp", "objc", "objcpp", "cuda", "proto" }
   ```
   - `root_dir` : 
   ```lua

--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -861,7 +861,7 @@ require'lspconfig'.clangd.setup{}
   ```
   - `filetypes` : 
   ```lua
-  { "c", "cpp", "objc", "objcpp", "cuda" }
+  { "c", "cpp", "objc", "objcpp", "cuda", "proto" }
   ```
   - `root_dir` : 
   ```lua

--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -42,7 +42,7 @@ local default_capabilities = {
 return {
   default_config = {
     cmd = { 'clangd' },
-    filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda' },
+    filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda', 'proto' },
     root_dir = function(fname)
       return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
     end,


### PR DESCRIPTION
clangd supports formatting and some basic linting for protobuf files. Here is an example .clang-format file with a section for protobuf files:

```
---
Language: Proto
BasedOnStyle: Google
ColumnLimit: 100
AllowShortFunctionsOnASingleLine: Empty
```