### PR TITLE
feat: add openscad_lsp

### DIFF
--- a/lua/lspconfig/server_configurations/openscad_lsp.lua
+++ b/lua/lspconfig/server_configurations/openscad_lsp.lua
@@ -1,0 +1,32 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'openscad-lsp' },
+    filetypes = { 'openscad' },
+    root_dir = util.find_git_ancestor,
+    single_file_support = true,
+  },
+  docs = {
+    description = [=[
+https://github.com/Leathong/openscad-LSP
+
+A Language Server Protocol server for OpenSCAD
+
+You can build and install `openscad-lsp` binary with `cargo`:
+```sh
+cargo install openscad-lsp
+```
+
+Vim does not have built-in syntax for the `openscad` filetype currently.
+
+This can be added via an autocmd:
+
+```lua
+vim.cmd [[ autocmd BufRead,BufNewFile *.scad set filetype=openscad ]]
+```
+
+or by installing a filetype plugin such as https://github.com/sirtaj/vim-openscad
+]=],
+  },
+}

--- a/lua/lspconfig/server_configurations/openscad_lsp.lua
+++ b/lua/lspconfig/server_configurations/openscad_lsp.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'openscad-lsp' },
+    cmd = { 'openscad-lsp', '--stdio' },
     filetypes = { 'openscad' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,

--- a/lua/lspconfig/server_configurations/openscad_lsp.lua
+++ b/lua/lspconfig/server_configurations/openscad_lsp.lua
@@ -17,16 +17,6 @@ You can build and install `openscad-lsp` binary with `cargo`:
 ```sh
 cargo install openscad-lsp
 ```
-
-Vim does not have built-in syntax for the `openscad` filetype currently.
-
-This can be added via an autocmd:
-
-```lua
-vim.cmd [[ autocmd BufRead,BufNewFile *.scad set filetype=openscad ]]
-```
-
-or by installing a filetype plugin such as https://github.com/sirtaj/vim-openscad
 ]=],
   },
 }


### PR DESCRIPTION
This server is a fork of sorts of the `openscad_ls` server that is
already supported by nvim-lspconfig. I have no insight into either
projects, but the `openscad-lsp` Cargo package seems to be more
actively maintained, see:

- `openscad_ls`: https://github.com/dzhu/openscad-language-server
- `openscad_lsp (this pr)`: https://github.com/Leathong/openscad-LSP
