### PR TITLE
fix(eslint): support flat config

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -47,6 +47,7 @@ local root_file = {
   '.eslintrc.yaml',
   '.eslintrc.yml',
   '.eslintrc.json',
+  'eslint.config.js',
   'package.json',
 }
 


### PR DESCRIPTION
Eslint have a new config scheme called flat config. Will become the only supported config in v9. https://eslint.org/blog/2022/08/new-config-system-part-2/#the-new-config-file%3A-eslint.config.js