### PR TITLE
refactor: simplify init options for @volar/vue-langauge-server v1.0

### DIFF
--- a/lua/lspconfig/server_configurations/volar.lua
+++ b/lua/lspconfig/server_configurations/volar.lua
@@ -10,40 +10,6 @@ local volar_init_options = {
   typescript = {
     tsdk = '',
   },
-  languageFeatures = {
-    implementation = true,
-    -- not supported - https://github.com/neovim/neovim/pull/14122
-    semanticTokens = false,
-    references = true,
-    definition = true,
-    typeDefinition = true,
-    callHierarchy = true,
-    hover = true,
-    rename = true,
-    renameFileRefactoring = true,
-    signatureHelp = true,
-    codeAction = true,
-    completion = {
-      defaultTagNameCase = 'both',
-      defaultAttrNameCase = 'kebabCase',
-    },
-    schemaRequestService = true,
-    documentHighlight = true,
-    documentLink = true,
-    codeLens = true,
-    diagnostics = true,
-  },
-  documentFeatures = {
-    -- not supported - https://github.com/neovim/neovim/pull/13654
-    documentColor = false,
-    selectionRange = true,
-    foldingRange = true,
-    linkedEditingRange = true,
-    documentSymbol = true,
-    documentFormatting = {
-      defaultPrintWidth = 100,
-    },
-  },
 }
 
 local bin_name = 'vue-language-server'


### PR DESCRIPTION
`languageFeatures` and `documentFeatures` options have been deprecated since @volar/vue-langauge-server v1.0.0, you can check released information at:

- https://github.com/johnsoncodehk/volar/pull/1916
- https://github.com/johnsoncodehk/volar/issues/2046#issuecomment-1287825923