### PR TITLE
refactor: rewrite root dir by using vim.fs module

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -423,9 +423,6 @@ end
 
 function M.search_ancestors(startpath, func)
   validate { func = { func, 'f' } }
-  if func(startpath) then
-    return startpath
-  end
   local guard = 100
   for path in M.path.iterate_parents(startpath) do
     -- Prevent infinite recursion if our algorithm breaks

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -477,7 +477,7 @@ end
 
 function M.find_node_modules_ancestor(startpath)
   return function()
-    return searcher(startpath, { '.hg' }, true)
+    return searcher(startpath, { 'node_modules' }, true)
   end
 end
 


### PR DESCRIPTION
a break change . the `vim.fs` module only works for nvim 0.8+ . so idk what time is can be merge.

relate issue: #2449  #2400 #1908