### PR TITLE
docs(sourcery): put setup inside code block

### DIFF
--- a/lua/lspconfig/server_configurations/sourcery.lua
+++ b/lua/lspconfig/server_configurations/sourcery.lua
@@ -35,21 +35,25 @@ https://github.com/sourcery-ai/sourcery
 
 Refactor Python instantly using the power of AI.
 
-It requires the initializationOptions param to be populated as shown below and will respond with the list of ServerCapabilities that it supports.
+It requires the init_options param to be populated as shown below and will respond with the list of ServerCapabilities that it supports:
 
-init_options = {
-    --- The Sourcery token for authenticating the user.
-    --- This is retrieved from the Sourcery website and must be
-    --- provided by each user. The extension must provide a
-    --- configuration option for the user to provide this value.
-    token = <YOUR_TOKEN>
+```lua
+require'lspconfig'.sourcery.setup {
+    init_options = {
+        --- The Sourcery token for authenticating the user.
+        --- This is retrieved from the Sourcery website and must be
+        --- provided by each user. The extension must provide a
+        --- configuration option for the user to provide this value.
+        token = <YOUR_TOKEN>,
 
-    --- The extension's name and version as defined by the extension.
-    extension_version = 'vim.lsp'
+        --- The extension's name and version as defined by the extension.
+        extension_version = 'vim.lsp',
 
-    --- The editor's name and version as defined by the editor.
-    editor_version = 'vim'
+        --- The editor's name and version as defined by the editor.
+        editor_version = 'vim',
+    },
 }
+```
 ]],
   },
 }


### PR DESCRIPTION
The current documentation of `sourcery` is incorrectly formatted due to configurations not being inside code block:

![图片](https://user-images.githubusercontent.com/95505675/203834402-319bc325-fc76-497e-a97f-fdbc59b5ccba.png)