### PR TITLE
fix: added `lua/` to sumenko root patterns

### DIFF
--- a/lua/lspconfig/server_configurations/sumneko_lua.lua
+++ b/lua/lspconfig/server_configurations/sumneko_lua.lua
@@ -6,6 +6,7 @@ local root_files = {
   '.stylua.toml',
   'stylua.toml',
   'selene.toml',
+  'lua/',
 }
 
 local bin_name = 'lua-language-server'


### PR DESCRIPTION
Neovim plugins always have a `lua/` directory where all the source code is. This PR adds this directory to the root pattern.