### PR TITLE
fix(rome): use lsp-proxy cmd

### DIFF
--- a/lua/lspconfig/server_configurations/rome.lua
+++ b/lua/lspconfig/server_configurations/rome.lua
@@ -1,10 +1,10 @@
 local util = require 'lspconfig.util'
 
 local bin_name = 'rome'
-local cmd = { bin_name, 'lsp' }
+local cmd = { bin_name, 'lsp-proxy' }
 
 if vim.fn.has 'win32' == 1 then
-  cmd = { 'cmd.exe', '/C', bin_name, 'lsp' }
+  cmd = { 'cmd.exe', '/C', bin_name, 'lsp-proxy' }
 end
 
 return {


### PR DESCRIPTION
Command (see https://docs.rome.tools/cli/#rome-lspproxy) was introduced for better stdin support in rome v10.0.0.

Original PR introducing this change: https://github.com/rome/tools/pull/3442

This is a breaking PR and requires users to update rome to version v10.0.0.