### PR TITLE
fix(lua-lsp): Append 'lua/' to root_patern if the pattern is under lua

### DIFF
--- a/lua/lspconfig/server_configurations/sumneko_lua.lua
+++ b/lua/lspconfig/server_configurations/sumneko_lua.lua
@@ -22,9 +22,13 @@ return {
     cmd = cmd,
     filetypes = { 'lua' },
     root_dir = function(fname)
-      local root = util.root_pattern(unpack(root_files))(fname) or util.root_pattern 'lua/'(fname)
+      local root = util.root_pattern(unpack(root_files))(fname)
       if root and root ~= vim.env.HOME then
         return root
+      end
+      root = util.root_pattern 'lua/'(fname)
+      if root then
+        return root .. '/lua/'
       end
       return util.find_git_ancestor(fname)
     end,


### PR DESCRIPTION
Currently when a lua file is under `..path/lua/..path` its detected by `root_pattern 'lua'` but instead of returning the expected path `..path/lua` it returns the parent path `..path/lua`

This PR fixes that 