### PR TITLE
fix: remove unused call to util.on_setup()

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -56,10 +56,6 @@ function configs.__newindex(t, config_name, config_def)
 
     local config = tbl_deep_extend('keep', user_config, default_config)
 
-    if util.on_setup then
-      pcall(util.on_setup, config, user_config)
-    end
-
     if config.autostart == true then
       local event
       local pattern

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -16,9 +16,6 @@ M.default_config = {
   capabilities = lsp.protocol.make_client_capabilities(),
 }
 
--- global on_setup hook
-M.on_setup = nil
-
 function M.bufname_valid(bufname)
   if not bufname then
     return false


### PR DESCRIPTION
This function is set to nil in lspconfig/util.lua so there is no need to check if it exists and call it when it exists since this is *never* the case.

Signed-off-by: Radu Alexe <alexeradu2007@gmail.com>