### PR TITLE
Sumenko lua rootpattern

### DIFF
--- a/lua/lspconfig/server_configurations/sumneko_lua.lua
+++ b/lua/lspconfig/server_configurations/sumneko_lua.lua
@@ -6,7 +6,6 @@ local root_files = {
   '.stylua.toml',
   'stylua.toml',
   'selene.toml',
-  'lua/',
 }
 
 local bin_name = 'lua-language-server'
@@ -21,7 +20,7 @@ return {
     cmd = cmd,
     filetypes = { 'lua' },
     root_dir = function(fname)
-      local root = util.root_pattern(unpack(root_files))(fname)
+      local root = util.root_pattern(unpack(root_files))(fname) or util.root_pattern 'lua/'(fname)
       if root and root ~= vim.env.HOME then
         return root
       end


### PR DESCRIPTION
As discussed with @zeertzjq , I've changed the root detection to how it was originally. 

But when no root file could be found, we fall back to finding a rootpattern with `lua/`