### PR TITLE
Avoid starting tailwindcss unless config is found

### DIFF
--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -105,10 +105,6 @@ return {
     end,
     root_dir = function(fname)
       return util.root_pattern('tailwind.config.js', 'tailwind.config.ts')(fname)
-        or util.root_pattern('postcss.config.js', 'postcss.config.ts')(fname)
-        or util.find_package_json_ancestor(fname)
-        or util.find_node_modules_ancestor(fname)
-        or util.find_git_ancestor(fname)
     end,
   },
   docs = {
@@ -121,7 +117,7 @@ npm install -g @tailwindcss/language-server
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern('tailwind.config.js', 'tailwind.config.ts', 'postcss.config.js', 'postcss.config.ts', 'package.json', 'node_modules', '.git')]],
+      root_dir = [[root_pattern('tailwind.config.js', 'tailwind.config.ts')]],
     },
   },
 }


### PR DESCRIPTION
The tailwindcss server is registered for a lot of file types. Since the config file will always be there if TailwindCSS is in use (as far as I can tell from experience and [the docs](https://tailwindcss.com/docs/configuration)), I would suggest only using these files for the root detection. In this way the server isn't spawned when it isn't necessary.