### PR TITLE
fix(lspinfo): normalize `fname` path correctly

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -112,7 +112,7 @@ local function make_client_info(client, fname)
   local workspace_folders = fn.has 'nvim-0.9' == 1 and client.workspace_folders or client.workspaceFolders
   local uv = vim.loop
   local is_windows = uv.os_uname().version:match 'Windows'
-  fname = vim.loop.fs_realpath(fname) or vim.fn.fnamemodify(vim.fn.resolve(fname), ':p')
+  fname = uv.fs_realpath(fname) or fn.fnamemodify(fn.resolve(fname), ':p')
   if is_windows then
     fname:gsub('%/', '%\\')
   end

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -112,7 +112,7 @@ local function make_client_info(client, fname)
   local workspace_folders = fn.has 'nvim-0.9' == 1 and client.workspace_folders or client.workspaceFolders
   local uv = vim.loop
   local is_windows = uv.os_uname().version:match 'Windows'
-  fname = vim.fn.fnamemodify(vim.fn.resolve(fname), ':p')
+  fname = vim.loop.fs_realpath(fname)
   local sep = is_windows and '\\' or '/'
   local fname_parts = vim.split(fname, sep, { trimempty = true })
   if workspace_folders then

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -112,7 +112,7 @@ local function make_client_info(client, fname)
   local workspace_folders = fn.has 'nvim-0.9' == 1 and client.workspace_folders or client.workspaceFolders
   local uv = vim.loop
   local is_windows = uv.os_uname().version:match 'Windows'
-  fname = vim.loop.fs_realpath(fname)
+  fname = vim.loop.fs_realpath(fname) or vim.fn.fnamemodify(vim.fn.resolve(fname), ':p')
   local sep = is_windows and '\\' or '/'
   local fname_parts = vim.split(fname, sep, { trimempty = true })
   if workspace_folders then

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -118,7 +118,7 @@ local function make_client_info(client, fname)
   end
   local sep = is_windows and '\\' or '/'
   local fname_parts = vim.tbl_filter(function(v)
-    return v ~= ''
+    return #v > 0
   end, vim.split(fname, sep))
   if workspace_folders then
     for _, schema in pairs(workspace_folders) do

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -113,8 +113,13 @@ local function make_client_info(client, fname)
   local uv = vim.loop
   local is_windows = uv.os_uname().version:match 'Windows'
   fname = vim.loop.fs_realpath(fname) or vim.fn.fnamemodify(vim.fn.resolve(fname), ':p')
+  if is_windows then
+    fname:gsub('%/', '%\\')
+  end
   local sep = is_windows and '\\' or '/'
-  local fname_parts = vim.split(fname, sep, { trimempty = true })
+  local fname_parts = vim.tbl_filter(function(v)
+    return v ~= ''
+  end, vim.split(fname, sep))
   if workspace_folders then
     for _, schema in pairs(workspace_folders) do
       local matched = true


### PR DESCRIPTION
`vim.fn.fnamemodify` and `vim.fn.resolve` doesn't normalize slashes in Windows paths, which can cause `:LspInfo` to falsely report that the current attached client is in single file mode.
As far as I know `uv.fs_realpath` does everything that `vim.fn.fnamemodify(..., ":p")` and `vim.fn.resolve` can do and more, so I removed them.