### PR TITLE
fix(clojure_lsp): add support for babashka only projects

### DIFF
--- a/lua/lspconfig/server_configurations/clojure_lsp.lua
+++ b/lua/lspconfig/server_configurations/clojure_lsp.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'clojure-lsp' },
     filetypes = { 'clojure', 'edn' },
-    root_dir = util.root_pattern('project.clj', 'deps.edn', 'build.boot', 'shadow-cljs.edn', '.git'),
+    root_dir = util.root_pattern('project.clj', 'deps.edn', 'build.boot', 'shadow-cljs.edn', '.git', 'bb.edn'),
   },
   docs = {
     description = [[
@@ -13,7 +13,7 @@ https://github.com/clojure-lsp/clojure-lsp
 Clojure Language Server
 ]],
     default_config = {
-      root_dir = [[root_pattern("project.clj", "deps.edn", "build.boot", "shadow-cljs.edn", ".git")]],
+      root_dir = [[root_pattern("project.clj", "deps.edn", "build.boot", "shadow-cljs.edn", ".git", "bb.edn")]],
     },
   },
 }


### PR DESCRIPTION
This adds supports for clojure lsp correctly setting the project root for Babashka only projects.

[Babashka](https://babashka.org/) is a widely used, fully featured, native clojure runtime intended for fast start up and scripting. Clojure LSP has full support for it and this should make it a easier for people using the [project setup](https://book.babashka.org/#project-setup).