### PR TITLE
fix: check server supported workspaceFolders

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -377,6 +377,11 @@ function M.server_per_root_dir_manager(make_config)
       return
     end
 
+    if clients[root_dir] then
+      lsp.buf_attach_client(bufnr, client.id)
+      return
+    end
+
     if single_file then
       lsp.buf_attach_client(bufnr, client.id)
       return

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -234,15 +234,6 @@ function M.server_per_root_dir_manager(make_config)
   local clients = {}
   local manager = {}
 
-  local function register_to_clients(root, id)
-    if not clients[root] then
-      clients[root] = {}
-    end
-    if not vim.tbl_contains(clients[root], id) then
-      table.insert(clients[root], id)
-    end
-  end
-
   function manager.add(root_dir, single_file, bufnr)
     root_dir = M.path.sanitize(root_dir)
 
@@ -261,6 +252,15 @@ function M.server_per_root_dir_manager(make_config)
         if client.name == client_name then
           return client
         end
+      end
+    end
+
+    local function register_to_clients(root, id)
+      if not clients[root] then
+        clients[root] = {}
+      end
+      if not vim.tbl_contains(clients[root], id) then
+        table.insert(clients[root], id)
       end
     end
 

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -351,10 +351,11 @@ function M.server_per_root_dir_manager(make_config)
       if supported_workspace_folders(client_instance) then
         lsp.buf_attach_client(bufnr, client_instance.id)
         register_workspace_folders(client_instance)
+        register_to_clients(client_instance.id)
       else
-        client_instance = start_new_client()
+        local id = start_new_client()
+        register_to_clients(id)
       end
-      register_to_clients(client_instance.id)
     end
 
     local attach_after_client_initialized = function(client_instance)

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -340,7 +340,7 @@ function M.server_per_root_dir_manager(make_config)
 
     local function supported_workspace_folders(client_instance)
       local supported =
-        vim.tbl_get(client_instance, 'server_capabilities', 'workspace', 'workspaceFolders,', 'supported')
+        vim.tbl_get(client_instance, 'server_capabilities', 'workspace', 'workspaceFolders', 'supported')
       if supported then
         return true
       end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -234,72 +234,58 @@ function M.server_per_root_dir_manager(make_config)
   local clients = {}
   local manager = {}
 
+  local function register_to_clients(root, id)
+    if not clients[root] then
+      clients[root] = {}
+    end
+    if not vim.tbl_contains(clients[root], id) then
+      table.insert(clients[root], id)
+    end
+  end
+
   function manager.add(root_dir, single_file, bufnr)
     root_dir = M.path.sanitize(root_dir)
 
-    local client_id_iterator = function(client_ids, conf)
-      for _, id in ipairs(client_ids) do
+    local function get_client_from_cache(client_name)
+      if vim.tbl_count(clients) == 0 then
+        return
+      end
+
+      local all_client_ids = {}
+      vim.tbl_map(function(val)
+        vim.list_extend(all_client_ids, { unpack(val) })
+      end, clients)
+
+      for _, id in ipairs(all_client_ids) do
         local client = lsp.get_client_by_id(id)
-        if client and client.name == conf.name then
+        if client.name == client_name then
           return client
         end
       end
     end
 
-    local register_to_clients = function(id)
-      if not clients[root_dir] then
-        clients[root_dir] = {}
-      end
-      if not vim.tbl_contains(clients[root_dir], id) then
-        table.insert(clients[root_dir], id)
-      end
-    end
-
-    -- get client which support workspace from clients table
-    local get_client_from_cache = function(conf)
-      if vim.tbl_count(clients) == 0 then
-        return
-      end
-      local client
-
-      if clients[root_dir] then
-        client = client_id_iterator(clients[root_dir], conf)
-      else
-        for _, ids in pairs(clients) do
-          client = client_id_iterator(ids, conf)
-          if client then
-            break
-          end
-        end
-      end
-
-      return client
-    end
-
     local new_config = make_config(root_dir)
-    local client = get_client_from_cache(new_config)
 
-    local function register_workspace_folders(client_instance)
+    local function register_workspace_folders(client)
       local params = {
         event = {
           added = { { uri = vim.uri_from_fname(root_dir), name = root_dir } },
           removed = {},
         },
       }
-      for _, schema in ipairs(client_instance.workspace_folders or {}) do
+      for _, schema in ipairs(client.workspace_folders or {}) do
         if schema.name == root_dir then
           return
         end
       end
-      client_instance.rpc.notify('workspace/didChangeWorkspaceFolders', params)
-      if not client_instance.workspace_folders then
-        client_instance.workspace_folders = {}
+      client.rpc.notify('workspace/didChangeWorkspaceFolders', params)
+      if not client.workspace_folders then
+        client.workspace_folders = {}
       end
-      table.insert(client_instance.workspace_folders, params.event.added[1])
+      table.insert(client.workspace_folders, params.event.added[1])
     end
 
-    local client_id
-    local start_new_client = function()
+    local function start_new_client()
       -- do nothing if the client is not enabled
       if new_config.enabled == false then
         return
@@ -315,9 +301,10 @@ function M.server_per_root_dir_manager(make_config)
         return
       end
       new_config.on_exit = M.add_hook_before(new_config.on_exit, function()
-        for k, v in pairs(clients[root_dir]) do
-          if v == client_id then
-            table.remove(clients[root_dir], k)
+        for index, id in pairs(clients[root_dir]) do
+          local exist = lsp.get_client_by_id(id)
+          if exist.name == new_config.name then
+            table.remove(clients[root_dir], index)
           end
         end
       end)
