### PR TITLE
fix: check client is available and get client id from cache

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -250,15 +250,16 @@ function M.server_per_root_dir_manager(make_config)
     -- Check if we have a client already or start and store it.
     if not client_id then
       local new_config = make_config(root_dir)
-      if clients[1] then
-        local client = lsp.get_client_by_id(clients[1])
-        if client.name == new_config.name then
+      if vim.tbl_count(clients) == 1 then
+        local id = vim.tbl_values(clients)[1]
+        local client = lsp.get_client_by_id(id)
+        if client and client.name == new_config.name then
           local params = lsp.util.make_workspace_params(
             { { uri = vim.uri_from_fname(root_dir), name = root_dir } },
             { {} }
           )
           table.insert(client.workspace_folders, params.event.added[1])
-          return clients[1]
+          return id
         end
       end
       -- do nothing if the client is not enabled


### PR DESCRIPTION
Problem: the clients cache the client id with root dir.
Solution: get the client id from value and valid the client.

Fix #2302 