### PR TITLE
feat: add qmlls which is the lsp from qt

### DIFF
--- a/lua/lspconfig/server_configurations/qmlls.lua
+++ b/lua/lspconfig/server_configurations/qmlls.lua
@@ -1,0 +1,19 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'qmlls' },
+    filetypes = { 'qmljs' },
+    root_dir = function(fname)
+      return util.find_git_ancestor(fname)
+    end,
+    single_file_support = true,
+  },
+  docs = {
+    description = [[
+https://github.com/qt/qtdeclarative
+
+LSP implementation for QML (autocompletion, live linting, etc. in editors),
+        ]],
+  },
+}


### PR DESCRIPTION
Now In qt6.4, the lsp is useable, so I add it

but qmlls is not always in the path, Like in archlinux, it is in the
/usr/lib/qt6/bin/qmlls, so the config maybe always needed edited by user
