### PR TITLE
feat: support show server doc description in LspInfo

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -268,7 +268,7 @@ return function()
 
   local function close()
     api.nvim_clear_autocmds { group = augroup, buffer = bufnr }
-    if api.nvim_buf_is_valid(bufnr) then
+    if api.nvim_buf_is_valid(bufnr) and api.nvim_buf_is_loaded(bufnr) then
       api.nvim_buf_delete(bufnr, { force = true })
     end
     if api.nvim_win_is_valid(win_id) then
@@ -339,7 +339,5 @@ return function()
     vim.keymap.set('n', '<ESC>', close_doc_win, { buffer = info.bufnr })
   end
 
-  vim.keymap.set('n', '<TAB>', function()
-    show_doc()
-  end, { buffer = true, nowait = true })
+  vim.keymap.set('n', '<TAB>', show_doc, { buffer = true, nowait = true })
 end

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -268,7 +268,7 @@ return function()
 
   local function close()
     api.nvim_clear_autocmds { group = augroup, buffer = bufnr }
-    if api.nvim_buf_is_valid(bufnr) and api.nvim_buf_is_loaded(bufnr) then
+    if api.nvim_buf_is_loaded(bufnr) then
       api.nvim_buf_delete(bufnr, { force = true })
     end
     if api.nvim_win_is_valid(win_id) then
@@ -310,6 +310,9 @@ return function()
   local function show_doc()
     local lines = {}
     local function append_lines(config)
+      if not config then
+        return
+      end
       local desc = vim.tbl_get(config, 'document_config', 'docs', 'description')
       if desc then
         table.insert(lines, string.format('# %s', config.name))
@@ -324,17 +327,11 @@ return function()
 
     for _, client in pairs(buf_clients) do
       local config = require('lspconfig.configs')[client.name]
-      if config then
-        append_lines(config)
-      end
+      append_lines(config)
     end
 
     for _, config in pairs(other_matching_configs) do
-      if config then
-        if config then
-          append_lines(config)
-        end
-      end
+      append_lines(config)
     end
 
     local info = windows.percentage_range_window(0.8, 0.7)

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -202,7 +202,7 @@ return function()
   end
 
   -- insert the tips at the top of window
-  table.insert(buf_lines, 'Server Doc <TAB> use q or <esc> to quit')
+  table.insert(buf_lines, 'Press q or <Esc> to close this window. Press <Tab> to view server documentation.')
 
   local header = {
     '',

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -51,7 +51,7 @@ end
 for group, hi in pairs {
   LspInfoBorder = { link = 'Label', default = true },
   LspInfoList = { link = 'Function', default = true },
-  LspInfoTip = { fg = 'black', bg = 'lightblue', default = true },
+  LspInfoTip = { link = 'Comment', default = true },
   LspInfoTitle = { link = 'Title', default = true },
   LspInfoFiletype = { link = 'Type', default = true },
 } do

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -51,7 +51,7 @@ end
 for group, hi in pairs {
   LspInfoBorder = { link = 'Label', default = true },
   LspInfoList = { link = 'Function', default = true },
-  LspInfoTip = { link = 'Comment', default = true },
+  LspInfoTip = { fg = 'black', bg = 'lightblue', default = true },
   LspInfoTitle = { link = 'Title', default = true },
   LspInfoFiletype = { link = 'Type', default = true },
 } do


### PR DESCRIPTION
this is useful  for user to check the server doc in neovim when there is something wrong in server .

![images](https://user-images.githubusercontent.com/41671631/211251397-2a67b703-ef0a-4a2e-986d-e25996da5ced.gif)


