### PR TITLE
feat: include cmd option for arduino_language_server

### DIFF
--- a/lua/lspconfig/server_configurations/arduino_language_server.lua
+++ b/lua/lspconfig/server_configurations/arduino_language_server.lua
@@ -1,12 +1,15 @@
 local util = require 'lspconfig.util'
 
 return {
-  default_config = {
-    filetypes = { 'arduino' },
-    root_dir = util.root_pattern '*.ino',
-  },
-  docs = {
-    description = [[
+	default_config = {
+		filetypes = { 'arduino' },
+		root_dir = util.root_pattern '*.ino',
+		cmd = {
+			"arduino-language-server",
+		}
+	},
+	docs = {
+		description = [[
 https://github.com/arduino/arduino-language-server
 
 Language server for Arduino
@@ -26,38 +29,56 @@ instructions](https://arduino.github.io/arduino-cli/latest/getting-started/#crea
 for generating a configuration file if you haven't done so already, and make
 sure you [install any relevant platforms
 libraries](https://arduino.github.io/arduino-cli/latest/getting-started/#install-the-core-for-your-board).
-Make sure to save the full path to the created `arduino-cli.yaml` file for later.
 
 The language server also requires `clangd` to be installed. Follow [these
 installation instructions](https://clangd.llvm.org/installation) for your
 platform.
 
-Next, you will need to decide which FQBN to use.
-To identify the available FQBNs for boards you currently have connected, you may use the `arduino-cli` command, like so:
+If you don't have a sketch yet create one.
+
+```sh
+$ arduino-cli sketch new test
+$ cd  test
+```
+
+You will need a `sketch.json` file in order for the language server to understand your project. It will also save you passing options to `arduino-cli` each time you compile or upload a file. You can generate the file like using the following commands.
+
+
+First gather some information about your board. Make sure your board is connected and run the following:
 
 ```sh
 $ arduino-cli board list
 Port         Protocol Type              Board Name  FQBN            Core
 /dev/ttyACM0 serial   Serial Port (USB) Arduino Uno arduino:avr:uno arduino:avr
-                                                    ^^^^^^^^^^^^^^^
 ```
 
-After all dependencies are installed you'll need to set the command for the
-language server in your setup:
+Then generate the file:
 
-```lua
-require'lspconfig'.arduino_language_server.setup {
-  cmd = {
-    "arduino-language-server",
-    "-cli-config", "/path/to/arduino-cli.yaml",
-    "-fqbn", "arduino:avr:uno",
-    "-cli", "arduino-cli",
-    "-clangd", "clangd"
+```sh
+arduino-cli board attach -p /dev/ttyACM0 test.ino
+```
+
+The resulting file should like like this:
+
+```json
+{
+  "cpu": {
+    "fqbn": "arduino:avr:uno",
+    "name": "Arduino Uno",
+    "port": "serial:///dev/ttyACM0"
   }
 }
 ```
 
+Your folder structure should look like this:
+
+```
+.
+├── test.ino
+└── sketch.json
+```
+
 For further instruction about configuration options, run `arduino-language-server --help`.
 ]],
-  },
+	},
 }

--- a/lua/lspconfig/server_configurations/arduino_language_server.lua
+++ b/lua/lspconfig/server_configurations/arduino_language_server.lua
@@ -1,15 +1,15 @@
 local util = require 'lspconfig.util'
 
 return {
-	default_config = {
-		filetypes = { 'arduino' },
-		root_dir = util.root_pattern '*.ino',
-		cmd = {
-			"arduino-language-server",
-		}
-	},
-	docs = {
-		description = [[
+  default_config = {
+    filetypes = { 'arduino' },
+    root_dir = util.root_pattern '*.ino',
+    cmd = {
+      'arduino-language-server',
+    },
+  },
+  docs = {
+    description = [[
 https://github.com/arduino/arduino-language-server
 
 Language server for Arduino
@@ -80,5 +80,5 @@ Your folder structure should look like this:
 
 For further instruction about configuration options, run `arduino-language-server --help`.
 ]],
-	},
+  },
 }


### PR DESCRIPTION
Currently the `arduino_language_server` doesn't run without passing custom configuration options to `setup`.

If an Arduino project is contains `sketch.json` file all but the `cmd` option can be omitted. As this stays the same it would be nice to move it into this repository. This also has the advantage of keeping project specific settings inside the project and not in the nvim config.

I've done the above and updated the docs with a minimal guide to setting up an Arduino project.

This is working on my machine `require("lspconfig").arduino_language_server.setup()` but it would be good if others could test it.

