### PR TITLE
fix: check cmd type equals function

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -41,11 +41,10 @@ local function make_config_info(config, bufnr)
   config_info.name = config.name
   config_info.helptags = {}
   if config.cmd then
-    local cmd
     if type(config.cmd) == 'function' then
       config_info.cmd = 'cmd is the function type'
     else
-      config_info.cmd = remove_newlines(cmd)
+      config_info.cmd = remove_newlines(config_info.cmd)
     end
     if vim.fn.executable(config.cmd[1]) == 1 then
       config_info.cmd_is_executable = 'true'

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -43,7 +43,7 @@ local function make_config_info(config, bufnr)
   if config.cmd then
     local cmd
     if type(config.cmd) == 'function' then
-      config_info.cmd = "custom cmd a function type"
+      config_info.cmd = 'cmd is the function type'
     else
       config_info.cmd = remove_newlines(cmd)
     end

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -36,27 +36,27 @@ local function remove_newlines(cmd)
   return cmd
 end
 
+local cmd_type = {
+  ['function'] = function(config)
+    local cmd = 'cmd is the function type'
+    return cmd, 'NA'
+  end,
+  ['table'] = function(config)
+    local cmd = remove_newlines(config.cmd)
+    if vim.fn.executable(config.cmd[1]) == 1 then
+      return cmd, 'true'
+    end
+    return cmd, error_messages.cmd_not_found
+  end,
+}
+
 local function make_config_info(config, bufnr)
   local config_info = {}
   config_info.name = config.name
   config_info.helptags = {}
 
-  local cmd_type = {
-    ['function'] = function()
-      local cmd = 'cmd is the function type'
-      return cmd, 'NA'
-    end,
-    ['table'] = function()
-      local cmd = remove_newlines(config_info.cmd)
-      if vim.fn.executable(config.cmd[1]) == 1 then
-        return cmd, 'true'
-      end
-      return cmd, error_messages.cmd_not_found
-    end,
-  }
-
   if config.cmd then
-    config_info.cmd, config_info.cmd_is_executable = cmd_type[type(config.cmd)]()
+    config_info.cmd, config_info.cmd_is_executable = cmd_type[type(config.cmd)](config)
   else
     config_info.cmd = 'cmd not defined'
     config_info.cmd_is_executable = 'NA'
@@ -114,7 +114,7 @@ end
 local function make_client_info(client)
   local client_info = {}
 
-  client_info.cmd = remove_newlines(client.config.cmd)
+  client_info.cmd, _ = cmd_type[type(client.config.cmd)](client.config)
   if client.workspaceFolders then
     client_info.root_dir = client.workspaceFolders[1].name
   else

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -41,7 +41,14 @@ local function make_config_info(config, bufnr)
   config_info.name = config.name
   config_info.helptags = {}
   if config.cmd then
-    config_info.cmd = remove_newlines(config.cmd)
+    local cmd
+    if type(config.cmd) == 'function' then
+      cmd = config.cmd()
+    else
+      cmd = config_info.cmd
+    end
+
+    config_info.cmd = remove_newlines(cmd)
     if vim.fn.executable(config.cmd[1]) == 1 then
       config_info.cmd_is_executable = 'true'
     else

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -37,9 +37,8 @@ local function remove_newlines(cmd)
 end
 
 local cmd_type = {
-  ['function'] = function(config)
-    local cmd = 'cmd is the function type'
-    return cmd, 'NA'
+  ['function'] = function(_)
+    return '<function>', 'NA'
   end,
   ['table'] = function(config)
     local cmd = remove_newlines(config.cmd)
@@ -114,7 +113,7 @@ end
 local function make_client_info(client)
   local client_info = {}
 
-  client_info.cmd, _ = cmd_type[type(client.config.cmd)](client.config)
+  client_info.cmd = cmd_type[type(client.config.cmd)](client.config)
   if client.workspaceFolders then
     client_info.root_dir = client.workspaceFolders[1].name
   else

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -43,12 +43,10 @@ local function make_config_info(config, bufnr)
   if config.cmd then
     local cmd
     if type(config.cmd) == 'function' then
-      cmd = config.cmd()
+      config_info.cmd = "custom cmd a function type"
     else
-      cmd = config_info.cmd
+      config_info.cmd = remove_newlines(cmd)
     end
-
-    config_info.cmd = remove_newlines(cmd)
     if vim.fn.executable(config.cmd[1]) == 1 then
       config_info.cmd_is_executable = 'true'
     else

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -40,12 +40,18 @@ local function make_config_info(config, bufnr)
   local config_info = {}
   config_info.name = config.name
   config_info.helptags = {}
+
+  local cmd_type = {
+    ['function'] = function()
+      return 'cmd is the function type'
+    end,
+    ['table'] = function()
+      return remove_newlines(config_info.cmd)
+    end,
+  }
+
   if config.cmd then
-    if type(config.cmd) == 'function' then
-      config_info.cmd = 'cmd is the function type'
-    else
-      config_info.cmd = remove_newlines(config_info.cmd)
-    end
+    config_info.cmd = cmd_type[type(config.cmd)]()
     if vim.fn.executable(config.cmd[1]) == 1 then
       config_info.cmd_is_executable = 'true'
     else

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -43,20 +43,20 @@ local function make_config_info(config, bufnr)
 
   local cmd_type = {
     ['function'] = function()
-      return 'cmd is the function type'
+      local cmd = 'cmd is the function type'
+      return cmd, 'NA'
     end,
     ['table'] = function()
-      return remove_newlines(config_info.cmd)
+      local cmd = remove_newlines(config_info.cmd)
+      if vim.fn.executable(config.cmd[1]) == 1 then
+        return cmd, 'true'
+      end
+      return cmd, error_messages.cmd_not_found
     end,
   }
 
   if config.cmd then
-    config_info.cmd = cmd_type[type(config.cmd)]()
-    if vim.fn.executable(config.cmd[1]) == 1 then
-      config_info.cmd_is_executable = 'true'
-    else
-      config_info.cmd_is_executable = error_messages.cmd_not_found
-    end
+    config_info.cmd, config_info.cmd_is_executable = cmd_type[type(config.cmd)]()
   else
     config_info.cmd = 'cmd not defined'
     config_info.cmd_is_executable = 'NA'


### PR DESCRIPTION
with the upstream change `cmd` can be a function value.

Fix #2141 