### PR TITLE
refactor: remove single_clients and improve clients reuse

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -272,12 +272,15 @@ function M.server_per_root_dir_manager(make_config)
     local client = get_client_from_cache(new_config)
 
     if client then
-      local params = lsp.util.make_workspace_params({ { uri = vim.uri_from_fname(root_dir), name = root_dir } }, { {} })
+      if single_file then
+        return client.id
+      end
+      local params = { uri = vim.uri_from_fname(root_dir), name = root_dir }
       client.rpc.notify('workspace/didChangeWorkspaceFolders', params)
       if not client.workspace_folders then
         client.workspace_folders = {}
       end
-      table.insert(client.workspace_folders, params.event.added[1])
+      table.insert(client.workspace_folders, params)
       if not clients[root_dir] then
         clients[root_dir] = {}
       end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -240,6 +240,8 @@ function M.server_per_root_dir_manager(make_config)
     local client_id_iterator = function(client_ids, conf)
       for _, id in ipairs(client_ids) do
         local client = lsp.get_client_by_id(id)
+        -- if found the workspace field in server_capabilities the server support workspace
+        -- if server not support the worskspace spawn a new server instance then.
         if client and client.name == conf.name and client.server_capabilities.workspace then
           return client
         end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -317,7 +317,7 @@ function M.server_per_root_dir_manager(make_config)
     return client_id
   end
 
-  function manager.clients(single_file)
+  function manager.clients()
     local res = {}
     for _, id in pairs(clients) do
       local client = lsp.get_client_by_id(id)

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -248,13 +248,7 @@ function M.server_per_root_dir_manager(make_config)
 
       for _, id in pairs(clients) do
         local client = lsp.get_client_by_id(id)
-        if
-          client
-          and client.name == conf.name
-          and client.server_capabilities
-          and client.server_capabilities.workspace
-          and client.server_capabilities.workspace.workspaceFolders.supported
-        then
+        if client and client.name == conf.name and client.server_capabilities.workspace then
           return client
         end
       end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -310,7 +310,6 @@ function M.server_per_root_dir_manager(make_config)
     -- Sending rootDirectory and workspaceFolders as null is not explicitly
     -- codified in the spec. Certain servers crash if initialized with a NULL
     -- root directory.
-    print('here', single_file)
     if single_file then
       new_config.root_dir = nil
       new_config.workspace_folders = nil


### PR DESCRIPTION
The design here is a bit wired. It stores clients in categories. It is possible to reuse the language server through the workspace. There is no need for classified storage. And the logic here is a bit long-winded. You only need to judge whether root_dir is in the clients table. If in we return the existing client. If not find all stored clients. If there is a client that needs it and supports workspace. Then return directly to this client. Then insert root into the workspace field. Trigger `didChangeWorkspaceFolders`. For non-existent we start new client.