### PR TITLE
feat(ruby_ls): add enabledFeatures to initialization options

### DIFF
--- a/lua/lspconfig/server_configurations/ruby_ls.lua
+++ b/lua/lspconfig/server_configurations/ruby_ls.lua
@@ -14,6 +14,16 @@ return {
     cmd = cmd,
     filetypes = { 'ruby' },
     root_dir = util.root_pattern('Gemfile', '.git'),
+    init_options = {
+      enabledFeatures = {
+        'codeActions',
+        'diagnostics',
+        'documentHighlights',
+        'documentSymbols',
+        'formatting',
+        'inlayHint',
+      },
+    },
   },
   docs = {
     description = [[


### PR DESCRIPTION
Without providing these the server will effectively do nothing.

The VSCode client uses these defaults:
https://github.com/Shopify/vscode-ruby-lsp/blob/4bf768d436cccce2aace8d4d738d8d15bd658759/package.json#L103.L115.
Some of these are excluded in this PR due to lack of native support.