### PR TITLE
feat: add erg-language-server support

### DIFF
--- a/lua/lspconfig/server_configurations/erg_language_server.lua
+++ b/lua/lspconfig/server_configurations/erg_language_server.lua
@@ -1,10 +1,12 @@
-local util = require "lspconfig.util"
+local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { "els" },
-    filetypes = { "erg" },
-    root_dir = util.find_git_ancestor,
+    cmd = { 'els' },
+    filetypes = { 'erg' },
+    root_dir = function(fname)
+      return util.root_pattern 'package.er'(fname) or util.find_git_ancestor(fname)
+    end,
   },
   docs = {
     description = [[
@@ -18,7 +20,7 @@ ELS (erg-language-server) is a language server for the Erg programing language.
  ```
     ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      root_dir = [[root_pattern("package.er") or find_git_ancestor]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/erg_language_server.lua
+++ b/lua/lspconfig/server_configurations/erg_language_server.lua
@@ -12,7 +12,7 @@ return {
     description = [[
 https://github.com/erg-lang/erg-language-server
 
-ELS (erg-language-server) is a language server for the Erg programing language.
+ELS (erg-language-server) is a language server for the Erg programming language.
 
 `els` can be installed via `cargo`:
  ```sh

--- a/lua/lspconfig/server_configurations/erg_language_server.lua
+++ b/lua/lspconfig/server_configurations/erg_language_server.lua
@@ -1,0 +1,24 @@
+local util = require "lspconfig.util"
+
+return {
+  default_config = {
+    cmd = { "els" },
+    filetypes = { "erg" },
+    root_dir = util.find_git_ancestor,
+  },
+  docs = {
+    description = [[
+https://github.com/erg-lang/erg-language-server
+
+ELS (erg-language-server) is a language server for the Erg programing language.
+
+`els` can be installed via `cargo`:
+ ```sh
+ cargo install els
+ ```
+    ]],
+    default_config = {
+      root_dir = [[util.find_git_ancestor]],
+    },
+  },
+}


### PR DESCRIPTION
Repost from #2164 

[Erg Programming Language](https://erg-lang.org/)

A generic statically typed language that can deeply improve the Python ecosystem.

Please add support for the Erg language with its language server [erg-language-server](https://github.com/erg-lang/erg-language-server).

Thanks in advance,
@pysan3