### PR TITLE
feat: filter user commands

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -291,7 +291,13 @@ function configs.__newindex(t, config_name, config_def)
       M.commands = vim.tbl_deep_extend('force', M.commands, client.config.commands)
     end
     if not M.commands_created and not vim.tbl_isempty(M.commands) then
-      util.create_module_commands(config_name, M.commands)
+      local user_commands = {}
+      for k, v in pairs(M.commands) do
+        if k:match '^%u' then
+          user_commands[k] = v
+        end
+      end
+      util.create_module_commands(config_name, user_commands)
     end
   end
 


### PR DESCRIPTION
This patch allows the usage of server commands without passing them using `on_init` or `before_init` (which might be overridden by a user). This is especially useful for custom servers. Therefore this is now possible:
```lua
local function custom_command(command, ctx)
    -- do something
end

local configs = require "lspconfig.configs"
if not configs["custom"] then
    configs["custom"] = {
        -- ...
        default_config = {
            -- ...
            commands = {
                ["custom.aCustomCommand"] = custom_command,
            },
        },
    }
end

```
These commands can be consumed by e.g. [code actions](https://github.com/neovim/neovim/blob/2d6735d8cecc587eb5549f65260ee9ddeb8e1d78/runtime/lua/vim/lsp/buf.lua#L807).