### PR TITLE
feat: export workspace markers

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -222,9 +222,9 @@ require'lspconfig'.als.setup{}
   ```lua
   { "ada" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern("Makefile", ".git", "*.gpr", "*.adc")
+  { "Makefile", ".git", "*.gpr", "*.adc" }
   ```
 
 
@@ -265,9 +265,9 @@ require'lspconfig'.angularls.setup{}
   ```lua
   { "typescript", "html", "typescriptreact", "typescript.tsx" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("angular.json")
+  { "angular.json" }
   ```
 
 
@@ -299,10 +299,6 @@ require'lspconfig'.ansiblels.setup{}
   - `filetypes` : 
   ```lua
   { "yaml.ansible" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `settings` : 
   ```lua
@@ -356,10 +352,6 @@ require'lspconfig'.antlersls.setup{}
   ```lua
   { "html", "antlers" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## apex_ls
@@ -392,13 +384,9 @@ require'lspconfig'.apex_ls.setup{}
   ```lua
   { "apexcode" }
   ```
-  - `on_new_config` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern('sfdx-project.json')
+  { "sfdx-project.json" }
   ```
 
 
@@ -469,10 +457,6 @@ require'lspconfig'.arduino_language_server.setup{}
   ```lua
   { "arduino" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## asm_lsp
@@ -500,10 +484,6 @@ require'lspconfig'.asm_lsp.setup{}
   - `filetypes` : 
   ```lua
   { "asm", "vmasm" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
 
 
@@ -542,13 +522,9 @@ require'lspconfig'.astro.setup{}
     }
   }
   ```
-  - `on_new_config` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")
+  { "package.json", "tsconfig.json", "jsconfig.json", ".git" }
   ```
 
 
