### PR TITLE
feat: add dafny support

### DIFF
--- a/lua/lspconfig/server_configurations/dafny.lua
+++ b/lua/lspconfig/server_configurations/dafny.lua
@@ -1,0 +1,13 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    filetypes = { 'dfy', 'dafny'},
+    cmd = { 'dotnet', '/opt/dafny/DafnyLanguageServer.dll'}
+  },
+  docs = {
+    description = [[
+    Lsp for dafny
+]],
+  },
+}


### PR DESCRIPTION
Hi.. I want to add support to another new language which is called dafny. It is a formal verification language.

But right now I still have a bit problems with it. The commands are only tested on Linux. It seems that lspconfig does not run the command dotnet /opt/dafny/DafnyLanguageServer.dll 

Can anybody help me with it?