### PR TITLE
fix(ruff-lsp): update docs to reflect init_options

### DIFF
--- a/lua/lspconfig/server_configurations/ruff_lsp.lua
+++ b/lua/lspconfig/server_configurations/ruff_lsp.lua
@@ -2,6 +2,7 @@ local util = require 'lspconfig.util'
 
 local root_files = {
   'pyproject.toml',
+  'ruff.toml',
 }
 
 return {
@@ -26,8 +27,8 @@ Extra CLI arguments for `ruff` can be provided via
 
 ```lua
 require'lspconfig'.ruff_lsp.setup{
-  settings = {
-    ruff_lsp = {
+  init_options = {
+    settings = {
       -- Any extra CLI arguments for `ruff` go here.
       args = {},
     }
@@ -36,6 +37,6 @@ require'lspconfig'.ruff_lsp.setup{
 ```
 
   ]],
-    root_dir = [[root_pattern("pyproject.toml", ".git")]],
+    root_dir = [[root_pattern("pyproject.toml", "ruff.toml", ".git")]],
   },
 }


### PR DESCRIPTION
`ruff-lsp` currently uses `init_options` and doesn't support settings. (I'll probably fix this, but for now the docs are incorrect.)