### PR TITLE
Add go_to_definiton information for omnisharp

### DIFF
--- a/lua/lspconfig/server_configurations/omnisharp.lua
+++ b/lua/lspconfig/server_configurations/omnisharp.lua
@@ -91,6 +91,8 @@ OmniSharp requires the [dotnet-sdk](https://dotnet.microsoft.com/download) to be
 
 **By default, omnisharp-roslyn doesn't have a `cmd` set.** This is because nvim-lspconfig does not make assumptions about your path. You must add the following to your init.vim or init.lua to set `cmd` to the absolute path ($HOME and ~ are not expanded) of the unzipped run script or binary.
 
+For `go_to_definition` to work fully, extended `textDocument/definition` handler is needed, for example see [omnisharp-extended-lsp.nvim](https://github.com/Hoffs/omnisharp-extended-lsp.nvim)
+
 ```lua
 require'lspconfig'.omnisharp.setup {
     cmd = { "dotnet", "/path/to/omnisharp/OmniSharp.dll" },


### PR DESCRIPTION
cc @williamboman since you seem to be familiar with omnisharp, just making sure this is a correct info

I just tried omnisharp and go to definition doesn't work without the linked extension