### PR TITLE
Add --adaptive-lsp-server-enabled for F# LSP

### DIFF
--- a/lua/lspconfig/server_configurations/fsautocomplete.lua
+++ b/lua/lspconfig/server_configurations/fsautocomplete.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'fsautocomplete', '--background-service-enabled' },
+    cmd = { 'fsautocomplete', '--background-service-enabled', '--adaptive-lsp-server-enabled' },
     root_dir = util.root_pattern('*.sln', '*.fsproj', '.git'),
     filetypes = { 'fsharp' },
     init_options = {


### PR DESCRIPTION
This change handle loading of projects and type checking in an adaptive way.

Depends on [fsautocomplete 0.58.0](https://www.nuget.org/packages/fsautocomplete/0.58.0) or greater.

Related pull requests:
https://github.com/fsharp/FsAutoComplete/pull/1007
https://github.com/ionide/ionide-vscode-fsharp/pull/1781