### PR TITLE
feat: single_file_support can be a function type

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -103,7 +103,7 @@ listed in `:help vim.lsp.start_client()` with the following unique entries:
 
 - {single_file_support}
 
-    `bool` (default: nil)
+    `bool` | `function` (default: nil)
 
     Determines if a server is started without a matching root directory.
     See |lspconfig-single-file-support|.

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -85,12 +85,19 @@ function configs.__newindex(t, config_name, config_def)
 
     local get_root_dir = config.root_dir
 
+    local function run_in_single(single)
+      vim.validate {
+        single = { single, { 'nil', 'b', 'f' } },
+      }
+      return (type(single) == 'boolean' or single == nil) and single or single()
+    end
+
     function M.launch()
       local root_dir
       if get_root_dir then
         local bufnr = api.nvim_get_current_buf()
         local bufname = api.nvim_buf_get_name(bufnr)
-        if #bufname == 0 and not config.single_file_support then
+        if #bufname == 0 and not run_in_single(config.single_file_support) then
           return
         elseif #bufname ~= 0 then
           if not util.bufname_valid(bufname) then
@@ -123,6 +130,9 @@ function configs.__newindex(t, config_name, config_def)
           end
         end
       elseif config.single_file_support then
+        if not run_in_single(config.single_file_support) then
+          return
+        end
         -- This allows on_new_config to use the parent directory of the file
         -- Effectively this is the root from lspconfig's perspective, as we use
         -- this to attach additional files in the same parent folder to the same server.
@@ -237,7 +247,7 @@ function configs.__newindex(t, config_name, config_def)
       local root_dir
 
       local bufname = api.nvim_buf_get_name(bufnr)
-      if #bufname == 0 and not config.single_file_support then
+      if #bufname == 0 and not run_in_single(config.single_file_support) then
         return
       elseif #bufname ~= 0 then
         if not util.bufname_valid(bufname) then
@@ -253,6 +263,9 @@ function configs.__newindex(t, config_name, config_def)
       if root_dir then
         manager.add(root_dir, false, bufnr)
       elseif config.single_file_support then
+        if not run_in_single(config.single_file_support) then
+          return
+        end
         local pseudo_root = #bufname == 0 and uv.cwd() or util.path.dirname(buf_path)
         manager.add(pseudo_root, true, bufnr)
       end


### PR DESCRIPTION
Problem:  if server set the `single_file_support` to true , this may cause a conflict when a filetype has two or above servers config which set `single_file_support` to true.  this filetype should be only start the server which match the root dir of current project.  the current behavior is other servers that set the `single_file_support` will also start and attach this buffer.

Solution:  make field `single_file_support` type support `function` then they can do some logic in this function to determine whether to attach or not in `single_file` mode.

After this pr:  can do it like this to avoid start tsserver in deno project.

```lua
lspconfig.denols.setup({
  root_dir = lspconfig.util.root_pattern("deno.json", "deno.jsonc"),
})

lspconfig.tsserver.setup({
  root_dir = lspconfig.util.root_pattern('package.json'),
  single_file_support = function()
    local cwd = vim.loop.cwd()
    if vim.fn.filereadable(cwd ..'/deno.json') == 0 then
      return true
    end
    return false
  end
})
```

Fix #2508 
Also Relate #2507 