### PR TITLE
fix: gdscript use ip address instead of localhost

### DIFF
--- a/lua/lspconfig/server_configurations/gdscript.lua
+++ b/lua/lspconfig/server_configurations/gdscript.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 local cmd = { 'nc', 'localhost', '6008' }
 
 if vim.fn.has 'nvim-0.8' == 1 then
-  cmd = vim.lsp.rpc.connect('localhost', '6008')
+  cmd = vim.lsp.rpc.connect('127.0.0.1', '6008')
 end
 
 return {


### PR DESCRIPTION
`vim.lsp.rpc.connect()` is unable to find a valid IP address with `localhost` changing it to `127.0.0.1` resolve the below error.

![error](https://user-images.githubusercontent.com/6450181/194060440-1793b6b7-b04e-4d52-984f-0637de914836.png)