### PR TITLE
fix: check client support workspaceFolders

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -241,14 +241,7 @@ function M.server_per_root_dir_manager(make_config)
     local client_id_iterator = function(client_ids, conf)
       for _, id in ipairs(client_ids) do
         local client = lsp.get_client_by_id(id)
-        -- if found the workspace field in server_capabilities the server support workspace
-        -- if server not support the worskspace spawn a new server instance then.
-        if
-          client
-          and client.name == conf.name
-          and client.server_capabilities
-          and client.server_capabilities.workspace
-        then
+        if client and client.name == conf.name and client.supports_method 'workspace/workspaceFolders' then
           return client
         end
       end


### PR DESCRIPTION
# Problem
we should not use  field in `server_capabilities` to check the server support workspace folders or not

# Solution
 use `client.support_method` to check


Fix #2349 