### PR TITLE
fix: wrong param in get_active_clients

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -129,7 +129,7 @@ api.nvim_create_user_command('LspStop', function(info)
   end
 
   if not server_name then
-    local servers_on_buffer = lsp.get_active_clients { buffer = current_buf }
+    local servers_on_buffer = lsp.get_active_clients { bufnr = current_buf }
     for _, client in ipairs(servers_on_buffer) do
       if client.attached_buffers[current_buf] then
         client.stop(force)


### PR DESCRIPTION
# Problem
`get_active_clients` function params is bufnr not buffer

# Solution
change buffer to bufnr