### PR TITLE
feat: add eruby to emmet_ls

### DIFF
--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -1882,7 +1882,7 @@ require'lspconfig'.emmet_ls.setup{}
   ```
   - `filetypes` : 
   ```lua
-  { "html", "typescriptreact", "javascriptreact", "css", "sass", "scss", "less" }
+  { "html", "typescriptreact", "javascriptreact", "css", "sass", "scss", "less", "eruby" }
   ```
   - `root_dir` : 
   ```lua

--- a/lua/lspconfig/server_configurations/emmet_ls.lua
+++ b/lua/lspconfig/server_configurations/emmet_ls.lua
@@ -10,7 +10,7 @@ end
 return {
   default_config = {
     cmd = cmd,
-    filetypes = { 'html', 'typescriptreact', 'javascriptreact', 'css', 'sass', 'scss', 'less' },
+    filetypes = { 'html', 'typescriptreact', 'javascriptreact', 'css', 'sass', 'scss', 'less', 'eruby' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
   },


### PR DESCRIPTION
Adds `eruby` support to the `emmet_ls` server configuration so that `*.html.erb` can get completions.