### PR TITLE
fix: use `v ls` instead of `vls`

### DIFF
--- a/lua/lspconfig/server_configurations/vls.lua
+++ b/lua/lspconfig/server_configurations/vls.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'vls' },
+    cmd = { 'v', 'ls' },
     filetypes = { 'vlang' },
     root_dir = util.root_pattern('v.mod', '.git'),
   },


### PR DESCRIPTION
`v ls` tool is used for installing, updating, and launching VLS (V Language Server).

Reference: https://github.com/vlang/v/releases/tag/0.3.1