### PR TITLE
fix: add clojure to tailwindcss lsp filetypes

### DIFF
--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -17,6 +17,7 @@ return {
       'astro',
       'astro-markdown',
       'blade',
+      'clojure',
       'django-html',
       'htmldjango',
       'edge',


### PR DESCRIPTION
Clojurescript is another filetype that can use tailwindcss lsp completion, given the following lsp configuration:
```
    tailwindcss = {
      settings = {
        tailwindCSS = {
          experimental = {
            classRegex = {
              ":class\\s+\"([^\"]*)\"",
              ":[\\w-.#>]+\\.([\\w-]*)"
            },
          },
          includeLanguages = {
            clojure = "html"
          },
        },
      },
    },
```