### PR TITLE
fix: update luarocks-tag-release action + set license

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v1.0.1
+        uses: nvim-neorocks/luarocks-tag-release@v1.0.2
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:
@@ -20,3 +20,4 @@ jobs:
             Language server configurations are community-maintained.
           copy_directories: |
             doc
+          licence: "Apache/2.0"


### PR DESCRIPTION
@teto this version escapes quotes in the description: (https://github.com/neovim/nvim-lspconfig/pull/2430#issuecomment-1418286733)

I also added a license field, because GitHub doesn't seem to recognize it.