### PR TITLE
feat: add root dir search by using vim.fs module

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -421,20 +421,19 @@ function M.server_per_root_dir_manager(make_config)
   return manager
 end
 
----using vim.fs module which enable in nvim 0.8 version
+---search path from start_path by match patterns, use vim.fs module.
 ---
 ---@param start_path string  current file path
 ---@param patterns table  search patterns
 ---@param ignore   boolean|nil when result include the start_path ignore it or not
 ---@private
-local function fs_searcher(start_path, patterns, ignore)
+local function fs_search(start_path, patterns, ignore)
   ignore = ignore or nil
   for _, pattern in pairs(patterns) do
     local result = vim.fs.find(
       pattern,
       { path = start_path, upward = true, stop = vim.env.HOME, type = 'directory', limit = math.huge }
     )
-    io.write(vim.inspect(result), start_path, ' ')
     if #result > 1 and ignore and vim.fs.dirname(result[1]) == start_path then
       return vim.fs.dirname(result[#result])
     elseif #result > 0 and not ignore then
@@ -452,7 +451,7 @@ function M.fs_root_pattern(patterns, ignore)
   }
   patterns = type(patterns) == 'string' and { patterns } or patterns
   return function(start_path)
-    return fs_searcher(start_path, patterns, ignore)
+    return fs_search(start_path, patterns, ignore)
   end
 end
 

--- a/test/lspconfig_spec.lua
+++ b/test/lspconfig_spec.lua
@@ -359,4 +359,22 @@ describe('lspconfig', function()
       )
     end)
   end)
+
+  describe('root_dir find by using vim.fs module', function()
+    it('ignore start_path', function()
+      ok(exec_lua [[
+        vim.api.nvim_command("cd ../test/")
+        local cwd = vim.fn.getcwd()
+        if vim.fn.isdirectory(cwd ..'/node_modules/') == 0 then
+          vim.fn.mkdir(cwd ..'/node_modules/')
+        end
+        if vim.fn.isdirectory(cwd ..'/test_dir/node_modules') == 0 then
+          vim.fn.mkdir(cwd..'/test_dir/node_modules/')
+        end
+        local lspconfig = require('lspconfig')
+        local root_dir = lspconfig.util.fs_node_modules_ancestor(cwd ..'/test_dir', true)()
+        return root_dir == cwd
+      ]])
+    end)
+  end)
 end)


### PR DESCRIPTION
Add new private function `fs_searcher` by  using `vim.fs` module that enable on nvim 0.8 version to search root dir , public two api functions based on `fs_searcher`.  
  - `lspconfig.util.fs_root_pattern` params is `patterns` string or table type , `ignore` boolean type which mean when the search restult has the current path( start_path param) ignore it or not 
  -  `lspconfig.util.fs_node_modules_ancestor`   params is `start_path` and `ignore`

more useful than old implement. but the `vim.fs` module only work on nvim 0.8+ so for some users who still use nvim 0.7 it's better not replace old implements .  replace time is when we wont support 0.7 in future.   also can fix below issues.

Relate issue #2449  #1908 