### PR TITLE
fix(astro): enable typescript server

### DIFF
--- a/lua/lspconfig/server_configurations/astro.lua
+++ b/lua/lspconfig/server_configurations/astro.lua
@@ -7,14 +7,32 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local function get_typescript_server_path(root_dir)
+  local project_root = util.find_node_modules_ancestor(root_dir)
+  return project_root and (util.path.join(project_root, 'node_modules', 'typescript', 'lib', 'tsserverlibrary.js'))
+    or ''
+end
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'astro' },
     root_dir = util.root_pattern('package.json', 'tsconfig.json', 'jsconfig.json', '.git'),
     init_options = {
+      typescript = {
+        serverPath = '',
+      },
       configuration = {},
     },
+    on_new_config = function(new_config, new_root_dir)
+      if
+        new_config.init_options
+        and new_config.init_options.typescript
+        and new_config.init_options.typescript.serverPath == ''
+      then
+        new_config.init_options.typescript.serverPath = get_typescript_server_path(new_root_dir)
+      end
+    end,
   },
   docs = {
     description = [[


### PR DESCRIPTION
As of version 0.24 of the LSP, a `typescript` field is required, with the same convention as `volar`.