### PR TITLE
fix(marksman): enable single_file_support

### DIFF
--- a/lua/lspconfig/server_configurations/marksman.lua
+++ b/lua/lspconfig/server_configurations/marksman.lua
@@ -11,6 +11,7 @@ return {
       local root_files = { '.marksman.toml' }
       return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
     end,
+    single_file_support = true,
   },
   docs = {
     description = [[


### PR DESCRIPTION
Marksman supports single-file mode from version [2022-09-08](https://github.com/artempyanykh/marksman/releases/tag/2022-09-08).