### PR TITLE
remove breaking warning

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -12,7 +12,6 @@ if vim.fn.has 'nvim-0.7' ~= 1 then
     version_info.minor,
     version_info.patch
   )
-  vim.notify_once(warning_str)
   return
 end
 


### PR DESCRIPTION
For me, for whatever reason, this particular line of code breaks the plugin.

`Error detected while processing /home/albertlopez/.local/share/nvim/site/pack/packer/start/nvim-lspconfig/plugin/lspconfig.lua: 
E5113: Error while calling lua chunk:
...te/pack/packer/start/nvim-lspconfig/plugin/lspconfig.lua:15: 
attempt to call field 'notify_once' (a n il value) stack traceback:
...te/pack/packer/start/nvim-lspconfig/plugin/lspconfig.lua:15: in main chunk`