### PR TITLE
fix: check server_capabilities field exist

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -243,7 +243,12 @@ function M.server_per_root_dir_manager(make_config)
         local client = lsp.get_client_by_id(id)
         -- if found the workspace field in server_capabilities the server support workspace
         -- if server not support the worskspace spawn a new server instance then.
-        if client and client.name == conf.name and client.server_capabilities.workspace then
+        if
+          client
+          and client.name == conf.name
+          and client.server_capabilities
+          and client.server_capabilities.workspace
+        then
           return client
         end
       end


### PR DESCRIPTION
I got an error like below (this error seems to be introduced by this PR: https://github.com/neovim/nvim-lspconfig/pull/2334):

```
Error executing lua callback: ...path/to/nvim-lspconfig/lua/lspconfig/util.lua:246: attempt to index field 'server_capabilities' (a nil value)
```

This PR fixes this error by adding `nil` check for `client.server_capabilities`.