@@ -618,13 +594,13 @@ require'lspconfig'.bashls.setup{}
   ```lua
   { "sh" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -657,13 +633,13 @@ require'lspconfig'.beancount.setup{}
     journalFile = ""
   }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -718,9 +694,9 @@ require'lspconfig'.bicep.setup{}
   ```lua
   {}
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.find_git_ancestor
+  { ".git" }
   ```
 
 
@@ -756,13 +732,13 @@ require'lspconfig'.blueprint_ls.setup{}
   ```lua
   { "blueprint" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -786,9 +762,9 @@ require'lspconfig'.bsl_ls.setup{}
   ```lua
   { "bsl", "os" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".git")
+  { ".git" }
   ```
 
 
@@ -874,13 +850,13 @@ require'lspconfig'.ccls.setup{}
   ```lua
   "utf-32"
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern('compile_commands.json', '.ccls', '.git')
-  ```
   - `single_file_support` : 
   ```lua
   false
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "compile_commands.json", ".ccls", ".git" }
   ```
 
 
@@ -919,22 +895,13 @@ require'lspconfig'.clangd.setup{}
   ```lua
   { "c", "cpp", "objc", "objcpp", "cuda", "proto" }
   ```
-  - `root_dir` : 
-  ```lua
-          root_pattern(
-            '.clangd',
-            '.clang-tidy',
-            '.clang-format',
-            'compile_commands.json',
-            'compile_flags.txt',
-            'configure.ac',
-            '.git'
-          )
-        
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".clangd", ".clang-tidy", ".clang-format", "compile_commands.json", "compile_flags.txt", ".git", "configure.ac" }
   ```
 
 
@@ -961,9 +928,9 @@ require'lspconfig'.clarity_lsp.setup{}
   ```lua
   { "clar", "clarity" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".git")
+  { ".git" }
   ```
 
 
@@ -990,9 +957,9 @@ require'lspconfig'.clojure_lsp.setup{}
   ```lua
   { "clojure", "edn" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("project.clj", "deps.edn", "build.boot", "shadow-cljs.edn", ".git")
+  { "project.clj", "deps.edn", "build.boot", "shadow-cljs.edn", ".git" }
   ```
 
 
@@ -1052,10 +1019,6 @@ require'lspconfig'.codeqlls.setup{}
 
 
 **Default values:**
-  - `before_init` : 
-  ```lua
-  see source file
-  ```
   - `cmd` : 
   ```lua
   { "codeql", "execute", "language-server", "--check-errors", "ON_CHANGE", "-q" }
@@ -1067,10 +1030,6 @@ require'lspconfig'.codeqlls.setup{}
   - `log_level` : 
   ```lua
   2
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `settings` : 
   ```lua
@@ -1103,13 +1062,13 @@ require'lspconfig'.crystalline.setup{}
   ```lua
   { "crystal" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern('shard.yml', '.git')
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "shard.yml", ".git" }
   ```
 
 
@@ -1145,10 +1104,6 @@ require'lspconfig'.csharp_ls.setup{}
   {
     AutomaticWorkspaceInit = true
   }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
 
 
@@ -1192,10 +1147,6 @@ require'lspconfig'.cssls.setup{}
   ```lua
   { "css", "scss", "less" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("package.json", ".git") or bufdir
-  ```
   - `settings` : 
   ```lua
   {
@@ -1213,6 +1164,10 @@ require'lspconfig'.cssls.setup{}
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "package.json", ".git" }
   ```
 
 
@@ -1280,9 +1235,9 @@ require'lspconfig'.cucumber_language_server.setup{}
   ```lua
   { "cucumber" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.find_git_ancestor
+  { ".git" }
   ```
 
 
@@ -1352,10 +1307,6 @@ require'lspconfig'.dartls.setup{}
     suggestFromUnimportedLibraries = true
   }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("pubspec.yaml")
-  ```
   - `settings` : 
   ```lua
   {
@@ -1364,6 +1315,10 @@ require'lspconfig'.dartls.setup{}
       showTodos = true
     }
   }
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "pubspec.yaml" }
   ```
 
 
@@ -1399,7 +1354,9 @@ require'lspconfig'.denols.setup{}
   ```
   - `filetypes` : 
   ```lua
-  { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" }
+  { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx",
+    workspace_markers = { "deno.json", "deno.jsonc", ".git" }
+  }
   ```
   - `handlers` : 
   ```lua
@@ -1415,10 +1372,6 @@ require'lspconfig'.denols.setup{}
     enable = true,
     unstable = false
   }
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("deno.json", "deno.jsonc", ".git")
   ```
 
 
@@ -1451,13 +1404,13 @@ require'lspconfig'.dhall_lsp_server.setup{}
   ```lua
   { "dhall" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -1520,13 +1473,13 @@ require'lspconfig'.dockerls.setup{}
   ```lua
   { "dockerfile" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("Dockerfile")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "Dockerfile" }
   ```
 
 
@@ -1556,10 +1509,6 @@ require'lspconfig'.dotls.setup{}
   ```lua
   { "dot" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -1579,6 +1528,7 @@ launching the language server on single files. If on an older version of EFM, di
 require('lspconfig')['efm'].setup{
   settings = ..., -- You must populate this according to the EFM readme
   filetypes = ..., -- Populate this according to the note below
+  workspace_markers = workspace_markers,
   single_file_support = false, -- This is the important line for supporting older version of EFM
 }
 ```
@@ -1607,10 +1557,6 @@ require'lspconfig'.efm.setup{}
   - `cmd` : 
   ```lua
   { "efm-langserver" }
-  ```
-  - `root_dir` : 
-  ```lua
-  util.root_pattern(".git")
   ```
   - `single_file_support` : 
   ```lua
@@ -1727,9 +1673,9 @@ require'lspconfig'.ember.setup{}
   ```lua
   { "handlebars", "typescript", "javascript" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("ember-cli-build.js", ".git")
+  { "ember-cli-build.js", ".git" }
   ```
 
 
@@ -1797,9 +1743,9 @@ require'lspconfig'.erg_language_server.setup{}
   ```lua
   { "erg" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("package.er") or find_git_ancestor
+  { "package.er", ".git" }
   ```
 
 
@@ -1835,13 +1781,13 @@ require'lspconfig'.erlangls.setup{}
   ```lua
   { "erlang" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern('rebar.config', 'erlang.mk', '.git')
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "rebar.config", "erlang.mk", ".git" }
   ```
 
 
@@ -1907,10 +1853,6 @@ require'lspconfig'.esbonio.setup{}
   ```lua
   { "rst" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## eslint
@@ -1961,14 +1903,6 @@ require'lspconfig'.eslint.setup{}
     ["eslint/openDoc"] = <function 3>,
     ["eslint/probeFailed"] = <function 4>
   }
-  ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `settings` : 
   ```lua
@@ -2033,9 +1967,9 @@ require'lspconfig'.flow.setup{}
   ```lua
   { "javascript", "javascriptreact", "javascript.jsx" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".flowconfig")
+  { ".flowconfig" }
   ```
 
 
@@ -2064,13 +1998,13 @@ require'lspconfig'.flux_lsp.setup{}
   ```lua
   { "flux" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -2099,10 +2033,6 @@ require'lspconfig'.foam_ls.setup{}
   - `filetypes` : 
   ```lua
   { "foam", "OpenFOAM" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
 
 
@@ -2136,10 +2066,6 @@ require'lspconfig'.fortls.setup{}
   - `filetypes` : 
   ```lua
   { "fortran" }
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".fortls")
   ```
   - `settings` : 
   ```lua
@@ -2189,10 +2115,6 @@ require'lspconfig'.fsautocomplete.setup{}
     AutomaticWorkspaceInit = true
   }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## fsharp_language_server
@@ -2233,10 +2155,6 @@ require'lspconfig'.fsharp_language_server.setup{}
     AutomaticWorkspaceInit = true
   }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -2266,9 +2184,9 @@ require'lspconfig'.fstar.setup{}
   ```lua
   { "fstar" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.find_git_ancestor
+  { ".git" }
   ```
 
 
@@ -2287,17 +2205,13 @@ require'lspconfig'.gdscript.setup{}
 
 
 **Default values:**
-  - `cmd` : 
-  ```lua
-  see source file
-  ```
   - `filetypes` : 
   ```lua
   { "gd", "gdscript", "gdscript3" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern("project.godot", ".git")
+  { "project.godot", ".git" }
   ```
 
 
@@ -2325,9 +2239,9 @@ require'lspconfig'.ghcide.setup{}
   ```lua
   { "haskell", "lhaskell" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("stack.yaml", "hie-bios", "BUILD.bazel", "cabal.config", "package.yaml")
+  { "stack.yaml", "hie-bios", "BUILD.bazel", "cabal.config", "package.yaml" }
   ```
 
 
@@ -2357,13 +2271,13 @@ require'lspconfig'.ghdl_ls.setup{}
   ```lua
   { "vhdl" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "hdl-prj.json", ".git" }
   ```
 
 
@@ -2408,14 +2322,6 @@ require'lspconfig'.glint.setup{}
   ```lua
   { "html.handlebars", "handlebars", "typescript", "typescript.glimmer", "javascript", "javascript.glimmer" }
   ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## glslls
@@ -2454,10 +2360,6 @@ require'lspconfig'.glslls.setup{}
   - `filetypes` : 
   ```lua
   { "glsl" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -2623,13 +2525,13 @@ require'lspconfig'.grammarly.setup{}
     clientId = "client_BaDkMgx4X19X9UxxYRCXZo"
   }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -2662,9 +2564,9 @@ require'lspconfig'.graphql.setup{}
   ```lua
   { "graphql", "typescriptreact", "javascriptreact" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern('.git', '.graphqlrc*', '.graphql.config.*', 'graphql.config.*')
+  { ".git", ".graphqlrc*", ".graphql.config.*", "graphql.config.*" }
   ```
 
 
@@ -2705,9 +2607,9 @@ require'lspconfig'.groovyls.setup{}
   ```lua
   { "groovy" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
+  { "Jenkinsfile", ".git" }
   ```
 
 
@@ -2760,10 +2662,6 @@ require'lspconfig'.haxe_language_server.setup{}
     displayArguments = { "build.hxml" }
   }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("*.hxml")
-  ```
   - `settings` : 
   ```lua
   {
@@ -2771,6 +2669,10 @@ require'lspconfig'.haxe_language_server.setup{}
       executable = "haxe"
     }
   }
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "*.hxml" }
   ```
 
 
@@ -2797,13 +2699,13 @@ require'lspconfig'.hdl_checker.setup{}
   ```lua
   { "vhdl", "verilog", "systemverilog" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -2832,9 +2734,9 @@ require'lspconfig'.hhvm.setup{}
   ```lua
   { "php", "hack" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".hhconfig")
+  { ".hhconfig" }
   ```
 
 
@@ -2874,9 +2776,9 @@ require'lspconfig'.hie.setup{}
   ```lua
   { "haskell" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("stack.yaml", "package.yaml", ".git")
+  { "stack.yaml", "package.yaml", ".git" }
   ```
 
 
@@ -2902,10 +2804,6 @@ require'lspconfig'.hls.setup{}
   - `filetypes` : 
   ```lua
   { "haskell", "lhaskell" }
-  ```
-  - `lspinfo` : 
-  ```lua
-  see source file
   ```
   - `root_dir` : 
   ```lua
@@ -2958,10 +2856,6 @@ require'lspconfig'.hoon_ls.setup{}
   - `filetypes` : 
   ```lua
   { "hoon" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -3021,10 +2915,6 @@ require'lspconfig'.html.setup{}
     provideFormatter = true
   }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -3083,10 +2973,6 @@ require'lspconfig'.idris2_lsp.setup{}
   ```lua
   { "idris2" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## intelephense
@@ -3142,10 +3028,6 @@ require'lspconfig'.java_language_server.setup{}
   ```lua
   { "java" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -3197,7 +3079,7 @@ require'lspconfig'.jdtls.setup{}
 **Default values:**
   - `cmd` : 
   ```lua
-  { "jdtls", "-configuration", "/home/runner/.cache/jdtls/config", "-data", "/home/runner/.cache/jdtls/workspace" }
+  { "jdtls", "-configuration", "/home/hatsu/.cache/jdtls/config", "-data", "/home/hatsu/.cache/jdtls/workspace" }
   ```
   - `filetypes` : 
   ```lua
@@ -3216,7 +3098,7 @@ require'lspconfig'.jdtls.setup{}
   ```lua
   {
     jvm_args = {},
-    workspace = "/home/runner/.cache/jdtls/workspace"
+    workspace = "/home/hatsu/.cache/jdtls/workspace"
   }
   ```
   - `root_dir` : 
@@ -3318,13 +3200,13 @@ require'lspconfig'.jsonls.setup{}
     provideFormatter = true
   }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -3356,13 +3238,9 @@ require'lspconfig'.jsonnet_ls.setup{}
   ```lua
   { "jsonnet", "libsonnet" }
   ```
-  - `on_new_config` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("jsonnetfile.json")
+  { "jsonnetfile.json", ".git" }
   ```
 
 
@@ -3405,13 +3283,13 @@ require'lspconfig'.julials.setup{}
   ```lua
   { "julia" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "Project.toml", ".git" }
   ```
 
 
@@ -3531,10 +3409,6 @@ require'lspconfig'.leanls.setup{}
   ```lua
   { "lean" }
   ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
   - `options` : 
   ```lua
   {
@@ -3579,10 +3453,6 @@ require'lspconfig'.lelwel_ls.setup{}
   ```lua
   { "llw" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## lemminx
@@ -3611,13 +3481,13 @@ require'lspconfig'.lemminx.setup{}
   ```lua
   { "xml", "xsd", "xsl", "xslt", "svg" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -3652,14 +3522,6 @@ require'lspconfig'.ltex.setup{}
   ```lua
   { "bib", "gitcommit", "markdown", "org", "plaintex", "rst", "rnoweb", "tex" }
   ```
-  - `get_language_id` : 
-  ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -3685,9 +3547,9 @@ require'lspconfig'.luau_lsp.setup{}
   ```lua
   { "luau" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".git")
+  { ".git" }
   ```
 
 
@@ -3726,10 +3588,6 @@ require'lspconfig'.m68k.setup{}
   ```lua
   { "asm68k" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -3763,13 +3621,13 @@ require'lspconfig'.marksman.setup{}
   ```lua
   { "markdown" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".git", ".marksman.toml")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".marksman.toml", ".git" }
   ```
 
 
@@ -3826,9 +3684,9 @@ require'lspconfig'.metals.setup{}
   ```lua
   4
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern("build.sbt", "build.sc", "build.gradle", "pom.xml")
+  { "build.sbt", "build.sc", "build.gradle", "pom.xml" }
   ```
 
 
@@ -3856,13 +3714,13 @@ require'lspconfig'.mint.setup{}
   ```lua
   { "mint" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "mint.json", ".git" }
   ```
 
 
@@ -3890,10 +3748,6 @@ require'lspconfig'.mlir_lsp_server.setup{}
   - `filetypes` : 
   ```lua
   { "mlir" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -3926,9 +3780,9 @@ require'lspconfig'.mlir_pdll_lsp_server.setup{}
   ```lua
   { "pdll" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
+  { "pdll_compile_commands.yml", ".git" }
   ```
 
 
@@ -3957,10 +3811,6 @@ require'lspconfig'.mm0_ls.setup{}
   - `filetypes` : 
   ```lua
   { "metamath-zero" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -4081,10 +3931,6 @@ require'lspconfig'.nickel_ls.setup{}
   ```lua
   { "ncl", "nickel" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## nil_ls
@@ -4113,13 +3959,13 @@ require'lspconfig'.nil_ls.setup{}
   ```lua
   { "nix" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("flake.nix", ".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "flake.nix", ".git" }
   ```
 
 
@@ -4150,13 +3996,13 @@ require'lspconfig'.nimls.setup{}
   ```lua
   { "nim" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "*.nimble", ".git" }
   ```
 
 
@@ -4188,9 +4034,9 @@ require'lspconfig'.nxls.setup{}
   ```lua
   { "json", "jsonc" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern
+  { "nx.json", ".git" }
   ```
 
 
@@ -4220,9 +4066,9 @@ require'lspconfig'.ocamlls.setup{}
   ```lua
   { "ocaml", "reason" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("*.opam", "esy.json", "package.json")
+  { "*.opam", "esy.json", "package.json" }
   ```
 
 
@@ -4254,13 +4100,9 @@ require'lspconfig'.ocamllsp.setup{}
   ```lua
   { "ocaml", "ocaml.menhir", "ocaml.interface", "ocaml.ocamllex", "reason", "dune" }
   ```
-  - `get_language_id` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("*.opam", "esy.json", "package.json", ".git", "dune-project", "dune-workspace")
+  { "*.opam", "esy.json", "package.json", ".git", "dune-project", "dune-workspace" }
   ```
 
 
@@ -4287,13 +4129,13 @@ require'lspconfig'.ols.setup{}
   ```lua
   { "odin" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.root_pattern("ols.json", ".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "ols.json", ".git" }
   ```
 
 
@@ -4387,10 +4229,6 @@ require'lspconfig'.omnisharp.setup{}
   ```lua
   {}
   ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
   - `organize_imports_on_format` : 
   ```lua
   false
@@ -4430,9 +4268,9 @@ require'lspconfig'.opencl_ls.setup{}
   ```lua
   { "opencl" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern(".git")
+  { ".git" }
   ```
 
 
@@ -4474,10 +4312,6 @@ require'lspconfig'.openscad_ls.setup{}
   ```lua
   { "openscad" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -4517,10 +4351,6 @@ require'lspconfig'.pasls.setup{}
   - `filetypes` : 
   ```lua
   { "pascal" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -4619,10 +4449,6 @@ require'lspconfig'.perlnavigator.setup{}
   ```lua
   { "perl" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -4655,10 +4481,6 @@ require'lspconfig'.perlpls.setup{}
   ```lua
   { "perl" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `settings` : 
   ```lua
   {
@@ -4675,6 +4497,10 @@ require'lspconfig'.perlpls.setup{}
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -4765,10 +4591,6 @@ require'lspconfig'.please.setup{}
   ```lua
   { "bzl" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -4828,10 +4650,6 @@ require'lspconfig'.powershell_es.setup{}
   ```lua
   { "ps1" }
   ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
   - `root_dir` : 
   ```lua
   git root or current directory
@@ -4872,10 +4690,6 @@ require'lspconfig'.prismals.setup{}
   ```lua
   { "prisma" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".git", "package.json")
-  ```
   - `settings` : 
   ```lua
   {
@@ -4883,6 +4697,10 @@ require'lspconfig'.prismals.setup{}
       prismaFmtBinPath = ""
     }
   }
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git", "package.json" }
   ```
 
 
@@ -4947,9 +4765,9 @@ require'lspconfig'.psalm.setup{}
   ```lua
   { "php" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("psalm.xml", "psalm.xml.dist")
+  { "psalm.xml", "psalm.xml.dist" }
   ```
 
 
@@ -5023,9 +4841,9 @@ require'lspconfig'.purescriptls.setup{}
   ```lua
   { "purescript" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern('spago.dhall', 'psc-package.json', 'bower.json', 'flake.nix', 'shell.nix'),
+  { "bower.json", "psc-package.json", "spago.dhall", "flake.nix", "shell.nix" }
   ```
 
 
@@ -5074,13 +4892,13 @@ require'lspconfig'.pylsp.setup{}
   ```lua
   { "python" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile", ".git" }
   ```
 
 
@@ -5113,10 +4931,6 @@ require'lspconfig'.pyre.setup{}
   ```lua
   { "python" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## pyright
@@ -5142,10 +4956,6 @@ require'lspconfig'.pyright.setup{}
   - `filetypes` : 
   ```lua
   { "python" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `settings` : 
   ```lua
@@ -5188,10 +4998,6 @@ require'lspconfig'.qml_lsp.setup{}
   ```lua
   { "qmljs" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## qmlls
@@ -5216,10 +5022,6 @@ require'lspconfig'.qmlls.setup{}
   - `filetypes` : 
   ```lua
   { "qmljs" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -5251,10 +5053,6 @@ require'lspconfig'.quick_lint_js.setup{}
   - `filetypes` : 
   ```lua
   { "javascript" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -5328,10 +5126,6 @@ require'lspconfig'.racket_langserver.setup{}
   ```lua
   { "racket", "scheme" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -5360,10 +5154,6 @@ require'lspconfig'.reason_ls.setup{}
   - `filetypes` : 
   ```lua
   { "reason" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
 
 
@@ -5416,21 +5206,15 @@ require'lspconfig'.relay_lsp.setup{}
   ```
   - `filetypes` : 
   ```lua
-  { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" }
+  { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx",
+    workspace_markers = { "relay.config.*", "package.json" }
+  }
   ```
   - `handlers` : 
   ```lua
   {
     ["window/showStatus"] = <function 1>
   }
-  ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("relay.config.*", "package.json")
   ```
 
 
@@ -5482,10 +5266,6 @@ require'lspconfig'.remark_ls.setup{}
   - `filetypes` : 
   ```lua
   { "markdown" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -5541,10 +5321,6 @@ require'lspconfig'.rescriptls.setup{}
   ```lua
   { "rescript" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -5597,9 +5373,9 @@ require'lspconfig'.rls.setup{}
   ```lua
   { "rust" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("Cargo.toml")
+  { "Cargo.toml" }
   ```
 
 
@@ -5668,9 +5444,9 @@ require'lspconfig'.robotframework_ls.setup{}
   ```lua
   { "robot" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern('robotidy.toml', 'pyproject.toml')(fname) or util.find_git_ancestor(fname)
+  { "robotidy.toml", "pyproject.toml", ".git" }
   ```
 
 
@@ -5750,9 +5526,9 @@ require'lspconfig'.ruby_ls.setup{}
     enabledFeatures = { "codeActions", "diagnostics", "documentHighlights", "documentSymbols", "formatting", "inlayHint" }
   }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("Gemfile", ".git")
+  { "Gemfile", ".git" }
   ```
 
 
@@ -5821,13 +5597,13 @@ require'lspconfig'.salt_ls.setup{}
   ```lua
   { "sls" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern('.git')
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -5854,13 +5630,13 @@ require'lspconfig'.scry.setup{}
   ```lua
   { "crystal" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern('shard.yml', '.git')
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "shard.yml", ".git" }
   ```
 
 
@@ -5888,9 +5664,9 @@ require'lspconfig'.serve_d.setup{}
   ```lua
   { "d" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern("dub.json", "dub.sdl", ".git")
+  { "dub.json", "dub.sdl", ".git" }
   ```
 
 
@@ -6009,9 +5785,9 @@ require'lspconfig'.solang.setup{}
   ```lua
   { "solidity" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.find_git_ancestor
+  { ".git" }
   ```
 
 
@@ -6050,10 +5826,6 @@ require'lspconfig'.solargraph.setup{}
     formatting = true
   }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("Gemfile", ".git")
-  ```
   - `settings` : 
   ```lua
   {
@@ -6061,6 +5833,10 @@ require'lspconfig'.solargraph.setup{}
       diagnostics = true
     }
   }
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "Gemfile", ".git" }
   ```
 
 
@@ -6087,9 +5863,9 @@ require'lspconfig'.solc.setup{}
   ```lua
   { "solidity" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern('hardhat.config.*', '.git')
+  { "hardhat.config.*", ".git" }
   ```
 
 
@@ -6145,10 +5921,6 @@ require'lspconfig'.solidity.setup{}
   ```lua
   { "solidity" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("package.json", ".git")
-  ```
   - `settings` : 
   ```lua
   {
@@ -6157,6 +5929,10 @@ require'lspconfig'.solidity.setup{}
       remapping = {}
     }
   }
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git", "package.json" }
   ```
 
 
@@ -6183,9 +5959,9 @@ require'lspconfig'.solidity_ls.setup{}
   ```lua
   { "solidity" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".git", "package.json")
+  { ".git", "package.json" }
   ```
 
 
@@ -6219,9 +5995,9 @@ require'lspconfig'.sorbet.setup{}
   ```lua
   { "ruby" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("Gemfile", ".git")
+  { "Gemfile", ".git" }
   ```
 
 
@@ -6248,9 +6024,9 @@ require'lspconfig'.sourcekit.setup{}
   ```lua
   { "swift", "c", "cpp", "objective-c", "objective-cpp" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("Package.swift", ".git")
+  { "Package.swift", ".git" }
   ```
 
 
@@ -6300,13 +6076,13 @@ require'lspconfig'.sourcery.setup{}
     extension_version = "vim.lsp"
   }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile", "pyrightconfig.json", ".git" }
   ```
 
 
@@ -6337,10 +6113,6 @@ require'lspconfig'.spectral.setup{}
   - `filetypes` : 
   ```lua
   { "yaml", "json", "yml" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `settings` : 
   ```lua
@@ -6380,10 +6152,6 @@ require'lspconfig'.sqlls.setup{}
   ```lua
   { "sql", "mysql" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -6420,10 +6188,6 @@ require'lspconfig'.sqls.setup{}
   ```lua
   { "sql", "mysql" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -6459,9 +6223,9 @@ require'lspconfig'.steep.setup{}
   ```lua
   { "ruby", "eruby" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("Steepfile", ".git")
+  { "Steepfile", ".git" }
   ```
 
 
@@ -6502,11 +6266,9 @@ require'lspconfig'.stylelint_lsp.setup{}
   ```
   - `filetypes` : 
   ```lua
-  { "css", "less", "scss", "sugarss", "vue", "wxss", "javascript", "javascriptreact", "typescript", "typescriptreact" }
-  ```
-  - `root_dir` : 
-  ```lua
-   root_pattern('.stylelintrc', 'package.json') 
+  { "css", "less", "scss", "sugarss", "vue", "wxss", "javascript", "javascriptreact", "typescript", "typescriptreact",
+    workspace_markers = { ".stylelintrc", "package.json" }
+  }
   ```
   - `settings` : 
   ```lua
@@ -6583,10 +6345,6 @@ require'lspconfig'.sumneko_lua.setup{}
   ```lua
   2
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".luarc.json", ".luacheckrc", ".stylua.toml", "stylua.toml", "selene.toml", ".git")
-  ```
   - `settings` : 
   ```lua
   {
@@ -6600,6 +6358,10 @@ require'lspconfig'.sumneko_lua.setup{}
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".luarc.json", ".luacheckrc", ".stylua.toml", "stylua.toml", "selene.toml", "lua/", ".git" }
   ```
 
 
@@ -6631,9 +6393,9 @@ require'lspconfig'.svelte.setup{}
   ```lua
   { "svelte" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("package.json", ".git")
+  { "package.json", ".git" }
   ```
 
 
@@ -6668,10 +6430,6 @@ require'lspconfig'.svlangserver.setup{}
   ```lua
   { "verilog", "systemverilog" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".svlangserver", ".git")
-  ```
   - `settings` : 
   ```lua
   {
@@ -6683,6 +6441,10 @@ require'lspconfig'.svlangserver.setup{}
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".svlangserver", ".git" }
   ```
 
 
@@ -6714,9 +6476,9 @@ require'lspconfig'.svls.setup{}
   ```lua
   { "verilog", "systemverilog" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.find_git_ancestor
+  { ".git" }
   ```
 
 
@@ -6793,10 +6555,6 @@ require'lspconfig'.tailwindcss.setup{}
     }
   }
   ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
   - `root_dir` : 
   ```lua
   root_pattern('tailwind.config.js', 'tailwind.config.ts', 'postcss.config.js', 'postcss.config.ts', 'package.json', 'node_modules', '.git')
@@ -6849,13 +6607,13 @@ require'lspconfig'.taplo.setup{}
   ```lua
   { "toml" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("*.toml", ".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "*.toml", ".git" }
   ```
 
 
@@ -6884,9 +6642,9 @@ require'lspconfig'.tblgen_lsp_server.setup{}
   ```lua
   { "tablegen" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
+  { "tablegen_compile_commands.yml", ".git" }
   ```
 
 
@@ -6914,11 +6672,9 @@ require'lspconfig'.teal_ls.setup{}
   ```
   - `filetypes` : 
   ```lua
-  { "teal" }
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("tlconfig.lua", ".git")
+  { "teal",
+    workspace_markers = { "tlconfig.lua", ".git" }
+  }
   ```
 
 
@@ -6969,9 +6725,9 @@ require'lspconfig'.terraform_lsp.setup{}
   ```lua
   { "terraform", "hcl" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".terraform", ".git")
+  { ".terraform", ".git" }
   ```
 
 
@@ -7021,9 +6777,9 @@ require'lspconfig'.terraformls.setup{}
   ```lua
   { "terraform" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".terraform", ".git")
+  { ".terraform", ".git" }
   ```
 
 
@@ -7053,10 +6809,6 @@ require'lspconfig'.texlab.setup{}
   - `filetypes` : 
   ```lua
   { "tex", "plaintex", "bib" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `settings` : 
   ```lua
@@ -7090,6 +6842,10 @@ require'lspconfig'.texlab.setup{}
   ```lua
   true
   ```
+  - `workspace_markers` : 
+  ```lua
+  { ".latexmkrc", ".git" }
+  ```
 
 
 ## tflint
@@ -7116,9 +6872,9 @@ require'lspconfig'.tflint.setup{}
   ```lua
   { "terraform" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".terraform", ".git", ".tflint.hcl")
+  { ".terraform", ".git", ".tflint.hcl" }
   ```
 
 
@@ -7157,10 +6913,6 @@ require'lspconfig'.theme_check.setup{}
   ```lua
   { "liquid" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -7196,13 +6948,13 @@ require'lspconfig'.tilt_ls.setup{}
   ```lua
   { "tiltfile" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -7258,9 +7010,9 @@ require'lspconfig'.tsserver.setup{}
     hostInfo = "neovim"
   }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")
+  { "tsconfig.json", "package.json", "jsconfig.json", ".git" }
   ```
 
 
@@ -7287,9 +7039,9 @@ require'lspconfig'.typeprof.setup{}
   ```lua
   { "ruby", "eruby" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("Gemfile", ".git")
+  { "Gemfile", ".git" }
   ```
 
 
@@ -7409,10 +7161,6 @@ require'lspconfig'.verible.setup{}
   ```lua
   { "systemverilog", "verilog" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## veridian
@@ -7444,10 +7192,6 @@ require'lspconfig'.veridian.setup{}
   - `filetypes` : 
   ```lua
   { "systemverilog", "verilog" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
 
 
@@ -7499,10 +7243,6 @@ require'lspconfig'.vimls.setup{}
     vimruntime = ""
   }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -7551,9 +7291,9 @@ require'lspconfig'.visualforce_ls.setup{}
     }
   }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern('sfdx-project.json')
+  { "sfdx-project.json" }
   ```
 
 
@@ -7583,9 +7323,9 @@ require'lspconfig'.vls.setup{}
   ```lua
   { "vlang" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("v.mod", ".git")
+  { "v.mod", ".git" }
   ```
 
 
@@ -7722,14 +7462,6 @@ require'lspconfig'.volar.setup{}
     }
   }
   ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## vuels
@@ -7800,9 +7532,9 @@ require'lspconfig'.vuels.setup{}
     }
   }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("package.json", "vue.config.js")
+  { "package.json", "vue.config.js" }
   ```
 
 
@@ -7832,13 +7564,13 @@ require'lspconfig'.wgsl_analyzer.setup{}
   ```lua
   { "wgsl" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".git"
-  ```
   - `settings` : 
   ```lua
   {}
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -7921,10 +7653,6 @@ require'lspconfig'.yamlls.setup{}
   ```lua
   { "yaml", "yaml.docker-compose" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `settings` : 
   ```lua
   {
@@ -7938,6 +7666,10 @@ require'lspconfig'.yamlls.setup{}
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -7966,9 +7698,9 @@ require'lspconfig'.zk.setup{}
   ```lua
   { "markdown" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".zk")
+  { ".zk" }
   ```
 
 
@@ -7995,13 +7727,13 @@ require'lspconfig'.zls.setup{}
   ```lua
   { "zig", "zir" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.root_pattern("zls.json", ".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "zls.json", ".git" }
   ```
 
 

--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -222,9 +222,9 @@ require'lspconfig'.als.setup{}
   ```lua
   { "ada" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern("Makefile", ".git", "*.gpr", "*.adc")
+  { "Makefile", ".git", "*.gpr", "*.adc" }
   ```
 
 
@@ -265,9 +265,9 @@ require'lspconfig'.angularls.setup{}
   ```lua
   { "typescript", "html", "typescriptreact", "typescript.tsx" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("angular.json")
+  { "angular.json" }
   ```
 
 
@@ -299,10 +299,6 @@ require'lspconfig'.ansiblels.setup{}
   - `filetypes` : 
   ```lua
   { "yaml.ansible" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `settings` : 
   ```lua
@@ -356,10 +352,6 @@ require'lspconfig'.antlersls.setup{}
   ```lua
   { "html", "antlers" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## apex_ls
@@ -392,13 +384,9 @@ require'lspconfig'.apex_ls.setup{}
   ```lua
   { "apexcode" }
   ```
-  - `on_new_config` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern('sfdx-project.json')
+  { "sfdx-project.json" }
   ```
 
 
@@ -469,10 +457,6 @@ require'lspconfig'.arduino_language_server.setup{}
   ```lua
   { "arduino" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## asm_lsp
@@ -500,10 +484,6 @@ require'lspconfig'.asm_lsp.setup{}
   - `filetypes` : 
   ```lua
   { "asm", "vmasm" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
 
 
@@ -542,13 +522,9 @@ require'lspconfig'.astro.setup{}
     }
   }
   ```
-  - `on_new_config` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")
+  { "package.json", "tsconfig.json", "jsconfig.json", ".git" }
   ```
 
 
@@ -618,13 +594,13 @@ require'lspconfig'.bashls.setup{}
   ```lua
   { "sh" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -657,13 +633,13 @@ require'lspconfig'.beancount.setup{}
     journalFile = ""
   }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -718,9 +694,9 @@ require'lspconfig'.bicep.setup{}
   ```lua
   {}
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.find_git_ancestor
+  { ".git" }
   ```
 
 
@@ -756,13 +732,13 @@ require'lspconfig'.blueprint_ls.setup{}
   ```lua
   { "blueprint" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -786,9 +762,9 @@ require'lspconfig'.bsl_ls.setup{}
   ```lua
   { "bsl", "os" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".git")
+  { ".git" }
   ```
 
 
@@ -874,13 +850,13 @@ require'lspconfig'.ccls.setup{}
   ```lua
   "utf-32"
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern('compile_commands.json', '.ccls', '.git')
-  ```
   - `single_file_support` : 
   ```lua
   false
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "compile_commands.json", ".ccls", ".git" }
   ```
 
 
@@ -919,22 +895,13 @@ require'lspconfig'.clangd.setup{}
   ```lua
   { "c", "cpp", "objc", "objcpp", "cuda", "proto" }
   ```
-  - `root_dir` : 
-  ```lua
-          root_pattern(
-            '.clangd',
-            '.clang-tidy',
-            '.clang-format',
-            'compile_commands.json',
-            'compile_flags.txt',
-            'configure.ac',
-            '.git'
-          )
-        
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".clangd", ".clang-tidy", ".clang-format", "compile_commands.json", "compile_flags.txt", ".git", "configure.ac" }
   ```
 
 
@@ -961,9 +928,9 @@ require'lspconfig'.clarity_lsp.setup{}
   ```lua
   { "clar", "clarity" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".git")
+  { ".git" }
   ```
 
 
@@ -990,9 +957,9 @@ require'lspconfig'.clojure_lsp.setup{}
   ```lua
   { "clojure", "edn" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("project.clj", "deps.edn", "build.boot", "shadow-cljs.edn", ".git")
+  { "project.clj", "deps.edn", "build.boot", "shadow-cljs.edn", ".git" }
   ```
 
 
@@ -1052,10 +1019,6 @@ require'lspconfig'.codeqlls.setup{}
 
 
 **Default values:**
-  - `before_init` : 
-  ```lua
-  see source file
-  ```
   - `cmd` : 
   ```lua
   { "codeql", "execute", "language-server", "--check-errors", "ON_CHANGE", "-q" }
@@ -1067,10 +1030,6 @@ require'lspconfig'.codeqlls.setup{}
   - `log_level` : 
   ```lua
   2
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `settings` : 
   ```lua
@@ -1103,13 +1062,13 @@ require'lspconfig'.crystalline.setup{}
   ```lua
   { "crystal" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern('shard.yml', '.git')
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "shard.yml", ".git" }
   ```
 
 
@@ -1145,10 +1104,6 @@ require'lspconfig'.csharp_ls.setup{}
   {
     AutomaticWorkspaceInit = true
   }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
 
 
@@ -1192,10 +1147,6 @@ require'lspconfig'.cssls.setup{}
   ```lua
   { "css", "scss", "less" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("package.json", ".git") or bufdir
-  ```
   - `settings` : 
   ```lua
   {
@@ -1213,6 +1164,10 @@ require'lspconfig'.cssls.setup{}
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "package.json", ".git" }
   ```
 
 
@@ -1280,9 +1235,9 @@ require'lspconfig'.cucumber_language_server.setup{}
   ```lua
   { "cucumber" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.find_git_ancestor
+  { ".git" }
   ```
 
 
@@ -1352,10 +1307,6 @@ require'lspconfig'.dartls.setup{}
     suggestFromUnimportedLibraries = true
   }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("pubspec.yaml")
-  ```
   - `settings` : 
   ```lua
   {
@@ -1364,6 +1315,10 @@ require'lspconfig'.dartls.setup{}
       showTodos = true
     }
   }
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "pubspec.yaml" }
   ```
 
 
@@ -1399,7 +1354,9 @@ require'lspconfig'.denols.setup{}
   ```
   - `filetypes` : 
   ```lua
-  { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" }
+  { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx",
+    workspace_markers = { "deno.json", "deno.jsonc", ".git" }
+  }
   ```
   - `handlers` : 
   ```lua
@@ -1415,10 +1372,6 @@ require'lspconfig'.denols.setup{}
     enable = true,
     unstable = false
   }
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("deno.json", "deno.jsonc", ".git")
   ```
 
 
@@ -1451,13 +1404,13 @@ require'lspconfig'.dhall_lsp_server.setup{}
   ```lua
   { "dhall" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -1520,13 +1473,13 @@ require'lspconfig'.dockerls.setup{}
   ```lua
   { "dockerfile" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("Dockerfile")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "Dockerfile" }
   ```
 
 
@@ -1556,10 +1509,6 @@ require'lspconfig'.dotls.setup{}
   ```lua
   { "dot" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -1579,6 +1528,7 @@ launching the language server on single files. If on an older version of EFM, di
 require('lspconfig')['efm'].setup{
   settings = ..., -- You must populate this according to the EFM readme
   filetypes = ..., -- Populate this according to the note below
+  workspace_markers = workspace_markers,
   single_file_support = false, -- This is the important line for supporting older version of EFM
 }
 ```
@@ -1607,10 +1557,6 @@ require'lspconfig'.efm.setup{}
   - `cmd` : 
   ```lua
   { "efm-langserver" }
-  ```
-  - `root_dir` : 
-  ```lua
-  util.root_pattern(".git")
   ```
   - `single_file_support` : 
   ```lua
@@ -1727,9 +1673,9 @@ require'lspconfig'.ember.setup{}
   ```lua
   { "handlebars", "typescript", "javascript" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("ember-cli-build.js", ".git")
+  { "ember-cli-build.js", ".git" }
   ```
 
 
@@ -1797,9 +1743,9 @@ require'lspconfig'.erg_language_server.setup{}
   ```lua
   { "erg" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("package.er") or find_git_ancestor
+  { "package.er", ".git" }
   ```
 
 
@@ -1835,13 +1781,13 @@ require'lspconfig'.erlangls.setup{}
   ```lua
   { "erlang" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern('rebar.config', 'erlang.mk', '.git')
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "rebar.config", "erlang.mk", ".git" }
   ```
 
 
@@ -1907,10 +1853,6 @@ require'lspconfig'.esbonio.setup{}
   ```lua
   { "rst" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## eslint
@@ -1961,14 +1903,6 @@ require'lspconfig'.eslint.setup{}
     ["eslint/openDoc"] = <function 3>,
     ["eslint/probeFailed"] = <function 4>
   }
-  ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `settings` : 
   ```lua
@@ -2033,9 +1967,9 @@ require'lspconfig'.flow.setup{}
   ```lua
   { "javascript", "javascriptreact", "javascript.jsx" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".flowconfig")
+  { ".flowconfig" }
   ```
 
 
@@ -2064,13 +1998,13 @@ require'lspconfig'.flux_lsp.setup{}
   ```lua
   { "flux" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -2099,10 +2033,6 @@ require'lspconfig'.foam_ls.setup{}
   - `filetypes` : 
   ```lua
   { "foam", "OpenFOAM" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
 
 
@@ -2136,10 +2066,6 @@ require'lspconfig'.fortls.setup{}
   - `filetypes` : 
   ```lua
   { "fortran" }
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".fortls")
   ```
   - `settings` : 
   ```lua
@@ -2189,10 +2115,6 @@ require'lspconfig'.fsautocomplete.setup{}
     AutomaticWorkspaceInit = true
   }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## fsharp_language_server
@@ -2233,10 +2155,6 @@ require'lspconfig'.fsharp_language_server.setup{}
     AutomaticWorkspaceInit = true
   }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -2266,9 +2184,9 @@ require'lspconfig'.fstar.setup{}
   ```lua
   { "fstar" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.find_git_ancestor
+  { ".git" }
   ```
 
 
@@ -2287,17 +2205,13 @@ require'lspconfig'.gdscript.setup{}
 
 
 **Default values:**
-  - `cmd` : 
-  ```lua
-  see source file
-  ```
   - `filetypes` : 
   ```lua
   { "gd", "gdscript", "gdscript3" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern("project.godot", ".git")
+  { "project.godot", ".git" }
   ```
 
 
@@ -2325,9 +2239,9 @@ require'lspconfig'.ghcide.setup{}
   ```lua
   { "haskell", "lhaskell" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("stack.yaml", "hie-bios", "BUILD.bazel", "cabal.config", "package.yaml")
+  { "stack.yaml", "hie-bios", "BUILD.bazel", "cabal.config", "package.yaml" }
   ```
 
 
@@ -2357,13 +2271,13 @@ require'lspconfig'.ghdl_ls.setup{}
   ```lua
   { "vhdl" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "hdl-prj.json", ".git" }
   ```
 
 
@@ -2408,14 +2322,6 @@ require'lspconfig'.glint.setup{}
   ```lua
   { "html.handlebars", "handlebars", "typescript", "typescript.glimmer", "javascript", "javascript.glimmer" }
   ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## glslls
@@ -2454,10 +2360,6 @@ require'lspconfig'.glslls.setup{}
   - `filetypes` : 
   ```lua
   { "glsl" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -2623,13 +2525,13 @@ require'lspconfig'.grammarly.setup{}
     clientId = "client_BaDkMgx4X19X9UxxYRCXZo"
   }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -2662,9 +2564,9 @@ require'lspconfig'.graphql.setup{}
   ```lua
   { "graphql", "typescriptreact", "javascriptreact" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern('.git', '.graphqlrc*', '.graphql.config.*', 'graphql.config.*')
+  { ".git", ".graphqlrc*", ".graphql.config.*", "graphql.config.*" }
   ```
 
 
@@ -2705,9 +2607,9 @@ require'lspconfig'.groovyls.setup{}
   ```lua
   { "groovy" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
+  { "Jenkinsfile", ".git" }
   ```
 
 
@@ -2760,10 +2662,6 @@ require'lspconfig'.haxe_language_server.setup{}
     displayArguments = { "build.hxml" }
   }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("*.hxml")
-  ```
   - `settings` : 
   ```lua
   {
@@ -2771,6 +2669,10 @@ require'lspconfig'.haxe_language_server.setup{}
       executable = "haxe"
     }
   }
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "*.hxml" }
   ```
 
 
@@ -2797,13 +2699,13 @@ require'lspconfig'.hdl_checker.setup{}
   ```lua
   { "vhdl", "verilog", "systemverilog" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -2832,9 +2734,9 @@ require'lspconfig'.hhvm.setup{}
   ```lua
   { "php", "hack" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".hhconfig")
+  { ".hhconfig" }
   ```
 
 
@@ -2874,9 +2776,9 @@ require'lspconfig'.hie.setup{}
   ```lua
   { "haskell" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("stack.yaml", "package.yaml", ".git")
+  { "stack.yaml", "package.yaml", ".git" }
   ```
 
 
@@ -2902,10 +2804,6 @@ require'lspconfig'.hls.setup{}
   - `filetypes` : 
   ```lua
   { "haskell", "lhaskell" }
-  ```
-  - `lspinfo` : 
-  ```lua
-  see source file
   ```
   - `root_dir` : 
   ```lua
@@ -2958,10 +2856,6 @@ require'lspconfig'.hoon_ls.setup{}
   - `filetypes` : 
   ```lua
   { "hoon" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -3021,10 +2915,6 @@ require'lspconfig'.html.setup{}
     provideFormatter = true
   }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -3083,10 +2973,6 @@ require'lspconfig'.idris2_lsp.setup{}
   ```lua
   { "idris2" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## intelephense
@@ -3142,10 +3028,6 @@ require'lspconfig'.java_language_server.setup{}
   ```lua
   { "java" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -3197,7 +3079,7 @@ require'lspconfig'.jdtls.setup{}
 **Default values:**
   - `cmd` : 
   ```lua
-  { "jdtls", "-configuration", "/home/runner/.cache/jdtls/config", "-data", "/home/runner/.cache/jdtls/workspace" }
+  { "jdtls", "-configuration", "/home/hatsu/.cache/jdtls/config", "-data", "/home/hatsu/.cache/jdtls/workspace" }
   ```
   - `filetypes` : 
   ```lua
@@ -3216,7 +3098,7 @@ require'lspconfig'.jdtls.setup{}
   ```lua
   {
     jvm_args = {},
-    workspace = "/home/runner/.cache/jdtls/workspace"
+    workspace = "/home/hatsu/.cache/jdtls/workspace"
   }
   ```
   - `root_dir` : 
@@ -3318,13 +3200,13 @@ require'lspconfig'.jsonls.setup{}
     provideFormatter = true
   }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -3356,13 +3238,9 @@ require'lspconfig'.jsonnet_ls.setup{}
   ```lua
   { "jsonnet", "libsonnet" }
   ```
-  - `on_new_config` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("jsonnetfile.json")
+  { "jsonnetfile.json", ".git" }
   ```
 
 
@@ -3405,13 +3283,13 @@ require'lspconfig'.julials.setup{}
   ```lua
   { "julia" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "Project.toml", ".git" }
   ```
 
 
@@ -3531,10 +3409,6 @@ require'lspconfig'.leanls.setup{}
   ```lua
   { "lean" }
   ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
   - `options` : 
   ```lua
   {
@@ -3579,10 +3453,6 @@ require'lspconfig'.lelwel_ls.setup{}
   ```lua
   { "llw" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## lemminx
@@ -3611,13 +3481,13 @@ require'lspconfig'.lemminx.setup{}
   ```lua
   { "xml", "xsd", "xsl", "xslt", "svg" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -3652,14 +3522,6 @@ require'lspconfig'.ltex.setup{}
   ```lua
   { "bib", "gitcommit", "markdown", "org", "plaintex", "rst", "rnoweb", "tex" }
   ```
-  - `get_language_id` : 
-  ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -3685,9 +3547,9 @@ require'lspconfig'.luau_lsp.setup{}
   ```lua
   { "luau" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".git")
+  { ".git" }
   ```
 
 
@@ -3726,10 +3588,6 @@ require'lspconfig'.m68k.setup{}
   ```lua
   { "asm68k" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -3763,13 +3621,13 @@ require'lspconfig'.marksman.setup{}
   ```lua
   { "markdown" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".git", ".marksman.toml")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".marksman.toml", ".git" }
   ```
 
 
@@ -3826,9 +3684,9 @@ require'lspconfig'.metals.setup{}
   ```lua
   4
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern("build.sbt", "build.sc", "build.gradle", "pom.xml")
+  { "build.sbt", "build.sc", "build.gradle", "pom.xml" }
   ```
 
 
@@ -3856,13 +3714,13 @@ require'lspconfig'.mint.setup{}
   ```lua
   { "mint" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "mint.json", ".git" }
   ```
 
 
@@ -3890,10 +3748,6 @@ require'lspconfig'.mlir_lsp_server.setup{}
   - `filetypes` : 
   ```lua
   { "mlir" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -3926,9 +3780,9 @@ require'lspconfig'.mlir_pdll_lsp_server.setup{}
   ```lua
   { "pdll" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
+  { "pdll_compile_commands.yml", ".git" }
   ```
 
 
@@ -3957,10 +3811,6 @@ require'lspconfig'.mm0_ls.setup{}
   - `filetypes` : 
   ```lua
   { "metamath-zero" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -4081,10 +3931,6 @@ require'lspconfig'.nickel_ls.setup{}
   ```lua
   { "ncl", "nickel" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## nil_ls
@@ -4113,13 +3959,13 @@ require'lspconfig'.nil_ls.setup{}
   ```lua
   { "nix" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("flake.nix", ".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "flake.nix", ".git" }
   ```
 
 
@@ -4150,13 +3996,13 @@ require'lspconfig'.nimls.setup{}
   ```lua
   { "nim" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "*.nimble", ".git" }
   ```
 
 
@@ -4188,9 +4034,9 @@ require'lspconfig'.nxls.setup{}
   ```lua
   { "json", "jsonc" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern
+  { "nx.json", ".git" }
   ```
 
 
@@ -4220,9 +4066,9 @@ require'lspconfig'.ocamlls.setup{}
   ```lua
   { "ocaml", "reason" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("*.opam", "esy.json", "package.json")
+  { "*.opam", "esy.json", "package.json" }
   ```
 
 
@@ -4254,13 +4100,9 @@ require'lspconfig'.ocamllsp.setup{}
   ```lua
   { "ocaml", "ocaml.menhir", "ocaml.interface", "ocaml.ocamllex", "reason", "dune" }
   ```
-  - `get_language_id` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("*.opam", "esy.json", "package.json", ".git", "dune-project", "dune-workspace")
+  { "*.opam", "esy.json", "package.json", ".git", "dune-project", "dune-workspace" }
   ```
 
 
@@ -4287,13 +4129,13 @@ require'lspconfig'.ols.setup{}
   ```lua
   { "odin" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.root_pattern("ols.json", ".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "ols.json", ".git" }
   ```
 
 
@@ -4387,10 +4229,6 @@ require'lspconfig'.omnisharp.setup{}
   ```lua
   {}
   ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
   - `organize_imports_on_format` : 
   ```lua
   false
@@ -4430,9 +4268,9 @@ require'lspconfig'.opencl_ls.setup{}
   ```lua
   { "opencl" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern(".git")
+  { ".git" }
   ```
 
 
@@ -4474,10 +4312,6 @@ require'lspconfig'.openscad_ls.setup{}
   ```lua
   { "openscad" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -4517,10 +4351,6 @@ require'lspconfig'.pasls.setup{}
   - `filetypes` : 
   ```lua
   { "pascal" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -4619,10 +4449,6 @@ require'lspconfig'.perlnavigator.setup{}
   ```lua
   { "perl" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -4655,10 +4481,6 @@ require'lspconfig'.perlpls.setup{}
   ```lua
   { "perl" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `settings` : 
   ```lua
   {
@@ -4675,6 +4497,10 @@ require'lspconfig'.perlpls.setup{}
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -4765,10 +4591,6 @@ require'lspconfig'.please.setup{}
   ```lua
   { "bzl" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -4828,10 +4650,6 @@ require'lspconfig'.powershell_es.setup{}
   ```lua
   { "ps1" }
   ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
   - `root_dir` : 
   ```lua
   git root or current directory
@@ -4872,10 +4690,6 @@ require'lspconfig'.prismals.setup{}
   ```lua
   { "prisma" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".git", "package.json")
-  ```
   - `settings` : 
   ```lua
   {
@@ -4883,6 +4697,10 @@ require'lspconfig'.prismals.setup{}
       prismaFmtBinPath = ""
     }
   }
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git", "package.json" }
   ```
 
 
@@ -4947,9 +4765,9 @@ require'lspconfig'.psalm.setup{}
   ```lua
   { "php" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("psalm.xml", "psalm.xml.dist")
+  { "psalm.xml", "psalm.xml.dist" }
   ```
 
 
@@ -5023,9 +4841,9 @@ require'lspconfig'.purescriptls.setup{}
   ```lua
   { "purescript" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern('spago.dhall', 'psc-package.json', 'bower.json', 'flake.nix', 'shell.nix'),
+  { "bower.json", "psc-package.json", "spago.dhall", "flake.nix", "shell.nix" }
   ```
 
 
@@ -5074,13 +4892,13 @@ require'lspconfig'.pylsp.setup{}
   ```lua
   { "python" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile", ".git" }
   ```
 
 
@@ -5113,10 +4931,6 @@ require'lspconfig'.pyre.setup{}
   ```lua
   { "python" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## pyright
@@ -5142,10 +4956,6 @@ require'lspconfig'.pyright.setup{}
   - `filetypes` : 
   ```lua
   { "python" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `settings` : 
   ```lua
@@ -5188,10 +4998,6 @@ require'lspconfig'.qml_lsp.setup{}
   ```lua
   { "qmljs" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## qmlls
@@ -5216,10 +5022,6 @@ require'lspconfig'.qmlls.setup{}
   - `filetypes` : 
   ```lua
   { "qmljs" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -5251,10 +5053,6 @@ require'lspconfig'.quick_lint_js.setup{}
   - `filetypes` : 
   ```lua
   { "javascript" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -5328,10 +5126,6 @@ require'lspconfig'.racket_langserver.setup{}
   ```lua
   { "racket", "scheme" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -5360,10 +5154,6 @@ require'lspconfig'.reason_ls.setup{}
   - `filetypes` : 
   ```lua
   { "reason" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
 
 
@@ -5416,21 +5206,15 @@ require'lspconfig'.relay_lsp.setup{}
   ```
   - `filetypes` : 
   ```lua
-  { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" }
+  { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx",
+    workspace_markers = { "relay.config.*", "package.json" }
+  }
   ```
   - `handlers` : 
   ```lua
   {
     ["window/showStatus"] = <function 1>
   }
-  ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("relay.config.*", "package.json")
   ```
 
 
@@ -5482,10 +5266,6 @@ require'lspconfig'.remark_ls.setup{}
   - `filetypes` : 
   ```lua
   { "markdown" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `single_file_support` : 
   ```lua
@@ -5541,10 +5321,6 @@ require'lspconfig'.rescriptls.setup{}
   ```lua
   { "rescript" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -5597,9 +5373,9 @@ require'lspconfig'.rls.setup{}
   ```lua
   { "rust" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("Cargo.toml")
+  { "Cargo.toml" }
   ```
 
 
@@ -5668,9 +5444,9 @@ require'lspconfig'.robotframework_ls.setup{}
   ```lua
   { "robot" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern('robotidy.toml', 'pyproject.toml')(fname) or util.find_git_ancestor(fname)
+  { "robotidy.toml", "pyproject.toml", ".git" }
   ```
 
 
@@ -5750,9 +5526,9 @@ require'lspconfig'.ruby_ls.setup{}
     enabledFeatures = { "codeActions", "diagnostics", "documentHighlights", "documentSymbols", "formatting", "inlayHint" }
   }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("Gemfile", ".git")
+  { "Gemfile", ".git" }
   ```
 
 
@@ -5821,13 +5597,13 @@ require'lspconfig'.salt_ls.setup{}
   ```lua
   { "sls" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern('.git')
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -5854,13 +5630,13 @@ require'lspconfig'.scry.setup{}
   ```lua
   { "crystal" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern('shard.yml', '.git')
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "shard.yml", ".git" }
   ```
 
 
@@ -5888,9 +5664,9 @@ require'lspconfig'.serve_d.setup{}
   ```lua
   { "d" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.root_pattern("dub.json", "dub.sdl", ".git")
+  { "dub.json", "dub.sdl", ".git" }
   ```
 
 
@@ -6009,9 +5785,9 @@ require'lspconfig'.solang.setup{}
   ```lua
   { "solidity" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.find_git_ancestor
+  { ".git" }
   ```
 
 
@@ -6050,10 +5826,6 @@ require'lspconfig'.solargraph.setup{}
     formatting = true
   }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("Gemfile", ".git")
-  ```
   - `settings` : 
   ```lua
   {
@@ -6061,6 +5833,10 @@ require'lspconfig'.solargraph.setup{}
       diagnostics = true
     }
   }
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "Gemfile", ".git" }
   ```
 
 
@@ -6087,9 +5863,9 @@ require'lspconfig'.solc.setup{}
   ```lua
   { "solidity" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern('hardhat.config.*', '.git')
+  { "hardhat.config.*", ".git" }
   ```
 
 
@@ -6145,10 +5921,6 @@ require'lspconfig'.solidity.setup{}
   ```lua
   { "solidity" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("package.json", ".git")
-  ```
   - `settings` : 
   ```lua
   {
@@ -6157,6 +5929,10 @@ require'lspconfig'.solidity.setup{}
       remapping = {}
     }
   }
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git", "package.json" }
   ```
 
 
@@ -6183,9 +5959,9 @@ require'lspconfig'.solidity_ls.setup{}
   ```lua
   { "solidity" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".git", "package.json")
+  { ".git", "package.json" }
   ```
 
 
@@ -6219,9 +5995,9 @@ require'lspconfig'.sorbet.setup{}
   ```lua
   { "ruby" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("Gemfile", ".git")
+  { "Gemfile", ".git" }
   ```
 
 
@@ -6248,9 +6024,9 @@ require'lspconfig'.sourcekit.setup{}
   ```lua
   { "swift", "c", "cpp", "objective-c", "objective-cpp" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("Package.swift", ".git")
+  { "Package.swift", ".git" }
   ```
 
 
@@ -6300,13 +6076,13 @@ require'lspconfig'.sourcery.setup{}
     extension_version = "vim.lsp"
   }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile", "pyrightconfig.json", ".git" }
   ```
 
 
@@ -6337,10 +6113,6 @@ require'lspconfig'.spectral.setup{}
   - `filetypes` : 
   ```lua
   { "yaml", "json", "yml" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `settings` : 
   ```lua
@@ -6380,10 +6152,6 @@ require'lspconfig'.sqlls.setup{}
   ```lua
   { "sql", "mysql" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -6420,10 +6188,6 @@ require'lspconfig'.sqls.setup{}
   ```lua
   { "sql", "mysql" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -6459,9 +6223,9 @@ require'lspconfig'.steep.setup{}
   ```lua
   { "ruby", "eruby" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("Steepfile", ".git")
+  { "Steepfile", ".git" }
   ```
 
 
@@ -6502,11 +6266,9 @@ require'lspconfig'.stylelint_lsp.setup{}
   ```
   - `filetypes` : 
   ```lua
-  { "css", "less", "scss", "sugarss", "vue", "wxss", "javascript", "javascriptreact", "typescript", "typescriptreact" }
-  ```
-  - `root_dir` : 
-  ```lua
-   root_pattern('.stylelintrc', 'package.json') 
+  { "css", "less", "scss", "sugarss", "vue", "wxss", "javascript", "javascriptreact", "typescript", "typescriptreact",
+    workspace_markers = { ".stylelintrc", "package.json" }
+  }
   ```
   - `settings` : 
   ```lua
@@ -6583,10 +6345,6 @@ require'lspconfig'.sumneko_lua.setup{}
   ```lua
   2
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".luarc.json", ".luacheckrc", ".stylua.toml", "stylua.toml", "selene.toml", ".git")
-  ```
   - `settings` : 
   ```lua
   {
@@ -6600,6 +6358,10 @@ require'lspconfig'.sumneko_lua.setup{}
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".luarc.json", ".luacheckrc", ".stylua.toml", "stylua.toml", "selene.toml", "lua/", ".git" }
   ```
 
 
@@ -6631,9 +6393,9 @@ require'lspconfig'.svelte.setup{}
   ```lua
   { "svelte" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("package.json", ".git")
+  { "package.json", ".git" }
   ```
 
 
@@ -6668,10 +6430,6 @@ require'lspconfig'.svlangserver.setup{}
   ```lua
   { "verilog", "systemverilog" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".svlangserver", ".git")
-  ```
   - `settings` : 
   ```lua
   {
@@ -6683,6 +6441,10 @@ require'lspconfig'.svlangserver.setup{}
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".svlangserver", ".git" }
   ```
 
 
@@ -6714,9 +6476,9 @@ require'lspconfig'.svls.setup{}
   ```lua
   { "verilog", "systemverilog" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  util.find_git_ancestor
+  { ".git" }
   ```
 
 
@@ -6793,10 +6555,6 @@ require'lspconfig'.tailwindcss.setup{}
     }
   }
   ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
   - `root_dir` : 
   ```lua
   root_pattern('tailwind.config.js', 'tailwind.config.ts', 'postcss.config.js', 'postcss.config.ts', 'package.json', 'node_modules', '.git')
@@ -6849,13 +6607,13 @@ require'lspconfig'.taplo.setup{}
   ```lua
   { "toml" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("*.toml", ".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "*.toml", ".git" }
   ```
 
 
@@ -6884,9 +6642,9 @@ require'lspconfig'.tblgen_lsp_server.setup{}
   ```lua
   { "tablegen" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  see source file
+  { "tablegen_compile_commands.yml", ".git" }
   ```
 
 
@@ -6914,11 +6672,9 @@ require'lspconfig'.teal_ls.setup{}
   ```
   - `filetypes` : 
   ```lua
-  { "teal" }
-  ```
-  - `root_dir` : 
-  ```lua
-  root_pattern("tlconfig.lua", ".git")
+  { "teal",
+    workspace_markers = { "tlconfig.lua", ".git" }
+  }
   ```
 
 
@@ -6969,9 +6725,9 @@ require'lspconfig'.terraform_lsp.setup{}
   ```lua
   { "terraform", "hcl" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".terraform", ".git")
+  { ".terraform", ".git" }
   ```
 
 
@@ -7021,9 +6777,9 @@ require'lspconfig'.terraformls.setup{}
   ```lua
   { "terraform" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".terraform", ".git")
+  { ".terraform", ".git" }
   ```
 
 
@@ -7053,10 +6809,6 @@ require'lspconfig'.texlab.setup{}
   - `filetypes` : 
   ```lua
   { "tex", "plaintex", "bib" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
   - `settings` : 
   ```lua
@@ -7090,6 +6842,10 @@ require'lspconfig'.texlab.setup{}
   ```lua
   true
   ```
+  - `workspace_markers` : 
+  ```lua
+  { ".latexmkrc", ".git" }
+  ```
 
 
 ## tflint
@@ -7116,9 +6872,9 @@ require'lspconfig'.tflint.setup{}
   ```lua
   { "terraform" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".terraform", ".git", ".tflint.hcl")
+  { ".terraform", ".git", ".tflint.hcl" }
   ```
 
 
@@ -7157,10 +6913,6 @@ require'lspconfig'.theme_check.setup{}
   ```lua
   { "liquid" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `settings` : 
   ```lua
   {}
@@ -7196,13 +6948,13 @@ require'lspconfig'.tilt_ls.setup{}
   ```lua
   { "tiltfile" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -7258,9 +7010,9 @@ require'lspconfig'.tsserver.setup{}
     hostInfo = "neovim"
   }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")
+  { "tsconfig.json", "package.json", "jsconfig.json", ".git" }
   ```
 
 
@@ -7287,9 +7039,9 @@ require'lspconfig'.typeprof.setup{}
   ```lua
   { "ruby", "eruby" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("Gemfile", ".git")
+  { "Gemfile", ".git" }
   ```
 
 
@@ -7409,10 +7161,6 @@ require'lspconfig'.verible.setup{}
   ```lua
   { "systemverilog", "verilog" }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## veridian
@@ -7444,10 +7192,6 @@ require'lspconfig'.veridian.setup{}
   - `filetypes` : 
   ```lua
   { "systemverilog", "verilog" }
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
   ```
 
 
@@ -7499,10 +7243,6 @@ require'lspconfig'.vimls.setup{}
     vimruntime = ""
   }
   ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
   - `single_file_support` : 
   ```lua
   true
@@ -7551,9 +7291,9 @@ require'lspconfig'.visualforce_ls.setup{}
     }
   }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern('sfdx-project.json')
+  { "sfdx-project.json" }
   ```
 
 
@@ -7583,9 +7323,9 @@ require'lspconfig'.vls.setup{}
   ```lua
   { "vlang" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("v.mod", ".git")
+  { "v.mod", ".git" }
   ```
 
 
@@ -7722,14 +7462,6 @@ require'lspconfig'.volar.setup{}
     }
   }
   ```
-  - `on_new_config` : 
-  ```lua
-  see source file
-  ```
-  - `root_dir` : 
-  ```lua
-  see source file
-  ```
 
 
 ## vuels
@@ -7800,9 +7532,9 @@ require'lspconfig'.vuels.setup{}
     }
   }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern("package.json", "vue.config.js")
+  { "package.json", "vue.config.js" }
   ```
 
 
@@ -7832,13 +7564,13 @@ require'lspconfig'.wgsl_analyzer.setup{}
   ```lua
   { "wgsl" }
   ```
-  - `root_dir` : 
-  ```lua
-  root_pattern(".git"
-  ```
   - `settings` : 
   ```lua
   {}
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -7921,10 +7653,6 @@ require'lspconfig'.yamlls.setup{}
   ```lua
   { "yaml", "yaml.docker-compose" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.find_git_ancestor
-  ```
   - `settings` : 
   ```lua
   {
@@ -7938,6 +7666,10 @@ require'lspconfig'.yamlls.setup{}
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { ".git" }
   ```
 
 
@@ -7966,9 +7698,9 @@ require'lspconfig'.zk.setup{}
   ```lua
   { "markdown" }
   ```
-  - `root_dir` : 
+  - `workspace_markers` : 
   ```lua
-  root_pattern(".zk")
+  { ".zk" }
   ```
 
 
@@ -7995,13 +7727,13 @@ require'lspconfig'.zls.setup{}
   ```lua
   { "zig", "zir" }
   ```
-  - `root_dir` : 
-  ```lua
-  util.root_pattern("zls.json", ".git")
-  ```
   - `single_file_support` : 
   ```lua
   true
+  ```
+  - `workspace_markers` : 
+  ```lua
+  { "zls.json", ".git" }
   ```
 
 

--- a/lua/lspconfig/server_configurations/als.lua
+++ b/lua/lspconfig/server_configurations/als.lua
@@ -5,11 +5,14 @@ if vim.fn.has 'win32' == 1 then
   bin_name = 'ada_language_server.exe'
 end
 
+local workspace_markers = { 'Makefile', '.git', '*.gpr', '*.adc' }
+
 return {
   default_config = {
     cmd = { bin_name },
     filetypes = { 'ada' },
-    root_dir = util.root_pattern('Makefile', '.git', '*.gpr', '*.adc'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -31,7 +34,7 @@ require('lspconfig').als.setup{
 ```
 ]],
     default_config = {
-      root_dir = [[util.root_pattern("Makefile", ".git", "*.gpr", "*.adc")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/angularls.lua
+++ b/lua/lspconfig/server_configurations/angularls.lua
@@ -26,14 +26,17 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, unpack(args) }
 end
 
+local workspace_markers = { 'angular.json' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'typescript', 'html', 'typescriptreact', 'typescript.tsx' },
+    workspace_markers = workspace_markers,
     -- Check for angular.json since that is the root of the project.
     -- Don't check for tsconfig.json or package.json since there are multiple of these
     -- in an angular monorepo setup.
-    root_dir = util.root_pattern 'angular.json',
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   on_new_config = function(new_config, new_root_dir)
     local new_probe_dir = get_probe_dir(new_root_dir)
@@ -69,7 +72,7 @@ require'lspconfig'.angularls.setup{
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("angular.json")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/ansiblels.lua
+++ b/lua/lspconfig/server_configurations/ansiblels.lua
@@ -7,6 +7,8 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { 'ansible.cfg', '.ansible-lint' }
+
 return {
   default_config = {
     cmd = cmd,
@@ -28,7 +30,7 @@ return {
       },
     },
     filetypes = { 'yaml.ansible' },
-    root_dir = util.root_pattern('ansible.cfg', '.ansible-lint'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/antlersls.lua
+++ b/lua/lspconfig/server_configurations/antlersls.lua
@@ -7,11 +7,13 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { 'composer.json' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'html', 'antlers' },
-    root_dir = util.root_pattern 'composer.json',
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/apex_ls.lua
+++ b/lua/lspconfig/server_configurations/apex_ls.lua
@@ -1,9 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'sfdx-project.json' }
+
 return {
   default_config = {
     filetypes = { 'apexcode' },
-    root_dir = util.root_pattern 'sfdx-project.json',
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     on_new_config = function(config)
       if not config.cmd and config.apex_jar_path then
         config.cmd = {
@@ -40,7 +43,7 @@ require'lspconfig'.apex_ls.setup {
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern('sfdx-project.json')]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/arduino_language_server.lua
+++ b/lua/lspconfig/server_configurations/arduino_language_server.lua
@@ -1,9 +1,11 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '*.ino' }
+
 return {
   default_config = {
     filetypes = { 'arduino' },
-    root_dir = util.root_pattern '*.ino',
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/asm_lsp.lua
+++ b/lua/lspconfig/server_configurations/asm_lsp.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'asm-lsp' },
     filetypes = { 'asm', 'vmasm' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/astro.lua
+++ b/lua/lspconfig/server_configurations/astro.lua
@@ -13,11 +13,14 @@ local function get_typescript_server_path(root_dir)
     or ''
 end
 
+local workspace_markers = { 'package.json', 'tsconfig.json', 'jsconfig.json', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'astro' },
-    root_dir = util.root_pattern('package.json', 'tsconfig.json', 'jsconfig.json', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     init_options = {
       typescript = {
         serverPath = '',
@@ -44,7 +47,7 @@ npm install -g @astrojs/language-server
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/bashls.lua
+++ b/lua/lspconfig/server_configurations/bashls.lua
@@ -7,6 +7,8 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, 'start' }
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = cmd,
@@ -18,7 +20,8 @@ return {
       GLOB_PATTERN = vim.env.GLOB_PATTERN or '*@(.sh|.inc|.bash|.command)',
     },
     filetypes = { 'sh' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -33,7 +36,7 @@ npm i -g bash-language-server
 Language server for bash, written using tree sitter in typescript.
 ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/beancount.lua
+++ b/lua/lspconfig/server_configurations/beancount.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'beancount-language-server', '--stdio' },
     filetypes = { 'beancount', 'bean' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
     init_options = {
       -- this is the path to the beancout journal file
@@ -18,7 +21,7 @@ https://github.com/polarmutex/beancount-language-server#installation
 See https://github.com/polarmutex/beancount-language-server#configuration for configuration options
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/bicep.lua
+++ b/lua/lspconfig/server_configurations/bicep.lua
@@ -1,9 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     filetypes = { 'bicep' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     init_options = {},
   },
   docs = {
@@ -41,7 +44,7 @@ To download the latest release and place in /usr/local/bin/bicep-langserver:
 ```
 ]=],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/blueprint_ls.lua
+++ b/lua/lspconfig/server_configurations/blueprint_ls.lua
@@ -7,6 +7,8 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, 'start' }
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = cmd,
@@ -18,7 +20,8 @@ return {
       GLOB_PATTERN = vim.env.GLOB_PATTERN or '*@(.blp)',
     },
     filetypes = { 'blueprint' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -31,7 +34,7 @@ Language server for the blurprint markup language, written in python and part
 of the blueprint-compiler.
 ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/bsl_ls.lua
+++ b/lua/lspconfig/server_configurations/bsl_ls.lua
@@ -1,9 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     filetypes = { 'bsl', 'os' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -13,7 +16,7 @@ return {
 
     ]],
     default_config = {
-      root_dir = [[root_pattern(".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/ccls.lua
+++ b/lua/lspconfig/server_configurations/ccls.lua
@@ -1,17 +1,17 @@
 local util = require 'lspconfig.util'
 
-local root_files = {
+local workspace_markers = {
   'compile_commands.json',
   '.ccls',
+  '.git',
 }
 
 return {
   default_config = {
     cmd = { 'ccls' },
     filetypes = { 'c', 'cpp', 'objc', 'objcpp' },
-    root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     offset_encoding = 'utf-32',
     -- ccls does not support sending a null root directory
     single_file_support = false,
@@ -44,7 +44,7 @@ lspconfig.ccls.setup {
 
 ]],
     default_config = {
-      root_dir = [[root_pattern('compile_commands.json', '.ccls', '.git')]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -21,12 +21,13 @@ local function switch_source_header(bufnr)
   end
 end
 
-local root_files = {
+local workspace_markers = {
   '.clangd',
   '.clang-tidy',
   '.clang-format',
   'compile_commands.json',
   'compile_flags.txt',
+  '.git',
   'configure.ac', -- AutoTools
 }
 
@@ -43,9 +44,8 @@ return {
   default_config = {
     cmd = { 'clangd' },
     filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda', 'proto' },
-    root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
-    end,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
+    workspace_markers = workspace_markers,
     single_file_support = true,
     capabilities = default_capabilities,
   },
@@ -71,17 +71,6 @@ https://clangd.llvm.org/installation.html
   specified as compile_commands.json, see https://clangd.llvm.org/installation#compile_commandsjson
 ]],
     default_config = {
-      root_dir = [[
-        root_pattern(
-          '.clangd',
-          '.clang-tidy',
-          '.clang-format',
-          'compile_commands.json',
-          'compile_flags.txt',
-          'configure.ac',
-          '.git'
-        )
-      ]],
       capabilities = [[default capabilities, with offsetEncoding utf-8]],
     },
   },

--- a/lua/lspconfig/server_configurations/clarity_lsp.lua
+++ b/lua/lspconfig/server_configurations/clarity_lsp.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'clarity-lsp' },
     filetypes = { 'clar', 'clarity' },
-    root_dir = util.root_pattern '.git',
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -13,7 +16,7 @@ return {
 To learn how to configure the clarity language server, see the [clarity-lsp documentation](https://github.com/hirosystems/clarity-lsp).
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/clojure_lsp.lua
+++ b/lua/lspconfig/server_configurations/clojure_lsp.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'project.clj', 'deps.edn', 'build.boot', 'shadow-cljs.edn', '.git' }
+
 return {
   default_config = {
     cmd = { 'clojure-lsp' },
     filetypes = { 'clojure', 'edn' },
-    root_dir = util.root_pattern('project.clj', 'deps.edn', 'build.boot', 'shadow-cljs.edn', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -13,7 +16,7 @@ https://github.com/clojure-lsp/clojure-lsp
 Clojure Language Server
 ]],
     default_config = {
-      root_dir = [[root_pattern("project.clj", "deps.edn", "build.boot", "shadow-cljs.edn", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/codeqlls.lua
+++ b/lua/lspconfig/server_configurations/codeqlls.lua
@@ -2,11 +2,13 @@ local util = require 'lspconfig.util'
 
 local workspace_folders = {}
 
+local workspace_markers = { 'qlpack.yml' }
+
 return {
   default_config = {
     cmd = { 'codeql', 'execute', 'language-server', '--check-errors', 'ON_CHANGE', '-q' },
     filetypes = { 'ql' },
-    root_dir = util.root_pattern 'qlpack.yml',
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     log_level = vim.lsp.protocol.MessageType.Warning,
     before_init = function(initialize_params)
       table.insert(workspace_folders, { name = 'workspace', uri = initialize_params['rootUri'] })

--- a/lua/lspconfig/server_configurations/crystalline.lua
+++ b/lua/lspconfig/server_configurations/crystalline.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'shard.yml', '.git' }
+
 return {
   default_config = {
     cmd = { 'crystalline' },
     filetypes = { 'crystal' },
-    root_dir = util.root_pattern 'shard.yml' or util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -14,7 +17,7 @@ https://github.com/elbywan/crystalline
 Crystal language server.
 ]],
     default_config = {
-      root_dir = [[root_pattern('shard.yml', '.git')]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/csharp_ls.lua
+++ b/lua/lspconfig/server_configurations/csharp_ls.lua
@@ -1,9 +1,11 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '*.sln', '*.csproj', '*.fsproj', '.git' }
+
 return {
   default_config = {
     cmd = { 'csharp-ls' },
-    root_dir = util.root_pattern('*.sln', '*.csproj', '*.fsproj', '.git'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     filetypes = { 'cs' },
     init_options = {
       AutomaticWorkspaceInit = true,

--- a/lua/lspconfig/server_configurations/cssls.lua
+++ b/lua/lspconfig/server_configurations/cssls.lua
@@ -7,11 +7,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { 'package.json', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'css', 'scss', 'less' },
-    root_dir = util.root_pattern('package.json', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
     settings = {
       css = { validate = true },
@@ -43,7 +46,7 @@ require'lspconfig'.cssls.setup {
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern("package.json", ".git") or bufdir]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/cucumber_language_server.lua
+++ b/lua/lspconfig/server_configurations/cucumber_language_server.lua
@@ -7,11 +7,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'cucumber' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -27,7 +30,7 @@ npm install -g @cucumber/language-server
 ```
     ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/dartls.lua
+++ b/lua/lspconfig/server_configurations/dartls.lua
@@ -5,11 +5,14 @@ local cmd = (
   or { 'dart', 'language-server', '--protocol=lsp' }
 )
 
+local workspace_markers = { 'pubspec.yaml' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'dart' },
-    root_dir = util.root_pattern 'pubspec.yaml',
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     init_options = {
       onlyAnalyzeProjectsWithOpenFiles = true,
       suggestFromUnimportedLibraries = true,
@@ -31,7 +34,7 @@ https://github.com/dart-lang/sdk/tree/master/pkg/analysis_server/tool/lsp_spec
 Language server for dart.
 ]],
     default_config = {
-      root_dir = [[root_pattern("pubspec.yaml")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/denols.lua
+++ b/lua/lspconfig/server_configurations/denols.lua
@@ -56,10 +56,13 @@ local function denols_handler(err, result, ctx)
   lsp.handlers[ctx.method](err, result, ctx)
 end
 
+local workspace_markers = { 'deno.json', 'deno.jsonc', '.git' }
+
 return {
   default_config = {
     cmd = { 'deno', 'lsp' },
     filetypes = {
+      workspace_markers = workspace_markers,
       'javascript',
       'javascriptreact',
       'javascript.jsx',
@@ -67,7 +70,7 @@ return {
       'typescriptreact',
       'typescript.tsx',
     },
-    root_dir = util.root_pattern('deno.json', 'deno.jsonc', '.git'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     init_options = {
       enable = true,
       unstable = false,
@@ -115,7 +118,7 @@ vim.g.markdown_fenced_languages = {
 
 ]],
     default_config = {
-      root_dir = [[root_pattern("deno.json", "deno.jsonc", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/dhall_lsp_server.lua
+++ b/lua/lspconfig/server_configurations/dhall_lsp_server.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'dhall-lsp-server' },
     filetypes = { 'dhall' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -20,7 +23,7 @@ cabal install dhall-lsp-server
 prebuilt binaries can be found [here](https://github.com/dhall-lang/dhall-haskell/releases).
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/diagnosticls.lua
+++ b/lua/lspconfig/server_configurations/diagnosticls.lua
@@ -7,10 +7,12 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = cmd,
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
     filetypes = {},
   },

--- a/lua/lspconfig/server_configurations/dockerls.lua
+++ b/lua/lspconfig/server_configurations/dockerls.lua
@@ -7,11 +7,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { 'Dockerfile' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'dockerfile' },
-    root_dir = util.root_pattern 'Dockerfile',
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -24,7 +27,7 @@ npm install -g dockerfile-language-server-nodejs
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("Dockerfile")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/dotls.lua
+++ b/lua/lspconfig/server_configurations/dotls.lua
@@ -7,11 +7,13 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'dot' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/efm.lua
+++ b/lua/lspconfig/server_configurations/efm.lua
@@ -1,9 +1,11 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'efm-langserver' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
 
@@ -20,6 +22,7 @@ launching the language server on single files. If on an older version of EFM, di
 require('lspconfig')['efm'].setup{
   settings = ..., -- You must populate this according to the EFM readme
   filetypes = ..., -- Populate this according to the note below
+  workspace_markers = workspace_markers,
   single_file_support = false, -- This is the important line for supporting older version of EFM
 }
 ```
@@ -37,7 +40,7 @@ require('lspconfig')['efm'].setup{
 
 ]],
     default_config = {
-      root_dir = [[util.root_pattern(".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/ember.lua
+++ b/lua/lspconfig/server_configurations/ember.lua
@@ -7,11 +7,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { 'ember-cli-build.js', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'handlebars', 'typescript', 'javascript' },
-    root_dir = util.root_pattern('ember-cli-build.js', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -24,7 +27,7 @@ npm install -g @lifeart/ember-language-server
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern("ember-cli-build.js", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/emmet_ls.lua
+++ b/lua/lspconfig/server_configurations/emmet_ls.lua
@@ -7,11 +7,13 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'html', 'typescriptreact', 'javascriptreact', 'css', 'sass', 'scss', 'less' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/erg_language_server.lua
+++ b/lua/lspconfig/server_configurations/erg_language_server.lua
@@ -1,12 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'package.er', '.git' }
+
 return {
   default_config = {
     cmd = { 'els' },
     filetypes = { 'erg' },
-    root_dir = function(fname)
-      return util.root_pattern 'package.er'(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -20,7 +21,7 @@ ELS (erg-language-server) is a language server for the Erg programming language.
  ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("package.er") or find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/erlangls.lua
+++ b/lua/lspconfig/server_configurations/erlangls.lua
@@ -5,11 +5,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', 'erlang_ls.cmd' }
 end
 
+local workspace_markers = { 'rebar.config', 'erlang.mk', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'erlang' },
-    root_dir = util.root_pattern('rebar.config', 'erlang.mk', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -28,7 +31,7 @@ Installation requirements:
     - [rebar3 3.9.1+](https://github.com/erlang/rebar3)
 ]],
     default_config = {
-      root_dir = [[root_pattern('rebar.config', 'erlang.mk', '.git')]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/esbonio.lua
+++ b/lua/lspconfig/server_configurations/esbonio.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'python3', '-m', 'esbonio' },
     filetypes = { 'rst' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/flow.lua
+++ b/lua/lspconfig/server_configurations/flow.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.flowconfig' }
+
 return {
   default_config = {
     cmd = { 'npx', '--no-install', 'flow', 'lsp' },
     filetypes = { 'javascript', 'javascriptreact', 'javascript.jsx' },
-    root_dir = util.root_pattern '.flowconfig',
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -21,7 +24,7 @@ npx flow lsp --help
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern(".flowconfig")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/flux_lsp.lua
+++ b/lua/lspconfig/server_configurations/flux_lsp.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'flux-lsp' },
     filetypes = { 'flux' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -16,7 +19,7 @@ cargo install --git https://github.com/influxdata/flux-lsp
 ```
 ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/fortls.lua
+++ b/lua/lspconfig/server_configurations/fortls.lua
@@ -1,5 +1,7 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.fortls', '.git' }
+
 return {
   default_config = {
     cmd = {
@@ -10,9 +12,7 @@ return {
       '--use_signature_help',
     },
     filetypes = { 'fortran' },
-    root_dir = function(fname)
-      return util.root_pattern '.fortls'(fname) or util.find_git_ancestor(fname)
-    end,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     settings = {},
   },
   docs = {
@@ -30,7 +30,7 @@ a local configuration file e.g. `.fortls`. For more information
 see the `fortls` [documentation](https://gnikit.github.io/fortls/options.html).
     ]],
     default_config = {
-      root_dir = [[root_pattern(".fortls")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/fsautocomplete.lua
+++ b/lua/lspconfig/server_configurations/fsautocomplete.lua
@@ -1,9 +1,11 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '*.sln', '*.fsproj', '.git' }
+
 return {
   default_config = {
     cmd = { 'fsautocomplete', '--adaptive-lsp-server-enabled' },
-    root_dir = util.root_pattern('*.sln', '*.fsproj', '.git'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     filetypes = { 'fsharp' },
     init_options = {
       AutomaticWorkspaceInit = true,

--- a/lua/lspconfig/server_configurations/fsharp_language_server.lua
+++ b/lua/lspconfig/server_configurations/fsharp_language_server.lua
@@ -1,9 +1,11 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '*.sln', '*.fsproj', '.git' }
+
 return {
   default_config = {
     cmd = { 'dotnet', 'FSharpLanguageServer.dll' },
-    root_dir = util.root_pattern('*.sln', '*.fsproj', '.git'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     filetypes = { 'fsharp' },
     init_options = {
       AutomaticWorkspaceInit = true,

--- a/lua/lspconfig/server_configurations/fstar.lua
+++ b/lua/lspconfig/server_configurations/fstar.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'fstar.exe', '--lsp' },
     filetypes = { 'fstar' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -13,7 +16,7 @@ https://github.com/FStarLang/FStar
 LSP support is included in FStar. Make sure `fstar.exe` is in your PATH.
 ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/gdscript.lua
+++ b/lua/lspconfig/server_configurations/gdscript.lua
@@ -6,11 +6,14 @@ if vim.fn.has 'nvim-0.8' == 1 then
   cmd = vim.lsp.rpc.connect('127.0.0.1', '6008')
 end
 
+local workspace_markers = { 'project.godot', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'gd', 'gdscript', 'gdscript3' },
-    root_dir = util.root_pattern('project.godot', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -19,7 +22,7 @@ https://github.com/godotengine/godot
 Language server for GDScript, used by Godot Engine.
 ]],
     default_config = {
-      root_dir = [[util.root_pattern("project.godot", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/ghcide.lua
+++ b/lua/lspconfig/server_configurations/ghcide.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'stack.yaml', 'hie-bios', 'BUILD.bazel', 'cabal.config', 'package.yaml' }
+
 return {
   default_config = {
     cmd = { 'ghcide', '--lsp' },
     filetypes = { 'haskell', 'lhaskell' },
-    root_dir = util.root_pattern('stack.yaml', 'hie-bios', 'BUILD.bazel', 'cabal.config', 'package.yaml'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
 
   docs = {
@@ -15,7 +18,7 @@ A library for building Haskell IDE tooling.
 "ghcide" isn't for end users now. Use "haskell-language-server" instead of "ghcide".
 ]],
     default_config = {
-      root_dir = [[root_pattern("stack.yaml", "hie-bios", "BUILD.bazel", "cabal.config", "package.yaml")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/ghdl_ls.lua
+++ b/lua/lspconfig/server_configurations/ghdl_ls.lua
@@ -1,12 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'hdl-prj.json', '.git' }
 return {
   default_config = {
     cmd = { 'ghdl-ls' },
     filetypes = { 'vhdl' },
-    root_dir = function(fname)
-      return util.root_pattern 'hdl-prj.json'(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -18,5 +18,6 @@ A language server for VHDL, using ghdl as its backend.
 `ghdl-ls` is part of pyghdl, for installation instructions see
 [the upstream README](https://github.com/ghdl/ghdl/tree/master/pyGHDL/lsp).
 ]],
+    workspace_markers = workspace_markers,
   },
 }

--- a/lua/lspconfig/server_configurations/glslls.lua
+++ b/lua/lspconfig/server_configurations/glslls.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'glslls', '--stdin' },
     filetypes = { 'glsl' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
     capabilities = {
       textDocument = {

--- a/lua/lspconfig/server_configurations/grammarly.lua
+++ b/lua/lspconfig/server_configurations/grammarly.lua
@@ -7,11 +7,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'markdown' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
     handlers = {
       ['$/updateDocumentState'] = function()
@@ -35,7 +38,7 @@ npm i -g grammarly-languageserver
 WARNING: Since this language server uses Grammarly's API, any document you open with it running is shared with them. Please evaluate their [privacy policy](https://www.grammarly.com/privacy-policy) before using this.
 ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/graphql.lua
+++ b/lua/lspconfig/server_configurations/graphql.lua
@@ -7,11 +7,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, 'server', '-m', 'stream' }
 end
 
+local workspace_markers = { '.git', '.graphqlrc*', '.graphql.config.*', 'graphql.config.*' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'graphql', 'typescriptreact', 'javascriptreact' },
-    root_dir = util.root_pattern('.git', '.graphqlrc*', '.graphql.config.*', 'graphql.config.*'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
 
   docs = {
@@ -27,7 +30,7 @@ npm install -g graphql-language-service-cli
 Note that you must also have [the graphql package](https://github.com/graphql/graphql-js) installed and create a [GraphQL config file](https://www.graphql-config.com/docs/user/user-introduction).
 ]],
     default_config = {
-      root_dir = [[util.root_pattern('.git', '.graphqlrc*', '.graphql.config.*', 'graphql.config.*')]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/groovyls.lua
+++ b/lua/lspconfig/server_configurations/groovyls.lua
@@ -1,5 +1,7 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'Jenkinsfile', '.git' }
+
 return {
   default_config = {
     cmd = {
@@ -8,9 +10,8 @@ return {
       'groovy-language-server-all.jar',
     },
     filetypes = { 'groovy' },
-    root_dir = function(fname)
-      return util.root_pattern 'Jenkinsfile'(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -32,5 +33,6 @@ require'lspconfig'.groovyls.setup{
 }
 ```
 ]],
+    workspace_markers = workspace_markers,
   },
 }

--- a/lua/lspconfig/server_configurations/haxe_language_server.lua
+++ b/lua/lspconfig/server_configurations/haxe_language_server.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '*.hxml' }
+
 return {
   default_config = {
     cmd = { 'haxe-language-server' },
     filetypes = { 'haxe' },
-    root_dir = util.root_pattern '*.hxml',
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     settings = {
       haxe = {
         executable = 'haxe',
@@ -41,7 +44,7 @@ your project's root directory. If your file is named something different,
 specify it using the `init_options.displayArguments` setting.
 ]],
     default_config = {
-      root_dir = [[root_pattern("*.hxml")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/hdl_checker.lua
+++ b/lua/lspconfig/server_configurations/hdl_checker.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'hdl_checker', '--lsp' },
     filetypes = { 'vhdl', 'verilog', 'systemverilog' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -14,7 +17,7 @@ Language server for hdl-checker.
 Install using: `pip install hdl-checker --upgrade`
 ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/hhvm.lua
+++ b/lua/lspconfig/server_configurations/hhvm.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.hhconfig' }
+
 return {
   default_config = {
     cmd = { 'hh_client', 'lsp' },
     filetypes = { 'php', 'hack' },
-    root_dir = util.root_pattern '.hhconfig',
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -15,7 +18,7 @@ See below for how to setup HHVM & typechecker:
 https://docs.hhvm.com/hhvm/getting-started/getting-started
     ]],
     default_config = {
-      root_dir = [[root_pattern(".hhconfig")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/hie.lua
+++ b/lua/lspconfig/server_configurations/hie.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'stack.yaml', 'package.yaml', '.git' }
+
 return {
   default_config = {
     cmd = { 'hie-wrapper', '--lsp' },
     filetypes = { 'haskell' },
-    root_dir = util.root_pattern('stack.yaml', 'package.yaml', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
 
   docs = {
@@ -28,7 +31,7 @@ init_options = {
         ]],
 
     default_config = {
-      root_dir = [[root_pattern("stack.yaml", "package.yaml", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/hoon_ls.lua
+++ b/lua/lspconfig/server_configurations/hoon_ls.lua
@@ -7,11 +7,13 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name }
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'hoon' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/html.lua
+++ b/lua/lspconfig/server_configurations/html.lua
@@ -7,11 +7,13 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { 'package.json', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'html' },
-    root_dir = util.root_pattern('package.json', '.git'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
     settings = {},
     init_options = {

--- a/lua/lspconfig/server_configurations/idris2_lsp.lua
+++ b/lua/lspconfig/server_configurations/idris2_lsp.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '*.ipkg' }
+
 return {
   default_config = {
     cmd = { 'idris2-lsp' },
     filetypes = { 'idris2' },
-    root_dir = util.root_pattern '*.ipkg',
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/java_language_server.lua
+++ b/lua/lspconfig/server_configurations/java_language_server.lua
@@ -1,9 +1,11 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'build.gradle', 'pom.xml', '.git' }
+
 return {
   default_config = {
     filetypes = { 'java' },
-    root_dir = util.root_pattern('build.gradle', 'pom.xml', '.git'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     settings = {},
   },
   docs = {

--- a/lua/lspconfig/server_configurations/jsonls.lua
+++ b/lua/lspconfig/server_configurations/jsonls.lua
@@ -7,14 +7,17 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'json', 'jsonc' },
+    workspace_markers = workspace_markers,
     init_options = {
       provideFormatter = true,
     },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -42,7 +45,7 @@ require'lspconfig'.jsonls.setup {
 ```
 ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/jsonnet_ls.lua
+++ b/lua/lspconfig/server_configurations/jsonnet_ls.lua
@@ -9,13 +9,14 @@ local function jsonnet_path(root_dir)
   return table.concat(paths, ':')
 end
 
+local workspace_markers = { 'jsonnetfile.json', '.git' }
+
 return {
   default_config = {
     cmd = { 'jsonnet-language-server' },
     filetypes = { 'jsonnet', 'libsonnet' },
-    root_dir = function(fname)
-      return util.root_pattern 'jsonnetfile.json'(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     on_new_config = function(new_config, root_dir)
       if not new_config.cmd_env then
         new_config.cmd_env = {}
@@ -37,7 +38,7 @@ go install github.com/grafana/jsonnet-language-server@latest
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern("jsonnetfile.json")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/julials.lua
+++ b/lua/lspconfig/server_configurations/julials.lua
@@ -40,13 +40,14 @@ local cmd = {
   ]],
 }
 
+local workspace_markers = { 'Project.toml', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'julia' },
-    root_dir = function(fname)
-      return util.root_pattern 'Project.toml'(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -71,5 +72,6 @@ Julia project, you must make sure that the project is instantiated:
 julia --project=/path/to/my/project -e 'using Pkg; Pkg.instantiate()'
 ```
     ]],
+    workspace_markers = workspace_markers,
   },
 }

--- a/lua/lspconfig/server_configurations/lelwel_ls.lua
+++ b/lua/lspconfig/server_configurations/lelwel_ls.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'lelwel-ls' },
     filetypes = { 'llw' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/lemminx.lua
+++ b/lua/lspconfig/server_configurations/lemminx.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'lemminx' },
     filetypes = { 'xml', 'xsd', 'xsl', 'xslt', 'svg' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -17,7 +20,7 @@ NOTE to macOS users: Binaries from unidentified developers are blocked by defaul
 
 ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/ltex.lua
+++ b/lua/lspconfig/server_configurations/ltex.lua
@@ -14,11 +14,13 @@ if vim.fn.has 'win32' == 1 then
   bin_name = bin_name .. '.bat'
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { bin_name },
     filetypes = { 'bib', 'gitcommit', 'markdown', 'org', 'plaintex', 'rst', 'rnoweb', 'tex' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
     get_language_id = function(_, filetype)
       local language_id = language_id_mapping[filetype]

--- a/lua/lspconfig/server_configurations/luau_lsp.lua
+++ b/lua/lspconfig/server_configurations/luau_lsp.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'luau-lsp', 'lsp' },
     filetypes = { 'luau' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     [[
@@ -21,7 +24,7 @@ autocmd BufRead,BufNewFile *.luau setf luau
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/m68k.lua
+++ b/lua/lspconfig/server_configurations/m68k.lua
@@ -7,11 +7,13 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { 'Makefile', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'asm68k' },
-    root_dir = util.root_pattern('Makefile', '.git'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/marksman.lua
+++ b/lua/lspconfig/server_configurations/marksman.lua
@@ -3,14 +3,14 @@ local util = require 'lspconfig.util'
 local bin_name = 'marksman'
 local cmd = { bin_name, 'server' }
 
+local workspace_markers = { '.marksman.toml', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'markdown' },
-    root_dir = function(fname)
-      local root_files = { '.marksman.toml' }
-      return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -24,7 +24,7 @@ Marksman works on MacOS, Linux, and Windows and is distributed as a self-contain
 Pre-built binaries can be downloaded from https://github.com/artempyanykh/marksman/releases
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git", ".marksman.toml")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/metals.lua
+++ b/lua/lspconfig/server_configurations/metals.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'build.sbt', 'build.sc', 'build.gradle', 'pom.xml' }
+
 return {
   default_config = {
     cmd = { 'metals' },
     filetypes = { 'scala' },
-    root_dir = util.root_pattern('build.sbt', 'build.sc', 'build.gradle', 'pom.xml'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     message_level = vim.lsp.protocol.MessageType.Log,
     init_options = {
       statusBarProvider = 'show-message',
@@ -34,7 +37,7 @@ Note: that if you're using [nvim-metals](https://github.com/scalameta/nvim-metal
 To install Metals, make sure to have [coursier](https://get-coursier.io/docs/cli-installation) installed, and once you do you can install the latest Metals with `cs install metals`.
 ]],
     default_config = {
-      root_dir = [[util.root_pattern("build.sbt", "build.sc", "build.gradle", "pom.xml")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/mint.lua
+++ b/lua/lspconfig/server_configurations/mint.lua
@@ -1,15 +1,17 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'mint.json', '.git' }
+
 return {
   default_config = {
     cmd = { 'mint', 'ls' },
     filetypes = { 'mint' },
-    root_dir = function(fname)
-      return util.root_pattern 'mint.json'(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
+    workspace_markers = workspace_markers,
     description = [[
 https://www.mint-lang.com
 

--- a/lua/lspconfig/server_configurations/mlir_lsp_server.lua
+++ b/lua/lspconfig/server_configurations/mlir_lsp_server.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'mlir-lsp-server' },
     filetypes = { 'mlir' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/mlir_pdll_lsp_server.lua
+++ b/lua/lspconfig/server_configurations/mlir_pdll_lsp_server.lua
@@ -1,12 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'pdll_compile_commands.yml', '.git' }
+
 return {
   default_config = {
     cmd = { 'mlir-pdll-lsp-server' },
     filetypes = { 'pdll' },
-    root_dir = function(fname)
-      return util.root_pattern 'pdll_compile_commands.yml'(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -16,5 +17,6 @@ The Language Server for the LLVM PDLL language
 
 `mlir-pdll-lsp-server` can be installed at the llvm-project repository (https://github.com/llvm/llvm-project)
 ]],
+    workspace_markers = workspace_markers,
   },
 }

--- a/lua/lspconfig/server_configurations/mm0_ls.lua
+++ b/lua/lspconfig/server_configurations/mm0_ls.lua
@@ -1,9 +1,11 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'mm0-rs', 'server' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     filetypes = { 'metamath-zero' },
     single_file_support = true,
   },

--- a/lua/lspconfig/server_configurations/nickel_ls.lua
+++ b/lua/lspconfig/server_configurations/nickel_ls.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'nls' },
     filetypes = { 'ncl', 'nickel' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
 
   docs = {

--- a/lua/lspconfig/server_configurations/nil_ls.lua
+++ b/lua/lspconfig/server_configurations/nil_ls.lua
@@ -1,11 +1,14 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'flake.nix', '.git' }
+
 return {
   default_config = {
     cmd = { 'nil' },
     filetypes = { 'nix' },
+    workspace_markers = workspace_markers,
     single_file_support = true,
-    root_dir = util.root_pattern('flake.nix', '.git'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -17,7 +20,7 @@ If you are using Nix with Flakes support, run `nix profile install github:oxalic
 Check the repository README for more information.
     ]],
     default_config = {
-      root_dir = [[root_pattern("flake.nix", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/nimls.lua
+++ b/lua/lspconfig/server_configurations/nimls.lua
@@ -1,12 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '*.nimble', '.git' }
+
 return {
   default_config = {
     cmd = { 'nimlsp' },
     filetypes = { 'nim' },
-    root_dir = function(fname)
-      return util.root_pattern '*.nimble'(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -19,5 +20,6 @@ https://github.com/PMunch/nimlsp
 nimble install nimlsp
 ```
     ]],
+    workspace_markers = workspace_markers,
   },
 }

--- a/lua/lspconfig/server_configurations/nxls.lua
+++ b/lua/lspconfig/server_configurations/nxls.lua
@@ -7,11 +7,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { 'nx.json', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'json', 'jsonc' },
-    root_dir = util.root_pattern('nx.json', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -25,7 +28,7 @@ npm i -g nxls
 ```
 ]],
     default_config = {
-      root_dir = [[util.root_pattern]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/ocamlls.lua
+++ b/lua/lspconfig/server_configurations/ocamlls.lua
@@ -6,11 +6,14 @@ local cmd = { bin_name, '--stdio' }
 if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
+local workspace_markers = { '*.opam', 'esy.json', 'package.json' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'ocaml', 'reason' },
-    root_dir = util.root_pattern('*.opam', 'esy.json', 'package.json'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -22,7 +25,7 @@ npm install -g ocaml-language-server
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("*.opam", "esy.json", "package.json")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/ocamllsp.lua
+++ b/lua/lspconfig/server_configurations/ocamllsp.lua
@@ -13,11 +13,14 @@ local get_language_id = function(_, ftype)
   return language_id_of[ftype]
 end
 
+local workspace_markers = { '*.opam', 'esy.json', 'package.json', '.git', 'dune-project', 'dune-workspace' }
+
 return {
   default_config = {
     cmd = { 'ocamllsp' },
     filetypes = { 'ocaml', 'ocaml.menhir', 'ocaml.interface', 'ocaml.ocamllex', 'reason', 'dune' },
-    root_dir = util.root_pattern('*.opam', 'esy.json', 'package.json', '.git', 'dune-project', 'dune-workspace'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     get_language_id = get_language_id,
   },
   docs = {
@@ -32,7 +35,7 @@ opam install ocaml-lsp-server
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("*.opam", "esy.json", "package.json", ".git", "dune-project", "dune-workspace")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/ols.lua
+++ b/lua/lspconfig/server_configurations/ols.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'ols.json', '.git' }
+
 return {
   default_config = {
     cmd = { 'ols' },
     filetypes = { 'odin' },
-    root_dir = util.root_pattern('ols.json', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -14,7 +17,7 @@ return {
            `Odin Language Server`.
         ]],
     default_config = {
-      root_dir = [[util.root_pattern("ols.json", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/opencl_ls.lua
+++ b/lua/lspconfig/server_configurations/opencl_ls.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'opencl-language-server' },
     filetypes = { 'opencl' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -15,7 +18,7 @@ Build instructions can be found [here](https://github.com/Galarius/opencl-langua
 Prebuilt binaries are available for Linux, macOS and Windows [here](https://github.com/Galarius/opencl-language-server/releases).
 ]],
     default_config = {
-      root_dir = [[util.root_pattern(".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/openscad_ls.lua
+++ b/lua/lspconfig/server_configurations/openscad_ls.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'openscad-language-server' },
     filetypes = { 'openscad' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/pasls.lua
+++ b/lua/lspconfig/server_configurations/pasls.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '*.lpi', '*.lpk', '.git' }
+
 return {
   default_config = {
     cmd = { 'pasls' },
     filetypes = { 'pascal' },
-    root_dir = util.root_pattern('*.lpi', '*.lpk', '.git'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/perlls.lua
+++ b/lua/lspconfig/server_configurations/perlls.lua
@@ -1,5 +1,7 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = {
@@ -21,7 +23,7 @@ return {
       },
     },
     filetypes = { 'perl' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/perlnavigator.lua
+++ b/lua/lspconfig/server_configurations/perlnavigator.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = {},
     filetypes = { 'perl' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/perlpls.lua
+++ b/lua/lspconfig/server_configurations/perlpls.lua
@@ -1,5 +1,7 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'pls' },
@@ -10,7 +12,8 @@ return {
       },
     },
     filetypes = { 'perl' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -23,7 +26,7 @@ https://metacpan.org/pod/PLS
 To use the language server, ensure that you have PLS installed and that it is in your path
 ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/please.lua
+++ b/lua/lspconfig/server_configurations/please.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.plzconfig' }
+
 return {
   default_config = {
     cmd = { 'plz', 'tool', 'lps' },
     filetypes = { 'bzl' },
-    root_dir = util.root_pattern '.plzconfig',
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/powershell_es.lua
+++ b/lua/lspconfig/server_configurations/powershell_es.lua
@@ -11,6 +11,8 @@ local function make_cmd(new_config)
   end
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     shell = 'pwsh',
@@ -22,7 +24,7 @@ return {
     end,
 
     filetypes = { 'ps1' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/prismals.lua
+++ b/lua/lspconfig/server_configurations/prismals.lua
@@ -7,16 +7,19 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { '.git', 'package.json' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'prisma' },
+    workspace_markers = workspace_markers,
     settings = {
       prisma = {
         prismaFmtBinPath = '',
       },
     },
-    root_dir = util.root_pattern('.git', 'package.json'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -28,7 +31,7 @@ npm install -g @prisma/language-server
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git", "package.json")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/prosemd_lsp.lua
+++ b/lua/lspconfig/server_configurations/prosemd_lsp.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'prosemd-lsp', '--stdio' },
     filetypes = { 'markdown' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/psalm.lua
+++ b/lua/lspconfig/server_configurations/psalm.lua
@@ -6,11 +6,14 @@ if vim.fn.has 'win32' == 1 then
   bin_name = bin_name .. '.bat'
 end
 
+local workspace_markers = { 'psalm.xml', 'psalm.xml.dist' }
+
 return {
   default_config = {
     cmd = { bin_name },
     filetypes = { 'php' },
-    root_dir = util.root_pattern('psalm.xml', 'psalm.xml.dist'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -23,7 +26,7 @@ composer global require vimeo/psalm
 ]],
     default_config = {
       cmd = { 'psalm-language-server' },
-      root_dir = [[root_pattern("psalm.xml", "psalm.xml.dist")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/purescriptls.lua
+++ b/lua/lspconfig/server_configurations/purescriptls.lua
@@ -7,11 +7,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { 'bower.json', 'psc-package.json', 'spago.dhall', 'flake.nix', 'shell.nix' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'purescript' },
-    root_dir = util.root_pattern('bower.json', 'psc-package.json', 'spago.dhall', 'flake.nix', 'shell.nix'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -23,7 +26,7 @@ The `purescript-language-server` can be added to your project and `$PATH` via
 * Nix under the `nodePackages` and `nodePackages_latest` package sets
 ]],
     default_config = {
-      root_dir = [[root_pattern('spago.dhall', 'psc-package.json', 'bower.json', 'flake.nix', 'shell.nix'),]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/pylsp.lua
+++ b/lua/lspconfig/server_configurations/pylsp.lua
@@ -1,19 +1,19 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = {
+  'pyproject.toml',
+  'setup.py',
+  'setup.cfg',
+  'requirements.txt',
+  'Pipfile',
+  '.git',
+}
 return {
   default_config = {
     cmd = { 'pylsp' },
     filetypes = { 'python' },
-    root_dir = function(fname)
-      local root_files = {
-        'pyproject.toml',
-        'setup.py',
-        'setup.cfg',
-        'requirements.txt',
-        'Pipfile',
-      }
-      return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -44,5 +44,6 @@ require'lspconfig'.pylsp.setup{
 
 Note: This is a community fork of `pyls`.
     ]],
+    workspace_markers = workspace_markers,
   },
 }

--- a/lua/lspconfig/server_configurations/pyre.lua
+++ b/lua/lspconfig/server_configurations/pyre.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.pyre_configuration' }
+
 return {
   default_config = {
     cmd = { 'pyre', 'persistent' },
     filetypes = { 'python' },
-    root_dir = util.root_pattern '.pyre_configuration',
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/qml_lsp.lua
+++ b/lua/lspconfig/server_configurations/qml_lsp.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '*.qml' }
+
 return {
   default_config = {
     cmd = { 'qml-lsp' },
     filetypes = { 'qmljs' },
-    root_dir = util.root_pattern '*.qml',
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/quick_lint_js.lua
+++ b/lua/lspconfig/server_configurations/quick_lint_js.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'package.json', 'jsconfig.json', '.git' }
+
 return {
   default_config = {
     cmd = { 'quick-lint-js', '--lsp-server' },
     filetypes = { 'javascript' },
-    root_dir = util.root_pattern('package.json', 'jsconfig.json', '.git'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/racket_langserver.lua
+++ b/lua/lspconfig/server_configurations/racket_langserver.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'racket', '--lib', 'racket-langserver' },
     filetypes = { 'racket', 'scheme' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/reason_ls.lua
+++ b/lua/lspconfig/server_configurations/reason_ls.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'bsconfig.json', '.git' }
+
 return {
   default_config = {
     cmd = { 'reason-language-server' },
     filetypes = { 'reason' },
-    root_dir = util.root_pattern('bsconfig.json', '.git'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/relay_lsp.lua
+++ b/lua/lspconfig/server_configurations/relay_lsp.lua
@@ -8,6 +8,8 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, 'lsp' }
 end
 
+local workspace_markers = { 'relay.config.*', 'package.json' }
+
 return {
   default_config = {
     -- (default: false) Whether or not we should automatically start the
@@ -21,6 +23,7 @@ return {
 
     cmd = cmd,
     filetypes = {
+      workspace_markers = workspace_markers,
       'javascript',
       'javascriptreact',
       'javascript.jsx',
@@ -28,7 +31,7 @@ return {
       'typescriptreact',
       'typescript.tsx',
     },
-    root_dir = util.root_pattern('relay.config.*', 'package.json'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     on_new_config = function(config, root_dir)
       local project_root = util.find_node_modules_ancestor(root_dir)
       local node_bin_path = util.path.join(project_root, 'node_modules', '.bin')
@@ -109,7 +112,7 @@ return {
     ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("relay.config.*", "package.json")]],
+      workspace_markers = workspace_markers,
       auto_start_compiler = false,
       path_to_config = nil,
     },

--- a/lua/lspconfig/server_configurations/remark_ls.lua
+++ b/lua/lspconfig/server_configurations/remark_ls.lua
@@ -7,11 +7,13 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'markdown' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/rescriptls.lua
+++ b/lua/lspconfig/server_configurations/rescriptls.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'bsconfig.json', '.git' }
+
 return {
   default_config = {
     cmd = {},
     filetypes = { 'rescript' },
-    root_dir = util.root_pattern('bsconfig.json', '.git'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     settings = {},
   },
   docs = {

--- a/lua/lspconfig/server_configurations/rls.lua
+++ b/lua/lspconfig/server_configurations/rls.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'Cargo.toml' }
+
 return {
   default_config = {
     cmd = { 'rls' },
     filetypes = { 'rust' },
-    root_dir = util.root_pattern 'Cargo.toml',
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -36,7 +39,7 @@ cmd = {"rustup", "run", "nightly", "rls"}
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("Cargo.toml")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/robotframework_ls.lua
+++ b/lua/lspconfig/server_configurations/robotframework_ls.lua
@@ -1,12 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'robotidy.toml', 'pyproject.toml', '.git' }
+
 return {
   default_config = {
     cmd = { 'robotframework_ls' },
     filetypes = { 'robot' },
-    root_dir = function(fname)
-      return util.root_pattern('robotidy.toml', 'pyproject.toml')(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -15,7 +16,7 @@ https://github.com/robocorp/robotframework-lsp
 Language Server Protocol implementation for Robot Framework.
 ]],
     default_config = {
-      root_dir = "util.root_pattern('robotidy.toml', 'pyproject.toml')(fname) or util.find_git_ancestor(fname)",
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/ruby_ls.lua
+++ b/lua/lspconfig/server_configurations/ruby_ls.lua
@@ -9,11 +9,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name }
 end
 
+local workspace_markers = { 'Gemfile', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'ruby' },
-    root_dir = util.root_pattern('Gemfile', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     init_options = {
       enabledFeatures = {
         'codeActions',
@@ -42,7 +45,7 @@ end
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("Gemfile", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/salt_ls.lua
+++ b/lua/lspconfig/server_configurations/salt_ls.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'salt_lsp_server' },
     filetypes = { 'sls' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -18,7 +21,7 @@ pip install salt-lsp
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern('.git')]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/scry.lua
+++ b/lua/lspconfig/server_configurations/scry.lua
@@ -1,12 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'shard.yml', '.git' }
+
 return {
   default_config = {
     cmd = { 'scry' },
     filetypes = { 'crystal' },
-    root_dir = function(fname)
-      return util.root_pattern 'shard.yml'(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -16,7 +17,7 @@ https://github.com/crystal-lang-tools/scry
 Crystal language server.
 ]],
     default_config = {
-      root_dir = [[root_pattern('shard.yml', '.git')]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/serve_d.lua
+++ b/lua/lspconfig/server_configurations/serve_d.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'dub.json', 'dub.sdl', '.git' }
+
 return {
   default_config = {
     cmd = { 'serve-d' },
     filetypes = { 'd' },
-    root_dir = util.root_pattern('dub.json', 'dub.sdl', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -14,7 +17,7 @@ return {
            Download a binary from https://github.com/Pure-D/serve-d/releases and put it in your $PATH.
         ]],
     default_config = {
-      root_dir = [[util.root_pattern("dub.json", "dub.sdl", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/solang.lua
+++ b/lua/lspconfig/server_configurations/solang.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'solang', '--language-server', '--target', 'ewasm' },
     filetypes = { 'solidity' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -21,7 +24,7 @@ There is currently no support for completion, goto definition, references, or ot
 
 ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/solargraph.lua
+++ b/lua/lspconfig/server_configurations/solargraph.lua
@@ -7,6 +7,8 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, 'stdio' }
 end
 
+local workspace_markers = { 'Gemfile', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
@@ -17,7 +19,8 @@ return {
     },
     init_options = { formatting = true },
     filetypes = { 'ruby' },
-    root_dir = util.root_pattern('Gemfile', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -32,7 +35,7 @@ gem install --user-install solargraph
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("Gemfile", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/solc.lua
+++ b/lua/lspconfig/server_configurations/solc.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'hardhat.config.*', '.git' }
+
 return {
   default_config = {
     cmd = { 'solc', '--lsp' },
     filetypes = { 'solidity' },
-    root_dir = util.root_pattern('hardhat.config.*', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -13,7 +16,7 @@ https://docs.soliditylang.org/en/latest/installing-solidity.html
 solc is the native language server for the Solidity language.
 ]],
     default_config = {
-      root_dir = [[root_pattern('hardhat.config.*', '.git')]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/solidity.lua
+++ b/lua/lspconfig/server_configurations/solidity.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git', 'package.json' }
+
 return {
   default_config = {
     cmd = { 'solidity-ls', '--stdio' },
     filetypes = { 'solidity' },
-    root_dir = util.root_pattern('.git', 'package.json'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     settings = { solidity = { includePath = '', remapping = {} } },
   },
   docs = {
@@ -43,7 +46,7 @@ After installing with package.json, just create a `remappings.txt` with:
 You can omit the node_modules as well.
 ]],
     default_config = {
-      root_dir = [[root_pattern("package.json", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/solidity_ls.lua
+++ b/lua/lspconfig/server_configurations/solidity_ls.lua
@@ -5,11 +5,14 @@ if vim.fn.has 'win32' == 1 then
   bin_name = bin_name .. '.cmd'
 end
 
+local workspace_markers = { '.git', 'package.json' }
+
 return {
   default_config = {
     cmd = { bin_name, '--stdio' },
     filetypes = { 'solidity' },
-    root_dir = util.root_pattern('.git', 'package.json'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -18,7 +21,7 @@ npm install -g solidity-language-server
 solidity-language-server is a language server for the solidity language ported from the vscode solidity extension
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git", "package.json")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/sorbet.lua
+++ b/lua/lspconfig/server_configurations/sorbet.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'Gemfile', '.git' }
+
 return {
   default_config = {
     cmd = { 'srb', 'tc', '--lsp' },
     filetypes = { 'ruby' },
-    root_dir = util.root_pattern('Gemfile', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -20,7 +23,7 @@ gem install sorbet
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("Gemfile", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/sourcekit.lua
+++ b/lua/lspconfig/server_configurations/sourcekit.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'Package.swift', '.git' }
+
 return {
   default_config = {
     cmd = { 'sourcekit-lsp' },
     filetypes = { 'swift', 'c', 'cpp', 'objective-c', 'objective-cpp' },
-    root_dir = util.root_pattern('Package.swift', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -13,7 +16,7 @@ https://github.com/apple/sourcekit-lsp
 Language server for Swift and C/C++/Objective-C.
     ]],
     default_config = {
-      root_dir = [[root_pattern("Package.swift", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/sourcery.lua
+++ b/lua/lspconfig/server_configurations/sourcery.lua
@@ -1,26 +1,26 @@
 local util = require 'lspconfig.util'
 
-local root_files = {
+local workspace_markers = {
   'pyproject.toml',
   'setup.py',
   'setup.cfg',
   'requirements.txt',
   'Pipfile',
   'pyrightconfig.json',
+  '.git',
 }
 
 return {
   default_config = {
     cmd = { 'sourcery', 'lsp' },
     filetypes = { 'python' },
+    workspace_markers = workspace_markers,
     init_options = {
       editor_version = 'vim',
       extension_version = 'vim.lsp',
       token = nil,
     },
-    root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
-    end,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   on_new_config = function(new_config, _)
@@ -51,5 +51,6 @@ init_options = {
     editor_version = 'vim'
 }
 ]],
+    workspace_markers = workspace_markers,
   },
 }

--- a/lua/lspconfig/server_configurations/spectral.lua
+++ b/lua/lspconfig/server_configurations/spectral.lua
@@ -2,11 +2,13 @@ local util = require 'lspconfig.util'
 
 local bin_name = 'spectral-language-server'
 
+local workspace_markers = { '.spectral.yaml', '.spectral.yml', '.spectral.json', '.spectral.js' }
+
 return {
   default_config = {
     cmd = { bin_name, '--stdio' },
     filetypes = { 'yaml', 'json', 'yml' },
-    root_dir = util.root_pattern('.spectral.yaml', '.spectral.yml', '.spectral.json', '.spectral.js'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
     settings = {
       enable = true,

--- a/lua/lspconfig/server_configurations/sqlls.lua
+++ b/lua/lspconfig/server_configurations/sqlls.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.sqllsrc.json' }
+
 return {
   default_config = {
     cmd = { 'sql-language-server', 'up', '--method', 'stdio' },
     filetypes = { 'sql', 'mysql' },
-    root_dir = util.root_pattern '.sqllsrc.json',
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     settings = {},
   },
   docs = {

--- a/lua/lspconfig/server_configurations/sqls.lua
+++ b/lua/lspconfig/server_configurations/sqls.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'config.yml' }
+
 return {
   default_config = {
     cmd = { 'sqls' },
     filetypes = { 'sql', 'mysql' },
-    root_dir = util.root_pattern 'config.yml',
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
     settings = {},
   },

--- a/lua/lspconfig/server_configurations/steep.lua
+++ b/lua/lspconfig/server_configurations/steep.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'Steepfile', '.git' }
+
 return {
   default_config = {
     cmd = { 'steep', 'langserver' },
     filetypes = { 'ruby', 'eruby' },
-    root_dir = util.root_pattern('Steepfile', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -15,7 +18,7 @@ https://github.com/soutaro/steep
 You need `Steepfile` to make it work. Generate it with `steep init`.
 ]],
     default_config = {
-      root_dir = [[root_pattern("Steepfile", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/stylelint_lsp.lua
+++ b/lua/lspconfig/server_configurations/stylelint_lsp.lua
@@ -7,10 +7,13 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { '.stylelintrc', 'package.json' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = {
+      workspace_markers = workspace_markers,
       'css',
       'less',
       'scss',
@@ -22,7 +25,7 @@ return {
       'typescript',
       'typescriptreact',
     },
-    root_dir = util.root_pattern('.stylelintrc', 'package.json'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     settings = {},
   },
   docs = {
@@ -48,7 +51,7 @@ require'lspconfig'.stylelint_lsp.setup{
 ```
 ]],
     default_config = {
-      root_dir = [[ root_pattern('.stylelintrc', 'package.json') ]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/sumneko_lua.lua
+++ b/lua/lspconfig/server_configurations/sumneko_lua.lua
@@ -1,11 +1,13 @@
 local util = require 'lspconfig.util'
 
-local root_files = {
+local workspace_markers = {
   '.luarc.json',
   '.luacheckrc',
   '.stylua.toml',
   'stylua.toml',
   'selene.toml',
+  'lua/',
+  '.git',
 }
 
 local bin_name = 'lua-language-server'
@@ -19,13 +21,8 @@ return {
   default_config = {
     cmd = cmd,
     filetypes = { 'lua' },
-    root_dir = function(fname)
-      local root = util.root_pattern(unpack(root_files))(fname) or util.root_pattern 'lua/'(fname)
-      if root and root ~= vim.env.HOME then
-        return root
-      end
-      return util.find_git_ancestor(fname)
-    end,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
+    workspace_markers = workspace_markers,
     single_file_support = true,
     log_level = vim.lsp.protocol.MessageType.Warning,
     settings = { Lua = { telemetry = { enable = false } } },
@@ -78,8 +75,5 @@ See `lua-language-server`'s [documentation](https://github.com/sumneko/lua-langu
 * [Lua.workspace.library](https://github.com/sumneko/lua-language-server/blob/076dd3e5c4e03f9cef0c5757dfa09a010c0ec6bf/locale/en-us/setting.lua#L77-L78)
 
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".luarc.json", ".luacheckrc", ".stylua.toml", "stylua.toml", "selene.toml", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/server_configurations/svelte.lua
+++ b/lua/lspconfig/server_configurations/svelte.lua
@@ -7,11 +7,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { 'package.json', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'svelte' },
-    root_dir = util.root_pattern('package.json', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -25,7 +28,7 @@ npm install -g svelte-language-server
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern("package.json", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/svlangserver.lua
+++ b/lua/lspconfig/server_configurations/svlangserver.lua
@@ -22,13 +22,14 @@ local function report_hierarchy()
   vim.lsp.buf.execute_command(params)
 end
 
+local workspace_markers = { '.svlangserver', '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'verilog', 'systemverilog' },
-    root_dir = function(fname)
-      return util.root_pattern '.svlangserver'(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
     settings = {
       systemverilog = {
@@ -59,7 +60,7 @@ $ npm install -g @imc-trading/svlangserver
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern(".svlangserver", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/svls.lua
+++ b/lua/lspconfig/server_configurations/svls.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'svls' },
     filetypes = { 'verilog', 'systemverilog' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -18,7 +21,7 @@ Language server for verilog and SystemVerilog
  ```
     ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/taplo.lua
+++ b/lua/lspconfig/server_configurations/taplo.lua
@@ -1,12 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '*.toml', '.git' }
+
 return {
   default_config = {
     cmd = { 'taplo', 'lsp', 'stdio' },
     filetypes = { 'toml' },
-    root_dir = function(fname)
-      return util.root_pattern '*.toml'(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -21,7 +22,7 @@ cargo install --features lsp --locked taplo-cli
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("*.toml", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/tblgen_lsp_server.lua
+++ b/lua/lspconfig/server_configurations/tblgen_lsp_server.lua
@@ -1,12 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'tablegen_compile_commands.yml', '.git' }
+
 return {
   default_config = {
     cmd = { 'tblgen-lsp-server' },
     filetypes = { 'tablegen' },
-    root_dir = function(fname)
-      return util.root_pattern 'tablegen_compile_commands.yml'(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -16,5 +17,6 @@ The Language Server for the LLVM TableGen language
 
 `tblgen-lsp-server` can be installed at the llvm-project repository (https://github.com/llvm/llvm-project)
 ]],
+    workspace_markers = workspace_markers,
   },
 }

--- a/lua/lspconfig/server_configurations/teal_ls.lua
+++ b/lua/lspconfig/server_configurations/teal_ls.lua
@@ -1,5 +1,7 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'tlconfig.lua', '.git' }
+
 return {
   default_config = {
     cmd = {
@@ -8,10 +10,11 @@ return {
       -- "logging=on",
     },
     filetypes = {
+      workspace_markers = workspace_markers,
       'teal',
       -- "lua", -- Also works for lua, but you may get type errors that cannot be resolved within lua itself
     },
-    root_dir = util.root_pattern('tlconfig.lua', '.git'),
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -23,7 +26,7 @@ luarocks install --dev teal-language-server
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern("tlconfig.lua", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/terraform_lsp.lua
+++ b/lua/lspconfig/server_configurations/terraform_lsp.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.terraform', '.git' }
+
 return {
   default_config = {
     cmd = { 'terraform-lsp' },
     filetypes = { 'terraform', 'hcl' },
-    root_dir = util.root_pattern('.terraform', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -37,7 +40,7 @@ choice:
   - less stability (due to reliance on Terraform's own internal packages)
 ]],
     default_config = {
-      root_dir = [[root_pattern(".terraform", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/terraformls.lua
+++ b/lua/lspconfig/server_configurations/terraformls.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.terraform', '.git' }
+
 return {
   default_config = {
     cmd = { 'terraform-ls', 'serve' },
     filetypes = { 'terraform' },
-    root_dir = util.root_pattern('.terraform', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -36,7 +39,7 @@ choice:
   - less stability (due to reliance on Terraform's own internal packages)
 ]],
     default_config = {
-      root_dir = [[root_pattern(".terraform", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -63,13 +63,14 @@ end
 --   end)
 -- end
 
+local workspace_markers = { '.latexmkrc', '.git' }
+
 return {
   default_config = {
     cmd = { 'texlab' },
     filetypes = { 'tex', 'plaintex', 'bib' },
-    root_dir = function(fname)
-      return util.root_pattern '.latexmkrc'(fname) or util.find_git_ancestor(fname)
-    end,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
     settings = {
       texlab = {
@@ -122,5 +123,6 @@ A completion engine built from scratch for (La)TeX.
 
 See https://github.com/latex-lsp/texlab/blob/master/docs/options.md for configuration options.
 ]],
+    workspace_markers = workspace_markers,
   },
 }

--- a/lua/lspconfig/server_configurations/tflint.lua
+++ b/lua/lspconfig/server_configurations/tflint.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.terraform', '.git', '.tflint.hcl' }
+
 return {
   default_config = {
     cmd = { 'tflint', '--langserver' },
     filetypes = { 'terraform' },
-    root_dir = util.root_pattern('.terraform', '.git', '.tflint.hcl'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -14,7 +17,7 @@ A pluggable Terraform linter that can act as lsp server.
 Installation instructions can be found in https://github.com/terraform-linters/tflint#installation.
 ]],
     default_config = {
-      root_dir = [[root_pattern(".terraform", ".git", ".tflint.hcl")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/theme_check.lua
+++ b/lua/lspconfig/server_configurations/theme_check.lua
@@ -2,11 +2,13 @@ local util = require 'lspconfig.util'
 
 local bin_name = 'theme-check-language-server'
 
+local workspace_markers = { '.theme-check.yml' }
+
 return {
   default_config = {
     cmd = { bin_name, '--stdio' },
     filetypes = { 'liquid' },
-    root_dir = util.root_pattern '.theme-check.yml',
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     settings = {},
   },
   docs = {

--- a/lua/lspconfig/server_configurations/tilt_ls.lua
+++ b/lua/lspconfig/server_configurations/tilt_ls.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'tilt', 'lsp', 'start' },
     filetypes = { 'tiltfile' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -20,7 +23,7 @@ autocmd BufRead Tiltfile setf=tiltfile
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/tsserver.lua
+++ b/lua/lspconfig/server_configurations/tsserver.lua
@@ -1,3 +1,4 @@
+local workspace_markers = { 'tsconfig.json', 'package.json', 'jsconfig.json', '.git' }
 local util = require 'lspconfig.util'
 
 local bin_name = 'typescript-language-server'
@@ -11,6 +12,7 @@ return {
   default_config = {
     init_options = { hostInfo = 'neovim' },
     cmd = cmd,
+    workspace_markers = workspace_markers,
     filetypes = {
       'javascript',
       'javascriptreact',
@@ -19,10 +21,7 @@ return {
       'typescriptreact',
       'typescript.tsx',
     },
-    root_dir = function(fname)
-      return util.root_pattern 'tsconfig.json'(fname)
-        or util.root_pattern('package.json', 'jsconfig.json', '.git')(fname)
-    end,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -53,8 +52,5 @@ Here's an example that disables type checking in JavaScript files.
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/server_configurations/typeprof.lua
+++ b/lua/lspconfig/server_configurations/typeprof.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'Gemfile', '.git' }
+
 return {
   default_config = {
     cmd = { 'typeprof', '--lsp', '--stdio' },
     filetypes = { 'ruby', 'eruby' },
-    root_dir = util.root_pattern('Gemfile', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -13,7 +16,7 @@ https://github.com/ruby/typeprof
 `typeprof` is the built-in analysis and LSP tool for Ruby 3.1+.
     ]],
     default_config = {
-      root_dir = [[root_pattern("Gemfile", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/verible.lua
+++ b/lua/lspconfig/server_configurations/verible.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'verible-verilog-ls' },
     filetypes = { 'systemverilog', 'verilog' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/veridian.lua
+++ b/lua/lspconfig/server_configurations/veridian.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = { 'veridian' },
     filetypes = { 'systemverilog', 'verilog' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/vimls.lua
+++ b/lua/lspconfig/server_configurations/vimls.lua
@@ -7,11 +7,13 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'vim' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
     init_options = {
       isNeovim = true,

--- a/lua/lspconfig/server_configurations/visualforce_ls.lua
+++ b/lua/lspconfig/server_configurations/visualforce_ls.lua
@@ -1,9 +1,12 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'sfdx-project.json' }
+
 return {
   default_config = {
     filetypes = { 'visualforce' },
-    root_dir = util.root_pattern 'sfdx-project.json',
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     init_options = {
       embeddedLanguages = {
         css = true,
@@ -32,7 +35,7 @@ require'lspconfig'.visualforce_ls.setup {
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern('sfdx-project.json')]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/vls.lua
+++ b/lua/lspconfig/server_configurations/vls.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'v.mod', '.git' }
+
 return {
   default_config = {
     cmd = { 'vls' },
     filetypes = { 'vlang' },
-    root_dir = util.root_pattern('v.mod', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   docs = {
     description = [[
@@ -16,7 +19,7 @@ V language server.
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern("v.mod", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/volar.lua
+++ b/lua/lspconfig/server_configurations/volar.lua
@@ -52,11 +52,13 @@ local cmd = { bin_name, '--stdio' }
 if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
+local workspace_markers = { 'package.json' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'vue' },
-    root_dir = util.root_pattern 'package.json',
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     init_options = volar_init_options,
     on_new_config = function(new_config, new_root_dir)
       if

--- a/lua/lspconfig/server_configurations/vuels.lua
+++ b/lua/lspconfig/server_configurations/vuels.lua
@@ -7,11 +7,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name }
 end
 
+local workspace_markers = { 'package.json', 'vue.config.js' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'vue' },
-    root_dir = util.root_pattern('package.json', 'vue.config.js'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     init_options = {
       config = {
         vetur = {
@@ -62,7 +65,7 @@ npm install -g vls
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern("package.json", "vue.config.js")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/wgsl_analyzer.lua
+++ b/lua/lspconfig/server_configurations/wgsl_analyzer.lua
@@ -7,11 +7,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name }
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'wgsl' },
-    root_dir = util.root_pattern '.git',
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     settings = {},
   },
   docs = {
@@ -24,7 +27,7 @@ cargo install --git https://github.com/wgsl-analyzer/wgsl-analyzer wgsl_analyzer
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git"]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/yamlls.lua
+++ b/lua/lspconfig/server_configurations/yamlls.lua
@@ -7,11 +7,14 @@ if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
+local workspace_markers = { '.git' }
+
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'yaml', 'yaml.docker-compose' },
-    root_dir = util.find_git_ancestor,
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
     settings = {
       -- https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting
@@ -81,7 +84,7 @@ require('lspconfig').yamlls.setup {
 
 ]],
     default_config = {
-      root_dir = [[util.find_git_ancestor]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/zk.lua
+++ b/lua/lspconfig/server_configurations/zk.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { '.zk' }
+
 return {
   default_config = {
     cmd = { 'zk', 'lsp' },
     filetypes = { 'markdown' },
-    root_dir = util.root_pattern '.zk',
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
   },
   commands = {
     ZkIndex = {
@@ -42,7 +45,7 @@ https://github.com/mickael-menu/zk
 A plain text note-taking assistant
 ]],
     default_config = {
-      root_dir = [[root_pattern(".zk")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/server_configurations/zls.lua
+++ b/lua/lspconfig/server_configurations/zls.lua
@@ -1,10 +1,13 @@
 local util = require 'lspconfig.util'
 
+local workspace_markers = { 'zls.json', '.git' }
+
 return {
   default_config = {
     cmd = { 'zls' },
     filetypes = { 'zig', 'zir' },
-    root_dir = util.root_pattern('zls.json', '.git'),
+    workspace_markers = workspace_markers,
+    root_dir = util.root_pattern(unpack(workspace_markers)),
     single_file_support = true,
   },
   docs = {
@@ -14,7 +17,7 @@ https://github.com/zigtools/zls
 Zig LSP implementation + Zig Language Server
         ]],
     default_config = {
-      root_dir = [[util.root_pattern("zls.json", ".git")]],
+      workspace_markers = workspace_markers,
     },
   },
 }

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -340,7 +340,7 @@ function M.root_pattern(...)
   local function matcher(path)
     for _, pattern in ipairs(patterns) do
       for _, p in ipairs(vim.fn.glob(M.path.join(M.path.escape_wildcards(path), pattern), true, true)) do
-        if M.path.exists(p) then
+        if M.path.exists(p) and p ~= vim.env.HOME then
           return path
         end
       end

--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -132,7 +132,7 @@ local function make_lsp_sections()
               if description and type(description) ~= 'string' then
                 description = inspect(description)
               elseif not description and type(v) == 'function' then
-                description = 'see source file'
+                return
               end
               return string.format('- `%s` : \n```lua\n%s\n```', k, description or inspect(v))
             end),


### PR DESCRIPTION
allow re-using workspace detection patterns externally, e.g. `vim.lsp.start()`

_NOTE: `root_files` were only added to the `docs` table at the moment._

### example usage

```lua
local clangd_config = require("lspconfig.server_configurations.clangd").default_config
clangd_config.name = clangd_config.name or "clangd"

local root_files = require("lspconfig.server_configurations.clangd").docs.default_config.root_files
local root_dir = vim.fs.dirname(vim.fs.find(root_files, { upward = true })[1])

clangd_config.workspace_folders = { {
  name = root_dir,
  uri = vim.uri_from_fname(root_dir),
} }
vim.lsp.start(clangd_config, opts)
```
