### PR TITLE
fix: generate correct workspace didchange request params

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -380,7 +380,7 @@ function M.server_per_root_dir_manager(make_config)
       return
     end
 
-    --this for reload from session if have mulitple same filetype buffers in session.
+    --this for reload from session if have multiple same filetype buffers in session.
     --first buffer spawn a new client second buffer need wait for the client initialized
     if not client.initialized then
       attach_after_client_initialized(bufnr, client)

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -320,12 +320,14 @@ function M.server_per_root_dir_manager(make_config)
 
     if client then
       local register_workspace_folders = function(client_instance)
-        local params = lsp.util.make_workspace_params(
-          { { uri = vim.uri_from_fname(root_dir), name = root_dir } },
-          { {} }
-        )
+        local params = {
+          event = {
+            added = { { uri = vim.uri_from_fname(root_dir), name = root_dir } },
+            removed = {},
+          },
+        }
         for _, schema in ipairs(client_instance.workspace_folders or {}) do
-          if schema.name == params.event.added[1].name then
+          if schema.name == root_dir then
             return
           end
         end


### PR DESCRIPTION
# Problem
1. the `removed` should be an empty table not table which have an empty list element.
2. some server support `workspaceFolders` but the it not show in server_capabilities. 

# Solution
1. remake params
2. currently assuming the server supports workspaces. no judgment

Fix #2360
Fix #2357