### PR TITLE
Revert "fix(lsp): don't spawn new lsp client if already persent (#2287)"

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -250,14 +250,6 @@ function M.server_per_root_dir_manager(make_config)
     -- Check if we have a client already or start and store it.
     if not client_id then
       local new_config = make_config(root_dir)
-      if next(clients) ~= nil then
-        for _, id in pairs(clients) do
-          local client = lsp.get_client_by_id(id)
-          if client.name == new_config.name then
-            return id
-          end
-        end
-      end
       -- do nothing if the client is not enabled
       if new_config.enabled == false then
         return


### PR DESCRIPTION
This reverts commit ac132be91a6a8170788e7139964288e673b31c5e.

This commit is causing lsp clients to not start when opening up a new project.