### PR TITLE
chore(license): move copyright notice to readme

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,10 +1,3 @@
-Copyright Neovim contributors. All rights reserved.
-
-nvim-lspconfig is licensed under the terms of the Apache 2.0 license.
-
-nvim-lspconfig's license follows:
-
-====
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/README.md
+++ b/README.md
@@ -158,3 +158,11 @@ a new configuration for it helps others, especially if the server requires speci
       to get started. Most configs are simple. For an extensive example see
       [texlab.lua](https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/texlab.lua).
 3. Ask questions on our [Discourse](https://neovim.discourse.group/c/7-category/7) or in the [Neovim Matrix room](https://app.element.io/#/room/#neovim:matrix.org).
+
+## License
+
+Copyright Neovim contributors. All rights reserved.
+
+nvim-lspconfig is licensed under the terms of the Apache 2.0 license.
+
+See [LICENSE.md](./LICENSE.md)


### PR DESCRIPTION
I noticed that GitHub can't parse the license SPDX ID form the license file. So I moved the copyright notice above the license text to the bottom of the readme.

### Before
![image](https://user-images.githubusercontent.com/12857160/218104176-fc8fd29c-a7ec-4c1e-a22d-912bbdb09690.png)

### After (my fork)
![image](https://user-images.githubusercontent.com/12857160/218104279-e2c582e1-293c-4079-aafc-9c36e60f93c3.png)
