### PR TITLE
feat: add drools-lsp support

### DIFF
--- a/lua/lspconfig/server_configurations/drools_lsp.lua
+++ b/lua/lspconfig/server_configurations/drools_lsp.lua
@@ -1,0 +1,84 @@
+local util = require 'lspconfig.util'
+
+local get = function(config, section, key)
+  return vim.tbl_get(config.settings, section, key) and config.settings[section][key] or nil
+end
+
+local get_java_bin = function()
+  local java_bin = vim.env.JAVA_HOME and util.path.join(vim.env.JAVA_HOME, 'bin', 'java') or 'java'
+  if vim.fn.has 'win32' == 1 then
+    java_bin = java_bin .. '.exe'
+  end
+  return java_bin
+end
+
+return {
+  default_config = {
+    filetypes = { 'drools' },
+    root_dir = util.find_git_ancestor(),
+    single_file_support = true,
+    on_new_config = function(config)
+      if not config.cmd then
+        local java_bin = get(config, 'java', 'bin') or get_java_bin()
+        local java_opts = get(config, 'java', 'opts') or {}
+        local drools_jar = get(config, 'drools', 'jar') or 'drools-lsp-server-jar-with-dependencies.jar'
+
+        config.cmd = { java_bin }
+        for _, o in ipairs(java_opts) do
+          table.insert(config.cmd, o)
+        end
+        --- @diagnostic disable-next-line:missing-parameter
+        vim.list_extend(config.cmd, { '-cp', drools_jar, 'org.drools.lsp.server.Main' })
+      end
+    end,
+  },
+  docs = {
+    description = [[
+https://github.com/kiegroup/drools-lsp
+
+Language server for the [Drools Rule Language (DRL)](https://docs.drools.org/latest/drools-docs/docs-website/drools/language-reference/#con-drl_drl-rules).
+
+The `drools-lsp` server is a self-contained java jar file (`drools-lsp-server-jar-with-dependencies.jar`), and can be downloaded from [https://github.com/kiegroup/drools-lsp/releases/](https://github.com/kiegroup/drools-lsp/releases/).
+
+Configuration information:
+```lua
+-- Option 1) Specify the entire command:
+require('lspconfig').drools_lsp.setup {
+  cmd = {
+    '/path/to/java',
+    '-cp',
+    '/path/to/drools-lsp-server-jar-with-dependencies.jar',
+    'org.drools.lsp.server.Main',
+  },
+}
+
+-- Option 2) Specify just the jar location (the JAVA_HOME environment variable will be respected):
+require('lspconfig').drools_lsp.setup {
+  settings = {
+    drools = {
+      jar = '/path/to/drools-lsp-server-jar-with-dependencies.jar',
+    },
+  },
+}
+
+-- Option 3) Specify the jar location plus the java bin path and/or java opts:
+require('lspconfig').drools_lsp.setup {
+  settings = {
+    java = {
+      bin = '/path/to/java',
+      opts = { '-Xmx500m' },
+    },
+    drools = {
+      jar = '/path/to/drools-lsp-server-jar-with-dependencies.jar',
+    },
+  },
+}
+```
+
+It is also recommended to set up automatic filetype detection for drools (`*.drl`) files, for example:
+```vim
+autocmd BufRead,BufNewFile *.drl set filetype=drools
+```
+]],
+  },
+}


### PR DESCRIPTION
This PR adds support for Red Hat's [Drools Rule Language](https://docs.drools.org/latest/drools-docs/docs-website/drools/language-reference/index.html#con-drl_drl-rules) (ft=`drools`, ext=`.drl`). The [drools-lsp](https://github.com/kiegroup/drools-lsp/) server is still under development, but it does have basic working capabilities, and I have successfully tested it (with this PR) in a minimal/vanilla neovim init config. Having this server configuration in nvim-lspconfig would enable developers to more easily develope DRL, **and** furthering the development and testing of the drools-lsp server itself.

Note: As soon as this PR gets merged, I will be submitting PRs to the mason.nvim repo ([diff](https://github.com/williamboman/mason.nvim/compare/main...errantepiphany:mason.nvim:DROOLS_LSP)) and the mason-lspconfig repo ([diff](https://github.com/williamboman/mason-lspconfig.nvim/compare/main...errantepiphany:mason-lspconfig.nvim:DROOLS_LSP)) - however this PR needs to get merged fist.

_Thank you so much!_

Full disclosure: I work for Red Hat on the Drools team itself. :)