### PR TITLE
fix: restart server when server need restart

### DIFF
--- a/lua/lspconfig/server_configurations/sumneko_lua.lua
+++ b/lua/lspconfig/server_configurations/sumneko_lua.lua
@@ -33,6 +33,7 @@ return {
       return util.find_git_ancestor(fname)
     end,
     single_file_support = true,
+    new_folder_restart = true,
     log_level = vim.lsp.protocol.MessageType.Warning,
     settings = { Lua = { telemetry = { enable = false } } },
   },


### PR DESCRIPTION
# Problem
if server like sumneko lua does not support dynamically add or remove workspace Folders restart server when new add or remove workspaceFolders.

# Solution 
 add a option in server config `new_folder_restart` , when this option is `true` restart server and clean cache

Fix #2366 