### PR TITLE
fix(lspinfo): safely expand filenames that don't exist on fs

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -103,6 +103,8 @@ local function make_config_info(config, bufnr)
   return lines
 end
 
+---@param client table
+---@param fname string
 local function make_client_info(client, fname)
   local client_info = {}
 
@@ -110,7 +112,7 @@ local function make_client_info(client, fname)
   local workspace_folders = fn.has 'nvim-0.9' == 1 and client.workspace_folders or client.workspaceFolders
   local uv = vim.loop
   local is_windows = uv.os_uname().version:match 'Windows'
-  fname = uv.fs_realpath(fname)
+  fname = vim.fn.fnamemodify(vim.fn.resolve(fname), ':p')
   local sep = is_windows and '\\' or '/'
   local fname_parts = vim.split(fname, sep, { trimempty = true })
   if workspace_folders then


### PR DESCRIPTION
The filename of a buffer may point to a node on the file system that
does not yet exist. `uv.fs_realpath()` will return nil in these cases,
causing a nil exception later on. The builtin `resolve()` function will
return the provided filename as-is if it does not yet exist.

Alternatively we could stick to libuv APIs.
