### PR TITLE
remarkls: make `root_dir` more restrictive

### DIFF
--- a/lua/lspconfig/server_configurations/remark_ls.lua
+++ b/lua/lspconfig/server_configurations/remark_ls.lua
@@ -10,9 +10,10 @@ end
 return {
   default_config = {
     cmd = cmd,
-    filetypes = { 'markdown', 'mdx' },
+    filetypes = { 'markdown' },
     root_dir = util.root_pattern(
       '.remarkrc',
+      '.remarkrc.json',
       '.remarkrc.js',
       '.remarkrc.cjs',
       '.remarkrc.mjs',

--- a/lua/lspconfig/server_configurations/remark_ls.lua
+++ b/lua/lspconfig/server_configurations/remark_ls.lua
@@ -10,8 +10,16 @@ end
 return {
   default_config = {
     cmd = cmd,
-    filetypes = { 'markdown', "mdx" },
-    root_dir = util.root_pattern('.remarkrc', '.remarkrc.js', '.remarkrc.cjs', '.remarkrc.mjs', '.remarkrc.yml', '.remarkrc.yaml', '.remarkignore'),
+    filetypes = { 'markdown', 'mdx' },
+    root_dir = util.root_pattern(
+      '.remarkrc',
+      '.remarkrc.js',
+      '.remarkrc.cjs',
+      '.remarkrc.mjs',
+      '.remarkrc.yml',
+      '.remarkrc.yaml',
+      '.remarkignore'
+    ),
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/remark_ls.lua
+++ b/lua/lspconfig/server_configurations/remark_ls.lua
@@ -10,8 +10,8 @@ end
 return {
   default_config = {
     cmd = cmd,
-    filetypes = { 'markdown' },
-    root_dir = util.find_git_ancestor,
+    filetypes = { 'markdown', "mdx" },
+    root_dir = util.root_pattern('.remarkrc', '.remarkrc.js', '.remarkrc.cjs', '.remarkrc.mjs', '.remarkrc.yml', '.remarkrc.yaml', '.remarkignore'),
     single_file_support = true,
   },
   docs = {


### PR DESCRIPTION
- Make `root_dir` more restrictive

The problem currently is that every time I type a _single character_, this message pops up aggressively and it switches focus to the pop-up: https://github.com/unifiedjs/unified-language-server/blob/4380a0ffbab401d42e679d2c620aa5b042cfc319/lib/index.js#L201-L210

There is no way to stop this. I have to run `:LspStop remarkls` manually in projects that have markdown but don't use remark (which is most projects).

Instead, we look for actual configuration files and only start the LS if they are present. The downside is that remark can also be configured in `package.json`, which wouldn't work with this change (would have to be documented)

### Alternatives

- Remove the warning in `unified-language-server`.
- Only show the warning once. As this warning is triggered in the creation phase of the language server, this probably works correctly in other editors but not in neovim.

@remcohaszing @wooorm thoughts?