### PR TITLE
fix: override another progress handler for jdtls

### DIFF
--- a/lua/lspconfig/server_configurations/jdtls.lua
+++ b/lua/lspconfig/server_configurations/jdtls.lua
@@ -120,6 +120,7 @@ return {
       ['textDocument/rename'] = on_textdocument_rename,
       ['workspace/applyEdit'] = on_workspace_applyedit,
       ['language/status'] = vim.schedule_wrap(on_language_status),
+      ['$/progress'] = vim.schedule_wrap(on_language_status),
     },
   },
   docs = {


### PR DESCRIPTION
Due to non-compliant message from jdtls, users may encounter issues like https://github.com/mfussenegger/nvim-jdtls/issues/327

LMK if there is a better way to do it but it seems to be the easiest temporary fix