### PR TITLE
feat: support volar 1.0

### DIFF
--- a/lua/lspconfig/server_configurations/volar.lua
+++ b/lua/lspconfig/server_configurations/volar.lua
@@ -2,14 +2,13 @@ local util = require 'lspconfig.util'
 
 local function get_typescript_server_path(root_dir)
   local project_root = util.find_node_modules_ancestor(root_dir)
-  return project_root and (util.path.join(project_root, 'node_modules', 'typescript', 'lib', 'tsserverlibrary.js'))
-    or ''
+  return project_root and (util.path.join(project_root, 'node_modules', 'typescript', 'lib')) or ''
 end
 
 -- https://github.com/johnsoncodehk/volar/blob/master/packages/shared/src/types.ts
 local volar_init_options = {
   typescript = {
-    serverPath = '',
+    tsdk = '',
   },
   languageFeatures = {
     implementation = true,
@@ -63,9 +62,9 @@ return {
       if
         new_config.init_options
         and new_config.init_options.typescript
-        and new_config.init_options.typescript.serverPath == ''
+        and new_config.init_options.typescript.tsdk == ''
       then
-        new_config.init_options.typescript.serverPath = get_typescript_server_path(new_root_dir)
+        new_config.init_options.typescript.tsdk = get_typescript_server_path(new_root_dir)
       end
     end,
   },


### PR DESCRIPTION
Volar has updated the options for the language server. see https://github.com/johnsoncodehk/volar/pull/1916 
In order to support this I have update the configuration.
this also has been reported to neovim https://github.com/neovim/neovim/issues/20010 but is more related to the config not the core.

Thanks in advance.