### PR TITLE
fix(graphql): fix crash on projects without graphql

### DIFF
--- a/lua/lspconfig/server_configurations/graphql.lua
+++ b/lua/lspconfig/server_configurations/graphql.lua
@@ -11,7 +11,7 @@ return {
   default_config = {
     cmd = cmd,
     filetypes = { 'graphql', 'typescriptreact', 'javascriptreact' },
-    root_dir = util.root_pattern('.git', '.graphqlrc*', '.graphql.config.*', 'graphql.config.*'),
+    root_dir = util.root_pattern('.graphqlrc*', '.graphql.config.*', 'graphql.config.*'),
   },
 
   docs = {
@@ -24,7 +24,7 @@ https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service-
 npm install -g graphql-language-service-cli
 ```
 
-Note that you must also have [the graphql package](https://github.com/graphql/graphql-js) installed and create a [GraphQL config file](https://www.graphql-config.com/docs/user/user-introduction).
+Note that you must also have [the graphql package](https://github.com/graphql/graphql-js) installed within your project and create a [GraphQL config file](https://the-guild.dev/graphql/config/docs).
 ]],
     default_config = {
       root_dir = [[util.root_pattern('.git', '.graphqlrc*', '.graphql.config.*', 'graphql.config.*')]],


### PR DESCRIPTION
The GraphQL language server needs a configuration file to initialise and the `graphql` package from NPM. Rooting on `.git` alone causes this server to repeatedly try opening and then close for each matching file type when it cannot find the config it is looking for.

See: https://the-guild.dev/graphql/codegen/docs/getting-started/installation#global-installation