### PR TITLE
Docs: Install note for astro-ls + typescript integration

### DIFF
--- a/lua/lspconfig/server_configurations/astro.lua
+++ b/lua/lspconfig/server_configurations/astro.lua
@@ -41,6 +41,22 @@ https://github.com/withastro/language-tools/tree/main/packages/language-server
 `astro-ls` can be installed via `npm`:
 ```sh
 npm install -g @astrojs/language-server
+
+To use `tsserver` integration, you need to install it via `npm`:
+```sh
+npm install -g typescript
+```
+
+Then configure `astro-ls` to use `typescript.js` file which comes with `typescript` package. It's locaed in `lib/typescript.js`:
+
+```lua
+require 'lspconfig'.astro.setup {
+  init_options = {
+    typescript = {
+      serverPath = "<YOUR_PATH_TO_GLOBAL_NPM_PACKAGES>/node_modules/typescript/lib/typescript.js"
+    },
+  },
+}
 ```
 ]],
     default_config = {


### PR DESCRIPTION
This PR adds a note to Astro Language Server, which requires additional configuration in order to fully work with TypeScript. Without this step, the LS won't fully understand `.astro` files.

My dotfiles for reference: https://github.com/witoszekdev/dotfiles/commit/afca98711d85053e85dbc9bbc439975147e30339