### PR TITLE
fix: remove deprecate function config.available_servers

### DIFF
--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -4,11 +4,6 @@ local M = {
   util = require 'lspconfig.util',
 }
 
-function M.available_servers()
-  vim.deprecate('lspconfig.available_servers', 'lspconfig.util.available_servers', '0.1.4', 'lspconfig')
-  return M.util.available_servers()
-end
-
 ---@class Alias
 ---@field to string The new name of the server
 ---@field version string The version that the alias will be removed in


### PR DESCRIPTION
this function mark as deprecate in 0.1.4
use util.available_servers instead of