### PR TITLE
Fix: Default cmd for solang

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -5969,7 +5969,7 @@ require'lspconfig'.solang.setup{}
 **Default values:**
   - `cmd` : 
   ```lua
-  { "solang", "--language-server", "--target", "ewasm" }
+  { "solang", "language-server", "--target", "evm" }
   ```
   - `filetypes` : 
   ```lua

--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -5969,7 +5969,7 @@ require'lspconfig'.solang.setup{}
 **Default values:**
   - `cmd` : 
   ```lua
-  { "solang", "--language-server", "--target", "ewasm" }
+  { "solang", "language-server", "--target", "evm" }
   ```
   - `filetypes` : 
   ```lua

--- a/lua/lspconfig/server_configurations/solang.lua
+++ b/lua/lspconfig/server_configurations/solang.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'solang', '--language-server', '--target', 'ewasm' },
+    cmd = { 'solang', 'language-server', '--target', 'evm' },
     filetypes = { 'solidity' },
     root_dir = util.find_git_ancestor,
   },


### PR DESCRIPTION
The current default command does not work as it should be <code>solang language-server --target ewasm</code> 
instead of <code>solang --language-server --target ewasm</code>. Additionally ewasm has been renamed to evm https://github.com/hyperledger/solang/pull/981. Changed the command in server_configuration lua file as well as docs.