### PR TITLE
revert: fix: added 'lua/' to sumenko root patterns

### DIFF
--- a/lua/lspconfig/server_configurations/sumneko_lua.lua
+++ b/lua/lspconfig/server_configurations/sumneko_lua.lua
@@ -6,7 +6,6 @@ local root_files = {
   '.stylua.toml',
   'stylua.toml',
   'selene.toml',
-  'lua/',
 }
 
 local bin_name = 'lua-language-server'


### PR DESCRIPTION
While it is true that `lua/` directory usually indicates the root directory of a Nvim plugin, it doesn't always indicate the root of a workspace. For example, in `neovim/neovim` repository, the existence of `test/functional/lua/` is causing `test/functional/` to be recognized as the root of a workspace, which is a bit annoying.