### PR TITLE
fix: eslint errors on start

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -495,7 +495,8 @@ function M.insert_package_json(config_files, field)
     local path_sep = is_windows and '\\' or '/'
     for line in io.lines(root_with_package .. path_sep .. 'package.json') do
       if line:find(field) then
-        return table.insert(config_files, 'package.json')
+        table.insert(config_files, 'package.json')
+        break
       end
     end
   end


### PR DESCRIPTION
## Error

![image](https://user-images.githubusercontent.com/19226858/218292645-a6cb7e23-020d-4e6c-aef5-ac074819eed7.png)

## Solution

Looks like there was a subtle change in logic in the `insert_package_json` util that was causing the function to return `nil` (introduced here https://github.com/neovim/nvim-lspconfig/commit/6669f2d8ebc38cfb9e639145569f94be5556d916). I'm not sure if it's something specific to my neovim version:

```
➜ nvim --version
NVIM v0.8.3
Build type: Release
LuaJIT 2.1.0-beta3
Compiled by brew@Monterey

Features: +acl +iconv +tui
```
Reverting to previous logic fixes it for me.