### PR TITLE
fix: remove --background-service-enabled and add  --adaptive-lsp-server-enabled for F#

### DIFF
--- a/lua/lspconfig/server_configurations/fsautocomplete.lua
+++ b/lua/lspconfig/server_configurations/fsautocomplete.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'fsautocomplete', '--background-service-enabled' },
+    cmd = { 'fsautocomplete', '--adaptive-lsp-server-enabled' },
     root_dir = util.root_pattern('*.sln', '*.fsproj', '.git'),
     filetypes = { 'fsharp' },
     init_options = {


### PR DESCRIPTION
@glepnir Thanks for the revision. I have opened a new PR.

This pull request removes the `--background-service-enabled` parameter, based on https://github.com/fsharp/FsAutoComplete/pull/952

This also change handle loading of projects and type checking in an adaptive way (https://github.com/fsharp/FsAutoComplete/pull/1007 and https://github.com/ionide/ionide-vscode-fsharp/pull/1781), adding the `--adaptive-lsp-server-enabled` parameter.

Depends on [fsautocomplete 0.58.0](https://www.nuget.org/packages/fsautocomplete/0.58.0) or greater.