### PR TITLE
fix(commands): Strange `LspStop` arguments, not matching doc

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -117,18 +117,17 @@ end, {
 
 api.nvim_create_user_command('LspStop', function(info)
   local current_buf = vim.api.nvim_get_current_buf()
-  local server_name, force
+  local server_id, force
   local arguments = vim.split(info.args, '%s')
   for _, v in pairs(arguments) do
     if v == '++force' then
       force = true
-    end
-    if v:find '%(' then
-      server_name = v
+    elseif v:find '^[0-9]+$' then
+      server_id = v
     end
   end
 
-  if not server_name then
+  if not server_id then
     local servers_on_buffer = lsp.get_active_clients { bufnr = current_buf }
     for _, client in ipairs(servers_on_buffer) do
       if client.attached_buffers[current_buf] then
@@ -136,7 +135,7 @@ api.nvim_create_user_command('LspStop', function(info)
       end
     end
   else
-    for _, client in ipairs(get_clients_from_cmd_args(server_name)) do
+    for _, client in ipairs(get_clients_from_cmd_args(server_id)) do
       client.stop(force)
     end
   end


### PR DESCRIPTION
`LspStop` only working like:
```
:LspStop (1)
```
putting `id` between parenthesis.