### PR TITLE
fix(drools-lsp): leverage simpler -jar syntax now that drools-lsp supports it

### DIFF
--- a/lua/lspconfig/server_configurations/drools_lsp.lua
+++ b/lua/lspconfig/server_configurations/drools_lsp.lua
@@ -28,7 +28,7 @@ return {
           table.insert(config.cmd, o)
         end
         --- @diagnostic disable-next-line:missing-parameter
-        vim.list_extend(config.cmd, { '-cp', drools_jar, 'org.drools.lsp.server.Main' })
+        vim.list_extend(config.cmd, { '-jar', drools_jar })
       end
     end,
   },
@@ -46,9 +46,8 @@ Configuration information:
 require('lspconfig').drools_lsp.setup {
   cmd = {
     '/path/to/java',
-    '-cp',
+    '-jar',
     '/path/to/drools-lsp-server-jar-with-dependencies.jar',
-    'org.drools.lsp.server.Main',
   },
 }
 


### PR DESCRIPTION
fix(drools-lsp): leverage simpler -jar syntax now that drools-lsp supports it

[This PR](https://github.com/kiegroup/drools-lsp/pull/7) in `kiegroup/drools-lsp` was merged and a new release was built, making this PR doable.

Signed-off-by: David Ward <dward@redhat.com>