### PR TITLE
feat(tsserver): set `single_file_support` to true

### DIFF
--- a/lua/lspconfig/server_configurations/tsserver.lua
+++ b/lua/lspconfig/server_configurations/tsserver.lua
@@ -23,6 +23,7 @@ return {
       return util.root_pattern 'tsconfig.json'(fname)
         or util.root_pattern('package.json', 'jsconfig.json', '.git')(fname)
     end,
+    single_file_support = true,
   },
   docs = {
     description = [[


### PR DESCRIPTION
Set `single_file_support` for tsserver to true by default, as typescript-language-server supports single-file mode.