@@ -335,29 +322,33 @@ function M.server_per_root_dir_manager(make_config)
         new_config.root_dir = nil
         new_config.workspace_folders = nil
       end
-      client_id = lsp.start_client(new_config)
+      return lsp.start_client(new_config)
     end
 
-    local function supported_workspace_folders(client_instance)
-      local supported =
-        vim.tbl_get(client_instance, 'server_capabilities', 'workspace', 'workspaceFolders', 'supported')
+    local function attach_or_spawn(client)
+      local supported = vim.tbl_get(client, 'server_capabilities', 'workspace', 'workspaceFolders', 'supported')
+      local client_id
       if supported then
-        return true
-      end
-      return false
-    end
-
-    local function attach_or_spawn_new(client_instance)
-      if supported_workspace_folders(client_instance) then
-        lsp.buf_attach_client(bufnr, client_instance.id)
-        register_workspace_folders(client_instance)
-        register_to_clients(client_instance.id)
+        lsp.buf_attach_client(bufnr, client.id)
+        register_workspace_folders(client)
+        client_id = client.id
       else
-        local id = start_new_client()
-        register_to_clients(id)
+        client_id = start_new_client()
+        if not client_id then
+          return
+        end
       end
+      register_to_clients(client_id)
     end
 
+    -- this function used for some situation like load from session
+    -- eg:
+    -- session have two same filetype in two project. file A trigger Filetyp event
+    -- start server. file B also trigger Filetype event. we start server is async.
+    -- tha mean when file A spawn new server this server maybe not initialized and
+    -- don't exchanged server_capabilities so the File B need wait the server initialized
+    -- if server support workspaceFolders then regisert File B root into workspaceFolders
+    -- otherwise spawn a new one.
     local attach_after_client_initialized = function(client_instance)
       local timer = vim.loop.new_timer()
       timer:start(
@@ -365,7 +356,7 @@ function M.server_per_root_dir_manager(make_config)
         10,
         vim.schedule_wrap(function()
           if client_instance.initialized and client_instance.server_capabilities and not timer:is_closing() then
-            attach_or_spawn_new(client_instance)
+            attach_or_spawn(client_instance)
             timer:stop()
             timer:close()
           end
@@ -373,26 +364,30 @@ function M.server_per_root_dir_manager(make_config)
       )
     end
 
-    if client then
-      if single_file then
-        lsp.buf_attach_client(bufnr, client.id)
-      -- make sure neovim had exchanged capabilities from language server
-      -- it's useful to check server support workspaceFolders or not
-      elseif client.initialized and client.server_capabilities then
-        attach_or_spawn_new(client)
-      elseif (client.initialized and not client.server_capabilities) or not client.initialized then
-        attach_after_client_initialized(client)
+    local client = get_client_from_cache(new_config.name)
+
+    if not client then
+      local client_id = start_new_client()
+      if not client_id then
+        return
       end
+      lsp.buf_attach_client(bufnr, client_id)
+      register_to_clients(root_dir, client_id)
       return
     end
 
-    start_new_client()
-    if not client_id then
+    if single_file then
+      lsp.buf_attach_client(bufnr, client.id)
       return
     end
 
-    lsp.buf_attach_client(bufnr, client_id)
-    register_to_clients(client_id)
+    -- make sure neovim had exchanged capabilities from language server
+    -- it's useful to check server support workspaceFolders or not
+    if client.initialized and client.server_capabilities then
+      attach_or_spawn(client)
+    else
+      attach_after_client_initialized(client)
+    end
   end
 
   function manager.clients()

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -337,6 +337,7 @@ function M.server_per_root_dir_manager(make_config)
         if not client_id then
           return
         end
+        lsp.buf_attach_client(bufnr, client_id)
       end
       register_to_clients(root_dir, client_id)
     end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -338,7 +338,7 @@ function M.server_per_root_dir_manager(make_config)
           return
         end
       end
-      register_to_clients(client_id)
+      register_to_clients(root_dir, client_id)
     end
 
     -- this function used for some situation like load from session

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -345,7 +345,7 @@ function M.server_per_root_dir_manager(make_config)
     -- eg:
     -- session have two same filetype in two project. file A trigger Filetyp event
     -- start server. file B also trigger Filetype event. we start server is async.
-    -- tha mean when file A spawn new server this server maybe not initialized and
+    -- that mean when file A spawn new server this server maybe not initialized and
     -- don't exchanged server_capabilities so the File B need wait the server initialized
     -- if server support workspaceFolders then regisert File B root into workspaceFolders
     -- otherwise spawn a new one.

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -242,6 +242,15 @@ function M.server_per_root_dir_manager(make_config)
         return
       end
 
+      if clients[root_dir] then
+        for _, id in pairs(clients[root_dir]) do
+          local client = lsp.get_client_by_id(id)
+          if client.name == client_name then
+            return client
+          end
+        end
+      end
+
       local all_client_ids = {}
       vim.tbl_map(function(val)
         vim.list_extend(all_client_ids, { unpack(val) })


### PR DESCRIPTION
rewrite the spawn the server instance logic. 

`clients`  cache the server instance id with root , key is root dir value is all clients id which attached this root dir .

1.  find the client from `clients `
2. if find exist client check this client support `workspaceFolders` by 
    `vim.tbl_get(client, 'server_capabilities', 'workspace', 'workspaceFolders', 'supported')` if true mean client support 
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_workspaceFolders
3.  otherwise spawn a new one.

notice there has a timer for some situation .like load from session .