### PR TITLE
docs(eslint): fix on save example creates a buflocal autocmd

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -184,12 +184,12 @@ npm i -g vscode-langservers-extracted
 ```lua
 lspconfig.eslint.setup({
   --- ...
-	on_attach = function(client, bufnr)
-		vim.api.nvim_create_autocmd("BufWritePre", {
-			buffer = bufnr,
-			command = "EslintFixAll",
-		})
-	end,
+  on_attach = function(client, bufnr)
+    vim.api.nvim_create_autocmd("BufWritePre", {
+      buffer = bufnr,
+      command = "EslintFixAll",
+    })
+  end,
 })
 ```
 

--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -181,8 +181,16 @@ npm i -g vscode-langservers-extracted
 ```
 
 `vscode-eslint-language-server` provides an `EslintFixAll` command that can be used to format a document on save:
-```vim
-autocmd BufWritePre *.tsx,*.ts,*.jsx,*.js EslintFixAll
+```lua
+lspconfig.eslint.setup({
+  --- ...
+	on_attach = function(client, bufnr)
+		vim.api.nvim_create_autocmd("BufWritePre", {
+			buffer = bufnr,
+			command = "EslintFixAll",
+		})
+	end,
+})
 ```
 
 See [vscode-eslint](https://github.com/microsoft/vscode-eslint/blob/55871979d7af184bf09af491b6ea35ebd56822cf/server/src/eslintServer.ts#L216-L229) for configuration options.


### PR DESCRIPTION
## Motivation

Creating a buflocal autocmd on attach is more useful, IMO, cause it guarantees the command will only be executed on buffers that support it. I found myself many times editing js or ts files outside of a project using eslint and would get an error on save because of the autocmd on the documentation.

Hopefully it helps others!