### PR TITLE
fix(stylelint_lsp): update root directory pattern

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -1,6 +1,5 @@
 local util = require 'lspconfig.util'
 local lsp = vim.lsp
-local is_windows = vim.fn.has 'win32' == 1
 
 local function fix_all(opts)
   opts = opts or {}
@@ -36,7 +35,7 @@ end
 local bin_name = 'vscode-eslint-language-server'
 local cmd = { bin_name, '--stdio' }
 
-if is_windows then
+if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
@@ -50,18 +49,7 @@ local root_file = {
   'eslint.config.js',
 }
 
-local root_with_package = util.find_package_json_ancestor(vim.fn.expand '%:p:h')
-
-if root_with_package then
-  -- only add package.json if it contains eslintConfig field
-  local path_sep = is_windows and '\\' or '/'
-  for line in io.lines(root_with_package .. path_sep .. 'package.json') do
-    if line:find 'eslintConfig' then
-      table.insert(root_file, 'package.json')
-      break
-    end
-  end
-end
+root_file = util.add_package_json_to_config_files_if_field_exists(root_file, 'eslintConfig')
 
 return {
   default_config = {

--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -49,7 +49,7 @@ local root_file = {
   'eslint.config.js',
 }
 
-root_file = util.add_package_json_to_config_files_if_field_exists(root_file, 'eslintConfig')
+root_file = util.insert_package_json(root_file, 'eslintConfig')
 
 return {
   default_config = {

--- a/lua/lspconfig/server_configurations/stylelint_lsp.lua
+++ b/lua/lspconfig/server_configurations/stylelint_lsp.lua
@@ -1,10 +1,9 @@
 local util = require 'lspconfig.util'
-local is_windows = vim.fn.has 'win32' == 1
 
 local bin_name = 'stylelint-lsp'
 local cmd = { bin_name, '--stdio' }
 
-if is_windows == 1 then
+if vim.fn.has 'win32' == 1 == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 
@@ -19,18 +18,7 @@ local root_file = {
   'stylelint.config.js',
 }
 
-local root_with_package = util.find_package_json_ancestor(vim.fn.expand '%:p:h')
-
-if root_with_package then
-  -- only add package.json if it contains stylelint field
-  local path_sep = is_windows and '\\' or '/'
-  for line in io.lines(root_with_package .. path_sep .. 'package.json') do
-    if line:find 'stylelint' then
-      table.insert(root_file, 'package.json')
-      break
-    end
-  end
-end
+root_file = util.add_package_json_to_config_files_if_field_exists(root_file, 'stylelint')
 
 return {
   default_config = {

--- a/lua/lspconfig/server_configurations/stylelint_lsp.lua
+++ b/lua/lspconfig/server_configurations/stylelint_lsp.lua
@@ -18,7 +18,7 @@ local root_file = {
   'stylelint.config.js',
 }
 
-root_file = util.add_package_json_to_config_files_if_field_exists(root_file, 'stylelint')
+root_file = util.insert_package_json(root_file, 'stylelint')
 
 return {
   default_config = {

--- a/lua/lspconfig/server_configurations/stylelint_lsp.lua
+++ b/lua/lspconfig/server_configurations/stylelint_lsp.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 local bin_name = 'stylelint-lsp'
 local cmd = { bin_name, '--stdio' }
 
-if vim.fn.has 'win32' == 1 == 1 then
+if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', bin_name, '--stdio' }
 end
 

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -4,7 +4,7 @@ local api = vim.api
 local lsp = vim.lsp
 local uv = vim.loop
 
-local is_windows = uv.os_uname().version:match 'Windows'
+local is_windows = uv.os_uname().sysname == 'Windows_NT'
 
 local M = {}
 

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -487,7 +487,7 @@ function M.find_package_json_ancestor(startpath)
   end)
 end
 
-function M.add_package_json_to_config_files_if_field_exists(config_files, field)
+function M.insert_package_json(config_files, field)
   local root_with_package = M.find_package_json_ancestor(vim.fn.expand '%:p:h')
 
   if root_with_package then


### PR DESCRIPTION
Hi! dear maintainers - this little contribution is to extend the `root_pattern` lookup by supporting all [StyleLint config files](https://stylelint.io/user-guide/configure/) and based on the [eslint.lua](https://github.com/neovim/nvim-lspconfig/blob/aeb76066212b09c7c01a3abb42fe82f0130ef402/lua/lspconfig/server_configurations/eslint.lua) method.

Signed-off-by: Wuelner Martínez <wuelner.martinez@outlook.com>