### PR TITLE
Update dead link in `texlab` description

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -7112,7 +7112,7 @@ https://github.com/latex-lsp/texlab
 
 A completion engine built from scratch for (La)TeX.
 
-See https://github.com/latex-lsp/texlab/blob/master/docs/options.md for configuration options.
+See https://github.com/latex-lsp/texlab/wiki/Configuration for configuration options.
 
 
 


### PR DESCRIPTION
Found a dead link in the `texlab` description. I've taken a look at the `texlab` repository, and corrected with the link pointing to the information I think the other link was pointing to.