### PR TITLE
feat: support multiple workspaceFolders and show correct root in Lspinfo

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -111,18 +111,13 @@ local function make_client_info(client, fname)
   local uv = vim.loop
   local is_windows = uv.os_uname().version:match 'Windows'
   fname = uv.fs_realpath(fname)
-  fname = is_windows and fname:lower() or fname
   local sep = is_windows and '\\' or '/'
   local fname_parts = vim.split(fname, sep, { trimempty = true })
-  --remove the host name, don't include them before compare
-  fname_parts = { unpack(fname_parts, 3) }
   if workspace_folders then
     for _, schema in pairs(workspace_folders) do
       local matched = true
       local root = uv.fs_realpath(schema.name)
-      root = is_windows and root:lower() or root
       local root_parts = vim.split(root, sep, { trimempty = true })
-      root_parts = { unpack(root_parts, 3) }
 
       for i = 1, #root_parts do
         if root_parts[i] ~= fname_parts[i] then

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -1,4 +1,4 @@
-local api, fn = vim.api, vim.fn
+local api, fn, lsp = vim.api, vim.fn, vim.lsp
 local windows = require 'lspconfig.ui.windows'
 local util = require 'lspconfig.util'
 
@@ -103,14 +103,21 @@ local function make_config_info(config, bufnr)
   return lines
 end
 
-local function make_client_info(client)
+local function make_client_info(client, fname)
   local client_info = {}
 
   client_info.cmd = cmd_type[type(client.config.cmd)](client.config)
   local workspace_folders = fn.has 'nvim-0.9' == 1 and client.workspace_folders or client.workspaceFolders
+  local tail_fname = fn.fnamemodify(fname, ':t')
   if workspace_folders then
-    client_info.root_dir = workspace_folders[1].name
-  else
+    for _, schema in pairs(workspace_folders) do
+      local result = vim.fs.find(tail_fname, { path = schema.name, type = 'file' })[1]
+      if result and result == fname then
+        client_info.root_dir = schema.name
+      end
+    end
+  end
+  if not client_info.root_dir then
     client_info.root_dir = 'Running in single file mode.'
   end
   client_info.filetypes = table.concat(client.config.filetypes or {}, ', ')
@@ -123,8 +130,6 @@ local function make_client_info(client)
       .. client.name
       .. ' (id: '
       .. tostring(client.id)
-      .. ', pid: '
-      .. tostring(client.rpc.pid)
       .. ', bufnr: ['
       .. client_info.attached_buffers_list
       .. '])',
@@ -150,10 +155,11 @@ end
 return function()
   -- These options need to be cached before switching to the floating
   -- buffer.
-  local buf_clients = vim.lsp.buf_get_clients()
-  local clients = vim.lsp.get_active_clients()
-  local buffer_filetype = vim.bo.filetype
   local original_bufnr = api.nvim_get_current_buf()
+  local buf_clients = lsp.get_active_clients { bufnr = original_bufnr }
+  local clients = lsp.get_active_clients()
+  local buffer_filetype = vim.bo.filetype
+  local fname = api.nvim_buf_get_name(original_bufnr)
 
   windows.default_options.wrap = true
   windows.default_options.breakindent = true
@@ -194,7 +200,7 @@ return function()
 
   vim.list_extend(buf_lines, buffer_clients_header)
   for _, client in pairs(buf_clients) do
-    local client_info = make_client_info(client)
+    local client_info = make_client_info(client, fname)
     vim.list_extend(buf_lines, client_info)
   end
 
@@ -206,7 +212,7 @@ return function()
     vim.list_extend(buf_lines, other_active_section_header)
   end
   for _, client in pairs(other_active_clients) do
-    local client_info = make_client_info(client)
+    local client_info = make_client_info(client, fname)
     vim.list_extend(buf_lines, client_info)
   end
 

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -108,15 +108,36 @@ local function make_client_info(client, fname)
 
   client_info.cmd = cmd_type[type(client.config.cmd)](client.config)
   local workspace_folders = fn.has 'nvim-0.9' == 1 and client.workspace_folders or client.workspaceFolders
-  local tail_fname = fn.fnamemodify(fname, ':t')
+  local uv = vim.loop
+  local is_windows = uv.os_uname().version:match 'Windows'
+  fname = uv.fs_realpath(fname)
+  fname = is_windows and fname:lower() or fname
+  local sep = is_windows and '\\' or '/'
+  local fname_parts = vim.split(fname, sep, { trimempty = true })
+  --remove the host name, don't include them before compare
+  fname_parts = { unpack(fname_parts, 3) }
+  local matched = true
   if workspace_folders then
     for _, schema in pairs(workspace_folders) do
-      local result = vim.fs.find(tail_fname, { path = schema.name, type = 'file' })[1]
-      if result and vim.loop.fs_realpath(result) == vim.loop.fs_realpath(fname) then
+      local root = uv.fs_realpath(schema.name)
+      root = is_windows and root:lower() or root
+      local root_parts = vim.split(root, sep, { trimempty = true })
+      root_parts = { unpack(root_parts, 3) }
+
+      for i = 1, #root_parts do
+        if root_parts[i] ~= fname_parts[i] then
+          matched = false
+          break
+        end
+      end
+
+      if matched then
         client_info.root_dir = schema.name
+        break
       end
     end
   end
+
   if not client_info.root_dir then
     client_info.root_dir = 'Running in single file mode.'
   end

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -112,7 +112,7 @@ local function make_client_info(client, fname)
   if workspace_folders then
     for _, schema in pairs(workspace_folders) do
       local result = vim.fs.find(tail_fname, { path = schema.name, type = 'file' })[1]
-      if result and result == fname then
+      if result and vim.loop.fs_realpath(result) == vim.loop.fs_realpath(fname) then
         client_info.root_dir = schema.name
       end
     end

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -116,9 +116,9 @@ local function make_client_info(client, fname)
   local fname_parts = vim.split(fname, sep, { trimempty = true })
   --remove the host name, don't include them before compare
   fname_parts = { unpack(fname_parts, 3) }
-  local matched = true
   if workspace_folders then
     for _, schema in pairs(workspace_folders) do
+      local matched = true
       local root = uv.fs_realpath(schema.name)
       root = is_windows and root:lower() or root
       local root_parts = vim.split(root, sep, { trimempty = true })

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -253,6 +253,8 @@ function M.server_per_root_dir_manager(make_config)
         id = vim.tbl_values(clients)[1]
       elseif vim.tbl_count(single_file_clients) == 1 then
         id = vim.tbl_values(single_file_clients)[1]
+      else
+        return
       end
       local client = lsp.get_client_by_id(id)
       if client and client.name == conf.name then


### PR DESCRIPTION
if client already in `single_file_clients`, when open a new file in project . we should check the client in `single_file_clients`. then don't spawn a new server instance.  with `single_file` mode the client not initialize the `workspace_folders` field , so 
initialize this field.  then insert the project to `workspace_folders ` . 

now we don't spawn multiple clients , just use one client instance with muliple workspace folders. check the current buffer file in the project or not. and show the correct project dir in `LspInfo`, 

remove pid in `LspInfo` . the `client.rpc.pid` had removed