### PR TITLE
feat: support Godot 4 port by default

### DIFF
--- a/lua/lspconfig/server_configurations/gdscript.lua
+++ b/lua/lspconfig/server_configurations/gdscript.lua
@@ -1,6 +1,6 @@
 local util = require 'lspconfig.util'
 
-local port = os.getenv 'GDScript_Port' or '6008'
+local port = os.getenv 'GDScript_Port' or '6005'
 local cmd = { 'nc', 'localhost', port }
 
 if vim.fn.has 'nvim-0.8' == 1 then


### PR DESCRIPTION
Godot 4 changed its default port. Since Godot 4 reached stable a few days ago, we should propose the stable version's port by default.