### PR TITLE
docs: `vim.lsp.buf.formatting()` is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ local on_attach = function(client, bufnr)
   vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, bufopts)
   vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
   vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
-  vim.keymap.set('n', '<space>f', vim.lsp.buf.formatting, bufopts)
+  vim.keymap.set('n', '<space>f', function() vim.lsp.buf.format { async = true } end, bufopts)
 end
 
 local lsp_flags = {

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -509,7 +509,7 @@ attached to a given buffer.
     vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, bufopts)
     vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
     vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
-    vim.keymap.set('n', '<space>f', vim.lsp.buf.formatting, bufopts)
+    vim.keymap.set('n', '<space>f', function() vim.lsp.buf.format { async = true } end, bufopts)
   end
 
   local lsp_flags = {


### PR DESCRIPTION
I think it's time to apply the changes in #2074 again as [Nvim v0.8.0](
https://github.com/neovim/neovim/releases/tag/v0.8.0) has released
```
vim.lsp.buf.formatting is deprecated. Use vim.lsp.buf.format { async = true } instead
```
