### PR TITLE
Try to get sourcery auth token from config file

### DIFF
--- a/lua/lspconfig/server_configurations/sourcery.lua
+++ b/lua/lspconfig/server_configurations/sourcery.lua
@@ -9,6 +9,22 @@ local root_files = {
   'pyrightconfig.json',
 }
 
+local get_token_from_auth_file = function()
+  local config_home = vim.fn.getenv 'XDG_CONFIG_HOME' or vim.fn.expand '~/.config'
+  local auth_file_path = config_home .. '/sourcery/auth.yaml'
+
+  if vim.fn.filereadable(auth_file_path) == 1 then
+    local content = vim.fn.readfile(auth_file_path)
+
+    for _, line in ipairs(content) do
+      local token = line:match 'sourcery_token: (.+)'
+      if token then
+        return token
+      end
+    end
+  end
+end
+
 return {
   default_config = {
     cmd = { 'sourcery', 'lsp' },
@@ -24,6 +40,10 @@ return {
     single_file_support = true,
   },
   on_new_config = function(new_config, _)
+    local possibly_token = get_token_from_auth_file()
+    if possibly_token then
+      new_config.init_options.token = possibly_token
+    end
     if not new_config.init_options.token then
       local notify = vim.notify_once or vim.notify
       notify('[lspconfig] The authentication token must be provided in config.init_options', vim.log.levels.ERROR)
@@ -54,6 +74,8 @@ require'lspconfig'.sourcery.setup {
     },
 }
 ```
+
+Alternatively, you can login to sourcery by running `sourcery login` with sourcery-cli and your token will be grabbed from sourcery config file.
 ]],
   },
 }

--- a/lua/lspconfig/server_configurations/sourcery.lua
+++ b/lua/lspconfig/server_configurations/sourcery.lua
@@ -10,9 +10,12 @@ local root_files = {
 }
 
 local get_token_from_auth_file = function()
-  local config_home = vim.fn.getenv 'XDG_CONFIG_HOME' or vim.fn.expand '~/.config'
-  local auth_file_path = config_home .. '/sourcery/auth.yaml'
+  local is_windows = vim.fn.has 'win32' == 1
+  local path_sep = is_windows and '\\' or '/'
 
+  local config_home = is_windows and vim.fn.getenv 'APPDATA'
+    or (vim.fn.getenv 'XDG_CONFIG_HOME' or vim.fn.expand '~/.config')
+  local auth_file_path = config_home .. path_sep .. 'sourcery' .. path_sep .. 'auth.yaml'
   if vim.fn.filereadable(auth_file_path) == 1 then
     local content = vim.fn.readfile(auth_file_path)
 


### PR DESCRIPTION
Sourcery-cli creates `auth.yaml` file to users config folder, which contains the login token. 

This PR adds check for login token in auth file. Logic shouldn't be breaking, since we're getting the token from file only if it's not defined already in lsp config.