### PR TITLE
fix: grammarly "clientId is required"

### DIFF
--- a/lua/lspconfig/server_configurations/grammarly.lua
+++ b/lua/lspconfig/server_configurations/grammarly.lua
@@ -18,6 +18,9 @@ return {
         return ''
       end,
     },
+    init_options = {
+      clientId = 'client_BaDkMgx4X19X9UxxYRCXZo',
+    },
   },
   docs = {
     description = [[


### PR DESCRIPTION
Base on the discussion in [znck/grammarly/](https://github.com/znck/grammarly/discussions/285)
Add clientId to init_options for fixing "Request initialize failed with message: clientId is required"