### PR TITLE
docs(arduino): mention upstream keywords bug

### DIFF
--- a/lua/lspconfig/server_configurations/arduino_language_server.lua
+++ b/lua/lspconfig/server_configurations/arduino_language_server.lua
@@ -79,6 +79,9 @@ Your folder structure should look like this:
 ```
 
 For further instruction about configuration options, run `arduino-language-server --help`.
+
+Note that an upstream bug makes keywords in some cases become undefined by the language server.
+Ref: https://github.com/arduino/arduino-ide/issues/159
 ]],
   },
 }


### PR DESCRIPTION

close #2434 