### PR TITLE
Fix dead link in `texlab` description

### DIFF
--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -120,7 +120,7 @@ https://github.com/latex-lsp/texlab
 
 A completion engine built from scratch for (La)TeX.
 
-See https://github.com/latex-lsp/texlab/blob/master/docs/options.md for configuration options.
+See https://github.com/latex-lsp/texlab/wiki/Configuration for configuration options.
 ]],
   },
 }


### PR DESCRIPTION
`texlab` changed where they store their documentation. Since https://github.com/latex-lsp/texlab/commit/d03e350679dfdbbd0d25e3c28131c4b2677789cf they store that information in their GitHub wiki.