### PR TITLE
fix(eslint): root dir not found if using package.json config

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -48,24 +48,18 @@ local root_file = {
   '.eslintrc.yml',
   '.eslintrc.json',
   'eslint.config.js',
-  'package.json',
 }
 
 local root_with_package = util.find_package_json_ancestor(vim.fn.expand '%:p:h')
 
 if root_with_package then
-  local must_remove = false
+  -- only add package.json if it contains eslintConfig field
   local path_sep = is_windows and '\\' or '/'
   for line in io.lines(root_with_package .. path_sep .. 'package.json') do
     if line:find 'eslintConfig' then
-      must_remove = false
-    else
-      must_remove = true
+      table.insert(root_file, 'package.json')
+      break
     end
-  end
-
-  if must_remove then
-    table.remove(root_file, #root_file)
   end
 end
 


### PR DESCRIPTION
First time contributor here 🙋‍♂️

ESLint server would not find root directory when config is set in `package.json`. I created a couple of examples here:
https://github.com/gomezhyuuga/nvim-lspconfig-test-eslint

`project-eslint-packagejson` should start properly the ESLint server but it shows this error:

<img width="1049" alt="image" src="https://user-images.githubusercontent.com/1633839/200737207-e0bf8830-0986-4cd3-a634-133086de796e.png">


Seems like this was introduced in #2208. (latest working version: `3592f769f2d6b07ce3083744cd0a13442f5d4f43`) 


### Lint

```
make lint
...

Total: 0 warnings / 0 errors in 189 files

Running selene
selene --display-style=quiet .
Results:
0 errors
0 warnings
0 parse errors

Running stylua
stylua --check .

```