### PR TITLE
fix(gdscript): support get the port from env variable

### DIFF
--- a/lua/lspconfig/server_configurations/gdscript.lua
+++ b/lua/lspconfig/server_configurations/gdscript.lua
@@ -1,6 +1,6 @@
 local util = require 'lspconfig.util'
 
-local port = os.getenv('GDScript_Port') or '6008'
+local port = os.getenv 'GDScript_Port' or '6008'
 local cmd = { 'nc', 'localhost', port }
 
 if vim.fn.has 'nvim-0.8' == 1 then

--- a/lua/lspconfig/server_configurations/gdscript.lua
+++ b/lua/lspconfig/server_configurations/gdscript.lua
@@ -1,9 +1,10 @@
 local util = require 'lspconfig.util'
 
-local cmd = { 'nc', 'localhost', '6008' }
+local port = os.getenv('GDScript_Port') or '6008'
+local cmd = { 'nc', 'localhost', port }
 
 if vim.fn.has 'nvim-0.8' == 1 then
-  cmd = vim.lsp.rpc.connect('127.0.0.1', '6008')
+  cmd = vim.lsp.rpc.connect('127.0.0.1', port)
 end
 
 return {


### PR DESCRIPTION
support get the port number from env variable `GDSript_Port`

Fix #2311 