### PR TITLE
docs: make sure username doesn't leak into generated document

### DIFF
--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -82,11 +82,21 @@ require'lspconfig'.{{template_name}}.setup{}
 ]]
 
 local function require_all_configs()
+  -- Make sure username doesn't leak into the generated document
+  local old_home = vim.env.HOME
+  local old_cache_home = vim.env.XDG_CACHE_HOME
+  vim.env.HOME = '/home/username'
+  vim.env.XDG_CACHE_HOME = '/home/username/.cache'
+
   -- Configs are lazy-loaded, tickle them to populate the `configs` singleton.
   for _, v in ipairs(vim.fn.glob('lua/lspconfig/server_configurations/*.lua', 1, 1)) do
     local module_name = v:gsub('.*/', ''):gsub('%.lua$', '')
     configs[module_name] = require('lspconfig.server_configurations.' .. module_name)
   end
+
+  -- Reset the environment variables
+  vim.env.HOME = old_home
+  vim.env.XDG_CACHE_HOME = old_cache_home
 end
 
 local function make_lsp_sections()

--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -85,8 +85,8 @@ local function require_all_configs()
   -- Make sure username doesn't leak into the generated document
   local old_home = vim.env.HOME
   local old_cache_home = vim.env.XDG_CACHE_HOME
-  vim.env.HOME = '/home/username'
-  vim.env.XDG_CACHE_HOME = '/home/username/.cache'
+  vim.env.HOME = '/home/user'
+  vim.env.XDG_CACHE_HOME = '/home/user/.cache'
 
   -- Configs are lazy-loaded, tickle them to populate the `configs` singleton.
   for _, v in ipairs(vim.fn.glob('lua/lspconfig/server_configurations/*.lua', 1, 1)) do


### PR DESCRIPTION
The documents previously contained `runner`, the username of GitHub Actions runners, which would be overwritten by the user's name when run locally and generate unwanted diff.