### PR TITLE
docs: arduino - mention upstream keywords bug

### DIFF
--- a/lua/lspconfig/server_configurations/arduino_language_server.lua
+++ b/lua/lspconfig/server_configurations/arduino_language_server.lua
@@ -79,6 +79,8 @@ Your folder structure should look like this:
 ```
 
 For further instruction about configuration options, run `arduino-language-server --help`.
+
+Note that an [upstream bug](https://github.com/arduino/arduino-ide/issues/159) makes keywords in some cases become undefined by the language server.
 ]],
   },
 }


### PR DESCRIPTION
BTW, perhaps the original contributor of this language server (@mjlbach) knows why does Arduino officially says that [`sketch.json` is not used by `arduino-cli`](https://arduino.github.io/arduino-cli/0.29/sketch-specification/#metadata) and how is this file related to the language server. Although I don't know the answer to this question, I'm pretty sure this documentation suggestion is still relevant.