### PR TITLE
ci: add luarocks upload release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: "release"
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: leafo/gh-actions-lua@v9
+        with:
+          luaVersion: "luajit-2.1.0-beta3"
+      - uses: leafo/gh-actions-luarocks@v4
+      - name: Install dkjson
+        run: luarocks install dkjson
+      - name: Luarocks Upload
+        env: 
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        run: make luarocks_upload
+      - name: Install release
+        run: make test_luarocks_install 

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,9 @@ lint:
 	stylua --check .
 
 .PHONY: test lint
+
+luarocks_upload:
+	bash ./scripts/luarocks-upload.sh
+
+test_luarocks_install:
+	bash ./scripts/test-luarocks-install.sh

--- a/scripts/luarocks-upload.sh
+++ b/scripts/luarocks-upload.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Expects the LUAROCKS_API_KEY secret to be set
+
+TMP_DIR=$(mktemp -d)
+MODREV=$(git describe --tags --always --first-parent | tr -d "v")
+DEST_ROCKSPEC="$TMP_DIR/nvim-lspconfig-$MODREV-1.rockspec"
+cp "nvim-lspconfig-scm-1.rockspec" "$DEST_ROCKSPEC"
+sed -i "s/= 'scm'/= '$MODREV'/g" "$DEST_ROCKSPEC"
+luarocks upload "$DEST_ROCKSPEC" --api-key="$LUAROCKS_API_KEY"

--- a/scripts/test-luarocks-install.sh
+++ b/scripts/test-luarocks-install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+MODREV=$(git describe --tags --always --first-parent | tr -d "v")
+luarocks install "nvim-lspconfig" "$MODREV"


### PR DESCRIPTION
The recently added rockspec (see #2307) has to be prepared and uploaded to luarocks for each release.

This adds an automated workflow for it, which has been tested with plenary.nvim.

To be able to upload to luarocks, the owner of the luarocks account will have to add an API key named `LUAROCKS_API_KEY` to this repo's GitHub Actions secrets.

![github-add-luarocks-api-key](https://user-images.githubusercontent.com/12857160/211114453-193dd454-a842-4e8f-a083-fe73c530a51d.png)
