### PR TITLE
change golangci-lint version to latest

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -2477,7 +2477,7 @@ Installation of binaries needed is done via
 
 ```
 go install github.com/nametake/golangci-lint-langserver@latest
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 ```
 
 


### PR DESCRIPTION
golangci-lint latest version now is v1.50.0