### PR TITLE
Enable `terraform-ls` for `.tf` files

### DIFF
--- a/lua/lspconfig/server_configurations/terraformls.lua
+++ b/lua/lspconfig/server_configurations/terraformls.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'terraform-ls', 'serve' },
-    filetypes = { 'terraform' },
+    filetypes = { 'terraform', 'tf' },
     root_dir = util.root_pattern('.terraform', '.git'),
   },
   docs = {


### PR DESCRIPTION
The `.tf` extension seems to be what Hashicorp suggest in most of their tutorials and documentation.