### PR TITLE
Updating it with a lsp that's actively maintained.

### DIFF
--- a/lua/lspconfig/server_configurations/openscad_ls.lua
+++ b/lua/lspconfig/server_configurations/openscad_ls.lua
@@ -9,24 +9,13 @@ return {
   },
   docs = {
     description = [=[
-https://github.com/dzhu/openscad-language-server
+https://github.com//Leathong/openscad-LSP
 
 A Language Server Protocol server for OpenSCAD
 
-You can build and install `openscad-language-server` binary with `cargo`:
+You can build and install `openscad-lsp` binary with `cargo`:
 ```sh
-cargo install openscad-language-server
+cargo install openscad-lsp
 ```
-
-Vim does not have built-in syntax for the `openscad` filetype currently.
-
-This can be added via an autocmd:
-
-```lua
-vim.cmd [[ autocmd BufRead,BufNewFile *.scad set filetype=openscad ]]
-```
-
-or by installing a filetype plugin such as https://github.com/sirtaj/vim-openscad
-]=],
   },
 }


### PR DESCRIPTION
Hello. 
https://github.com/dzhu/openscad-language-server has not had any updates since Sep 2021. This project should be considered deprecated. Therefore I am updating this to have the only actively maintained lsp used on vscode and emacs. Plus since vim-patch:8.2.4767 vim has recognized .scad files: https://github.com/neovim/neovim/pull/18138.

If there are any issues with this request I would love to discuss further.
Thank you.