### PR TITLE
fix(lspinfo): set the lspinfo bufhidden to wipe

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -191,7 +191,7 @@ return function()
 
   local win_info = windows.percentage_range_window(0.8, 0.7)
   local bufnr, win_id = win_info.bufnr, win_info.win_id
-  vim.bo[bufnr].bufhidden = 'wipe'
+  api.nvim_buf_set_option(bufnr, 'bufhidden', 'wipe')
 
   local buf_lines = {}
 

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -191,7 +191,7 @@ return function()
 
   local win_info = windows.percentage_range_window(0.8, 0.7)
   local bufnr, win_id = win_info.bufnr, win_info.win_id
-  api.nvim_set_option_value('bufhidden', 'wipe', { buf = bufnr })
+  vim.bo[bufnr].bufhidden = 'wipe'
 
   local buf_lines = {}
 


### PR DESCRIPTION
api `nvim_set_option_value` not works on low neovim version.

close #2499 