### PR TITLE
feat: extend the syntax for LspInfo(Title|List)

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -298,9 +298,9 @@ return function()
     syn keyword Error false
     syn match LspInfoFiletypeList /\<filetypes\?:\s*\zs.*\ze/ contains=LspInfoFiletype
     syn match LspInfoFiletype /\k\+/ contained
-    syn match LspInfoTitle /^\s*\%(Client\|Config\):\s*\zs\k\+\ze/
+    syn match LspInfoTitle /^\s*\%(Client\|Config\):\s*\zs\S\+\ze/
     syn match LspInfoListList /^\s*Configured servers list:\s*\zs.*\ze/ contains=LspInfoList
-    syn match LspInfoList /\k\+/ contained
+    syn match LspInfoList /\S\+/ contained
   ]]
 
   api.nvim_buf_add_highlight(bufnr, 0, 'LspInfoTip', 0, 0, -1)


### PR DESCRIPTION
replace \k with \S
support e.g., null-ls


## before

<img width="231" alt="image" src="https://user-images.githubusercontent.com/13248742/218614134-1f817fb1-84da-48e4-aaf3-04a7fb993cfc.png">


## after

<img width="227" alt="image" src="https://user-images.githubusercontent.com/13248742/218614202-cf409011-9b81-4d50-ba78-e4283025f4c0.png">
