### PR TITLE
fix: not register workspace when in single file mode

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -72,8 +72,8 @@ function configs.__newindex(t, config_name, config_def)
       end
       api.nvim_create_autocmd(event, {
         pattern = pattern,
-        callback = function()
-          M.manager.try_add()
+        callback = function(opt)
+          M.manager.try_add(opt.buf)
         end,
         group = lsp_group,
         desc = string.format(

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -304,7 +304,9 @@ function M.server_per_root_dir_manager(make_config)
         vim.schedule_wrap(function()
           if client_instance.initialized and not timer:is_closing() then
             lsp.buf_attach_client(buffer_nr, client_instance.id)
-            register_workspace_folders(client_instance)
+            if not single_file then
+              register_workspace_folders(client_instance)
+            end
             timer:stop()
             timer:close()
           end


### PR DESCRIPTION
if file in single file mode after client initialized not register into the workspace