### PR TITLE
fix(elixirls): added surface filetype for elixirls server configuration

### DIFF
--- a/lua/lspconfig/server_configurations/elixirls.lua
+++ b/lua/lspconfig/server_configurations/elixirls.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    filetypes = { 'elixir', 'eelixir', 'heex' },
+    filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
     root_dir = function(fname)
       return util.root_pattern('mix.exs', '.git')(fname) or vim.loop.os_homedir()
     end,


### PR DESCRIPTION
I've came across problem while working on Phoenix + Surface UI + TailwindCSS. Without Elixirls I'm not able to format `.sface` file.