### PR TITLE
feat: add 'starlark-rust' LSP for starlark and BUILD files

### DIFF
--- a/lua/lspconfig/server_configurations/starlark-rust.lua
+++ b/lua/lspconfig/server_configurations/starlark-rust.lua
@@ -1,0 +1,20 @@
+local util = require 'lspconfig/util'
+
+return {
+  default_config = {
+    cmd = { 'starlark', '--lsp' },
+    filetypes = { 'star', 'bzl', 'BUILD.bazel' },
+    root_dir = util.find_git_ancestor,
+  },
+  docs = {
+    description = [[
+            https://github.com/facebookexperimental/starlark-rust/
+            The LSP part of `starlark-rust` is not currently documented,
+            but the implementation works well for linting.
+            This gives valuable warnings for potential issues in the code,
+            but does not support refactorings.
+
+            It can be installed with cargo: https://crates.io/crates/starlark
+        ]],
+  },
+}

--- a/lua/lspconfig/server_configurations/starlark-rust.lua
+++ b/lua/lspconfig/server_configurations/starlark-rust.lua
@@ -9,7 +9,7 @@ return {
   docs = {
     description = [[
             https://github.com/facebookexperimental/starlark-rust/
-            The LSP part of `starlark-rust` is not currently documented,
+The LSP part of `starlark-rust` is not currently documented,
             but the implementation works well for linting.
             This gives valuable warnings for potential issues in the code,
             but does not support refactorings.

--- a/lua/lspconfig/server_configurations/starlark-rust.lua
+++ b/lua/lspconfig/server_configurations/starlark-rust.lua
@@ -10,7 +10,7 @@ return {
     description = [[
 https://github.com/facebookexperimental/starlark-rust/
 The LSP part of `starlark-rust` is not currently documented,
-            but the implementation works well for linting.
+ but the implementation works well for linting.
             This gives valuable warnings for potential issues in the code,
             but does not support refactorings.
 

--- a/lua/lspconfig/server_configurations/starlark-rust.lua
+++ b/lua/lspconfig/server_configurations/starlark-rust.lua
@@ -14,7 +14,7 @@ The LSP part of `starlark-rust` is not currently documented,
 This gives valuable warnings for potential issues in the code,
             but does not support refactorings.
 
-            It can be installed with cargo: https://crates.io/crates/starlark
+It can be installed with cargo: https://crates.io/crates/starlark
         ]],
   },
 }

--- a/lua/lspconfig/server_configurations/starlark-rust.lua
+++ b/lua/lspconfig/server_configurations/starlark-rust.lua
@@ -8,7 +8,7 @@ return {
   },
   docs = {
     description = [[
-            https://github.com/facebookexperimental/starlark-rust/
+https://github.com/facebookexperimental/starlark-rust/
 The LSP part of `starlark-rust` is not currently documented,
             but the implementation works well for linting.
             This gives valuable warnings for potential issues in the code,

--- a/lua/lspconfig/server_configurations/starlark-rust.lua
+++ b/lua/lspconfig/server_configurations/starlark-rust.lua
@@ -12,7 +12,7 @@ https://github.com/facebookexperimental/starlark-rust/
 The LSP part of `starlark-rust` is not currently documented,
  but the implementation works well for linting.
 This gives valuable warnings for potential issues in the code,
-            but does not support refactorings.
+but does not support refactorings.
 
 It can be installed with cargo: https://crates.io/crates/starlark
 ]],

--- a/lua/lspconfig/server_configurations/starlark-rust.lua
+++ b/lua/lspconfig/server_configurations/starlark-rust.lua
@@ -15,6 +15,6 @@ This gives valuable warnings for potential issues in the code,
             but does not support refactorings.
 
 It can be installed with cargo: https://crates.io/crates/starlark
-        ]],
+]],
   },
 }

--- a/lua/lspconfig/server_configurations/starlark-rust.lua
+++ b/lua/lspconfig/server_configurations/starlark-rust.lua
@@ -11,7 +11,7 @@ return {
 https://github.com/facebookexperimental/starlark-rust/
 The LSP part of `starlark-rust` is not currently documented,
  but the implementation works well for linting.
-            This gives valuable warnings for potential issues in the code,
+This gives valuable warnings for potential issues in the code,
             but does not support refactorings.
 
             It can be installed with cargo: https://crates.io/crates/starlark


### PR DESCRIPTION
This uses the github name and not the cargo name as it is not so official and may be replaced by a better LSP. So the name is not already taken by this linter.