### PR TITLE
fix: use client config capabilities to check server support workspace

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -244,8 +244,9 @@ function M.server_per_root_dir_manager(make_config)
         if
           client
           and client.name == conf.name
-          and client.supports_method
-          and client.supports_method 'workspace/workspaceFolders'
+          and client.config
+          and client.config.capabilities
+          and client.config.capabilities.workspace
         then
           return client
         end


### PR DESCRIPTION
# Problem
 when there has another server request the before server may not have the `server_capabiliese` and `supports_method`. 

# Solution
 maybe we can use client capabilties.

Fix #2353 