### PR TITLE
fix(vls): add `v` as filetype

### DIFF
--- a/lua/lspconfig/server_configurations/vls.lua
+++ b/lua/lspconfig/server_configurations/vls.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'v', 'ls' },
-    filetypes = { 'vlang' },
+    filetypes = { 'v', 'vlang' },
     root_dir = util.root_pattern('v.mod', '.git'),
   },
   docs = {


### PR DESCRIPTION
Currently, there is a little conflict when working with `.v` filetypes between treesitter and nvim-lsp.
Treesitter will highlight files of file-type `v` while vls is requires filetype `vlang`. Instead of working around this issue i thought adding `v` as filetype is a proper solution.

I'll extend this request to related repos like mason if this is going to be merged.