### PR TITLE
feat: add azure pipelines lsp

### DIFF
--- a/lua/lspconfig/server_configurations/azure_pipelines_language_server.lua
+++ b/lua/lspconfig/server_configurations/azure_pipelines_language_server.lua
@@ -1,0 +1,53 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = {},
+    filetypes = { 'yaml' },
+    root_dir = util.find_git_ancestor,
+    single_file_support = true,
+    settings = {},
+  },
+  docs = {
+    description = [[
+https://github.com/microsoft/azure-pipelines-language-server
+
+An Azure Pipelines language server
+
+**By default, `azure-pipelines-language-server` doesn't have a `cmd` set.** This is because nvim-lspconfig does not make assumptions about your path.
+You have to install the language server manually.
+
+`azure-pipelines-language-server` can be installed via `npm`:
+
+```sh
+npm install -g azure-pipelines-language-server
+```
+
+Once installed, point `cmd` to `server.js` inside the `server/out` directory:
+
+```lua
+cmd = {'node', '<path_to_repo>/server/out/server.js', '--stdio'}
+```
+
+By default `azure-pipelines-language-server` will only work in files named `azure-pipelines.yml`, this can be changed by providing additional settings like so:
+```lua
+require("lspconfig").azure_pipelines_language_server.setup {
+  ... -- other configuration for setup {}
+  settings = {
+      yaml = {
+          schemas = {
+              ["https://raw.githubusercontent.com/microsoft/azure-pipelines-vscode/master/service-schema.json"] = {
+                  "/azure-pipeline*.y*l",
+                  "/*.azure*",
+                  "Azure-Pipelines/**/*.y*l",
+                  "Pipelines/*.y*l",
+              },
+          },
+      },
+  },
+}
+```
+The Azure Pipelines LSP is a fork of `yaml-language-server` and as such the same settings can be passed to it as `yaml-language-server`.
+]],
+  },
+}

--- a/lua/lspconfig/server_configurations/azure_pipelines_ls.lua
+++ b/lua/lspconfig/server_configurations/azure_pipelines_ls.lua
@@ -23,10 +23,10 @@ You have to install the language server manually.
 npm install -g azure-pipelines-language-server
 ```
 
-Once installed, point `cmd` to `server.js` inside the `server/out` directory:
+Once installed, point `cmd` to `server.js` inside the `out` directory:
 
 ```lua
-cmd = {'node', '<path_to_repo>/server/out/server.js', '--stdio'}
+cmd = {'node', '<path_to_azure_pipelines_install>/out/server.js', '--stdio'}
 ```
 
 By default `azure-pipelines-ls` will only work in files named `azure-pipelines.yml`, this can be changed by providing additional settings like so:

--- a/lua/lspconfig/server_configurations/azure_pipelines_ls.lua
+++ b/lua/lspconfig/server_configurations/azure_pipelines_ls.lua
@@ -14,10 +14,10 @@ https://github.com/microsoft/azure-pipelines-language-server
 
 An Azure Pipelines language server
 
-**By default, `azure-pipelines-language-server` doesn't have a `cmd` set.** This is because nvim-lspconfig does not make assumptions about your path.
+**By default, `azure-pipelines-ls` doesn't have a `cmd` set.** This is because nvim-lspconfig does not make assumptions about your path.
 You have to install the language server manually.
 
-`azure-pipelines-language-server` can be installed via `npm`:
+`azure-pipelines-ls` can be installed via `npm`:
 
 ```sh
 npm install -g azure-pipelines-language-server
@@ -29,9 +29,9 @@ Once installed, point `cmd` to `server.js` inside the `server/out` directory:
 cmd = {'node', '<path_to_repo>/server/out/server.js', '--stdio'}
 ```
 
-By default `azure-pipelines-language-server` will only work in files named `azure-pipelines.yml`, this can be changed by providing additional settings like so:
+By default `azure-pipelines-ls` will only work in files named `azure-pipelines.yml`, this can be changed by providing additional settings like so:
 ```lua
-require("lspconfig").azure_pipelines_language_server.setup {
+require("lspconfig").azure_pipelines_ls.setup {
   ... -- other configuration for setup {}
   settings = {
       yaml = {

--- a/lua/lspconfig/server_configurations/azure_pipelines_ls.lua
+++ b/lua/lspconfig/server_configurations/azure_pipelines_ls.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = {},
     filetypes = { 'yaml' },
-    root_dir = util.find_git_ancestor,
+    root_dir = util.root_pattern 'azure-pipelines.yml',
     single_file_support = true,
     settings = {},
   },


### PR DESCRIPTION
### Summary
This adds [microsoft's fork of yamlls](https://github.com/microsoft/azure-pipelines-language-server) which supports their custom parsing of some data values in their json specs providing better support for azure pipelines.

### Bullet Points
- Added `azure-pipelines-language-server`
- Ensured lint style followed via running `stylua **/*.lua && luacheck **/*.lua` in the repository

### Notes
This accompanies a PR to mason.nvim: [williamboman/mason.nvim#1604](https://github.com/williamboman/mason.nvim/pull/1064)

The full name of the lsp server is quite bulky, being `azure_pipelines_language_server`, and may need a renaming for users, maybe `azure_pipelines_lsp`?

### System and Environment Details 
I have tested and verified the server works on Linux with Neovim nightly, `NVIM v0.9.0 dev-1135+g419819b62`.

Config as passed to `lspconfig`:
```lua
local lsp_server_bin_dir = vim.fn.stdpath("data") .. "/mason/bin/"

require("lspconfig").azure_pipelines_ls.setup({
    cmd = { lsp_server_bin_dir .. "azure-pipelines-language-server", "--stdio" },
})
```
The server was installed using my PR branch to [`mason.nvim`](https://github.com/williamboman/mason.nvim/pull/1064), it can be installed otherwise with `npm install -g azure-pipelines-language-server` and then targeting its path with `node /PATH_TO_INSTALL/out/server.js --stdio`