### PR TITLE
fix: run all matched client in LspStart

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -438,8 +438,22 @@ function M.get_other_matching_providers(filetype)
   return other_matching_configs
 end
 
+function M.get_config_by_ft(filetype)
+  local configs = require 'lspconfig.configs'
+  local matching_configs = {}
+  for _, config in pairs(configs) do
+    local filetypes = config.filetypes or {}
+    for _, ft in pairs(filetypes) do
+      if ft == filetype then
+        table.insert(matching_configs, config)
+      end
+    end
+  end
+  return matching_configs
+end
+
 function M.get_active_client_by_name(bufnr, servername)
-  for _, client in pairs(vim.lsp.buf_get_clients(bufnr)) do
+  for _, client in pairs(vim.lsp.get_active_clients { bufnr = bufnr }) do
     if client.name == servername then
       return client
     end

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -76,8 +76,8 @@ api.nvim_create_user_command('LspStart', function(info)
     end
   end
 
-  local other_matching_configs = require('lspconfig.util').get_other_matching_providers(vim.bo.filetype)
-  for _, config in ipairs(other_matching_configs) do
+  local matching_configs = require('lspconfig.util').get_config_by_ft(vim.bo.filetype)
+  for _, config in ipairs(matching_configs) do
     config.launch()
   end
 end, {


### PR DESCRIPTION
Problem:   when `LspStart` without any argument it will launch the server which not in active even the filetypes match the 
                   current buffer .
Solution:  currently we support client with multiples workspaceFolders , it don't spawn another server instance . so no need 
                 use `get_other_matching_config` function .just get all matched config then launch them. 


Fix #2312