### PR TITLE
docs(bahsls): mention server specific config

### DIFF
--- a/lua/lspconfig/server_configurations/bashls.lua
+++ b/lua/lspconfig/server_configurations/bashls.lua
@@ -19,6 +19,9 @@ return {
     },
     filetypes = { 'sh' },
     root_dir = util.find_git_ancestor,
+    settings = {
+      bashIde = {},
+    },
     single_file_support = true,
   },
   docs = {


### PR DESCRIPTION
Configuration specific to Bashls is accessible via the `bashIde` key. This is not obvious and hence is hereby documented.