### PR TITLE
feat: add anakin language server (Python)

### DIFF
--- a/lua/lspconfig/server_configurations/anakin_language_server.lua
+++ b/lua/lspconfig/server_configurations/anakin_language_server.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'anakin-language-server' },
+    cmd = { 'anakinls' },
     filetypes = { 'python' },
     root_dir = function(fname)
       local root_files = {
@@ -15,12 +15,22 @@ return {
       return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
     end,
     single_file_support = true,
+    settings = {
+      anakinls = {
+        pyflakes_errors = { 'UndefinedName', 'UndefinedLocal' },
+      },
+    },
   },
   docs = {
     description = [[
 https://pypi.org/project/anakin-language-server/
 
 `anakin-language-server` is yet another Jedi Python language server.
+
+Available options:
+
+* Initialization: https://github.com/muffinmad/anakin-language-server#initialization-option
+* Configuration: https://github.com/muffinmad/anakin-language-server#configuration-options
     ]],
   },
 }

--- a/lua/lspconfig/server_configurations/anakin_language_server.lua
+++ b/lua/lspconfig/server_configurations/anakin_language_server.lua
@@ -1,0 +1,26 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'anakin-language-server' },
+    filetypes = { 'python' },
+    root_dir = function(fname)
+      local root_files = {
+        'pyproject.toml',
+        'setup.py',
+        'setup.cfg',
+        'requirements.txt',
+        'Pipfile',
+      }
+      return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
+    end,
+    single_file_support = true,
+  },
+  docs = {
+    description = [[
+https://pypi.org/project/anakin-language-server/
+
+`anakin-language-server` is yet another Jedi Python language server.
+    ]],
+  },
+}

--- a/lua/lspconfig/server_configurations/anakin_language_server.lua
+++ b/lua/lspconfig/server_configurations/anakin_language_server.lua
@@ -17,7 +17,51 @@ return {
     single_file_support = true,
     settings = {
       anakinls = {
-        pyflakes_errors = { 'UndefinedName', 'UndefinedLocal' },
+        pyflakes_errors = {
+          -- https://github.com/PyCQA/pyflakes/blob/master/pyflakes/messages.py
+
+          -- TODO: Is this a good idea...?
+          
+          'ImportStarNotPermitted',
+
+          'UndefinedExport',
+          'UndefinedLocal',
+          'UndefinedName',
+
+          'DuplicateArgument',
+          'MultiValueRepeatedKeyLiteral',
+          'MultiValueRepeatedKeyVariable',
+
+          'FutureFeatureNotDefined',
+          'LateFutureImport',
+
+          'ReturnOutsideFunction',
+          'YieldOutsideFunction',
+          'ContinueOutsideLoop',
+          'BreakOutsideLoop',
+
+          'TwoStarredExpressions',
+          'TooManyExpressionsInStarredAssignment',
+
+          'ForwardAnnotationSyntaxError',
+          'RaiseNotImplemented',
+
+          'StringDotFormatExtraPositionalArguments',
+          'StringDotFormatExtraNamedArguments',
+          'StringDotFormatMissingArgument',
+          'StringDotFormatMixingAutomatic',
+          'StringDotFormatInvalidFormat',
+
+          'PercentFormatInvalidFormat',
+          'PercentFormatMixedPositionalAndNamed',
+          'PercentFormatUnsupportedFormat',
+          'PercentFormatPositionalCountMismatch',
+          'PercentFormatExtraNamedArguments',
+          'PercentFormatMissingArgument',
+          'PercentFormatExpectedMapping',
+          'PercentFormatExpectedSequence',
+          'PercentFormatStarRequiresSequence',
+        },
       },
     },
   },

--- a/lua/lspconfig/server_configurations/anakin_language_server.lua
+++ b/lua/lspconfig/server_configurations/anakin_language_server.lua
@@ -18,10 +18,8 @@ return {
     settings = {
       anakinls = {
         pyflakes_errors = {
-          -- https://github.com/PyCQA/pyflakes/blob/master/pyflakes/messages.py
+          -- Full list: https://github.com/PyCQA/pyflakes/blob/master/pyflakes/messages.py
 
-          -- TODO: Is this a good idea...?
-          
           'ImportStarNotPermitted',
 
           'UndefinedExport',


### PR DESCRIPTION
Adds support for [Anakin language server](https://pypi.org/project/anakin-language-server/), another (minimal but useful and reasonably fast) language server for Python.

I tried to run the command from the contributing doc:

```bash
nvim -R -Es +'set rtp+=$PWD' +'luafile scripts/docgen.lua'
```

It ran without errors, but I didn't see any section for the new language server config in the generated file. I'm not sure if I did something wrong.

The language server config does seem to work fine, I've been using it all day.