### PR TITLE
fix: cmd support vim.lsp.rpc.connect function

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -34,7 +34,11 @@ function configs.__newindex(t, config_name, config_def)
     local lsp_group = vim.api.nvim_create_augroup('lspconfig', { clear = false })
 
     validate {
-      cmd = { user_config.cmd, 't', true },
+      cmd = {
+        user_config.cmd,
+        { 'f', 't' },
+        true,
+      },
       root_dir = { user_config.root_dir, 'f', true },
       filetypes = { user_config.filetype, 't', true },
       on_new_config = { user_config.on_new_config, 'f', true },


### PR DESCRIPTION
when user what to set cmd to vim.rpc.connect, but it is a function

nvim has already support vim.lsp.rpc.connect, but it is a function , and in the default config, it can be just set as a function, so I think lsp-config should also handle such kind of action


