### PR TITLE
fix: lspconfig help command typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 * If you found a bug in the Nvim LSP client, [report it at the Nvim core repo](https://github.com/neovim/neovim/issues/new?assignees=&labels=bug%2Clsp&template=lsp_bug_report.yml).
 * These configs are **best-effort and unsupported.** See [contributions](#contributions).
 
-See also `:help lspconfig`.
+See also `:help lsp-config`.
 
 ## Install
 


### PR DESCRIPTION
Now readme says `:h lspconfig` to show the help, but it seems typo (:h lsp-config works in my environment).

FWIW
![2022-10-07_13-08](https://user-images.githubusercontent.com/61998590/194465987-38f15ab0-accd-4691-b233-c7c03034a605.png)
