### PR TITLE
Only re-use the same server for multiple workspaces if the server supports it

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -257,7 +257,12 @@ function M.server_per_root_dir_manager(make_config)
         return
       end
       local client = lsp.get_client_by_id(id)
-      if client and client.name == conf.name then
+      if
+        client
+        and client.name == conf.name
+        and client.server_capabilities.workspaceFolders
+        and client.server_capabilities.workspaceFolders.supported
+      then
         return client
       end
       return nil


### PR DESCRIPTION
rust-analyzer stopped working for multiple workspaces, this starts multiple processes for it again