### PR TITLE
Replace `uv.fs_realpath` with vim builtin functions

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -118,7 +118,7 @@ local function make_client_info(client, fname)
   if workspace_folders then
     for _, schema in pairs(workspace_folders) do
       local matched = true
-      local root = uv.fs_realpath(schema.name)
+      local root = vim.fn.fnamemodify(schema.name, ":p")
       local root_parts = vim.split(root, sep, { trimempty = true })
 
       for i = 1, #root_parts do

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -160,7 +160,7 @@ M.path = (function()
 
   -- Traverse the path calling cb along the way.
   local function traverse_parents(path, cb)
-    path = uv.fs_realpath(path)
+    path = vim.fn.fnamemodify(path, ':p')
     local dir = path
     -- Just in case our algo is buggy, don't infinite loop.
     for _ = 1, 100 do
@@ -186,7 +186,7 @@ M.path = (function()
       else
         return
       end
-      if v and uv.fs_realpath(v) then
+      if v and vim.fn.isdirectory(v) then
         return v, path
       else
         return
@@ -358,7 +358,7 @@ function M.server_per_root_dir_manager(make_config)
 
       -- Launch the server in the root directory used internally by lspconfig, if otherwise unset
       -- also check that the path exist
-      if not new_config.cmd_cwd and uv.fs_realpath(root_dir) then
+      if not new_config.cmd_cwd and vim.fn.isdirectory(root_dir) then
         new_config.cmd_cwd = root_dir
       end
 


### PR DESCRIPTION
The method `uv.fs_realpath` is a lua binding for `uv_fs_realpath` in libuv, which currently not cover several corner cases in Windows OS. See API [document](http://docs.libuv.org/en/v1.x/fs.html#:~:text=int-,uv_fs_realpath,-\(uv_loop_t%20*) of libuv for details. 

Promote to fix #2341 