### PR TITLE
feat: eslint support astro file

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -51,6 +51,7 @@ return {
       'typescript.tsx',
       'vue',
       'svelte',
+      'astro',
     },
     -- https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats
     root_dir = util.root_pattern(


### PR DESCRIPTION
add `astro` filetype in eslint server.

Fix #2187 