### PR TITLE
fix: get all client from clients cache in manager.clients

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -393,10 +393,12 @@ function M.server_per_root_dir_manager(make_config)
 
   function manager.clients()
     local res = {}
-    for _, id in pairs(clients) do
-      local client = lsp.get_client_by_id(id)
-      if client then
-        table.insert(res, client)
+    for _, client_ids in pairs(clients) do
+      for _, id in pairs(client_ids) do
+        local client = lsp.get_client_by_id(id)
+        if client then
+          table.insert(res, client)
+        end
       end
     end
     return res


### PR DESCRIPTION
# Problme
currently `clients` table store client for each  root dir.

# Solution
add iterator for client ids for each root dir