### PR TITLE
feat: add PyrightSetPythonPath command to pyright config

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -6228,6 +6228,7 @@ require'lspconfig'.pyright.setup{}
 ```
 **Commands:**
 - PyrightOrganizeImports: Organize Imports
+- PyrightSetPythonPath: Reconfigure pyright with the provided python path
 
 **Default values:**
   - `cmd` : 

--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -6228,6 +6228,7 @@ require'lspconfig'.pyright.setup{}
 ```
 **Commands:**
 - PyrightOrganizeImports: Organize Imports
+- PyrightSetPythonPath: Reconfigure pyright with the provided python path
 
 **Default values:**
   - `cmd` : 

--- a/lua/lspconfig/server_configurations/pyright.lua
+++ b/lua/lspconfig/server_configurations/pyright.lua
@@ -24,6 +24,17 @@ local function organize_imports()
   vim.lsp.buf.execute_command(params)
 end
 
+local function set_python_path(path)
+  local clients = vim.lsp.get_active_clients {
+    bufnr = vim.api.nvim_get_current_buf(),
+    name = 'pyright',
+  }
+  for _, client in ipairs(clients) do
+    client.config.settings = vim.tbl_deep_extend('force', client.config.settings, { python = { pythonPath = path } })
+    client.notify('workspace/didChangeConfiguration', { settings = nil })
+  end
+end
+
 return {
   default_config = {
     cmd = cmd,
@@ -44,6 +55,12 @@ return {
     PyrightOrganizeImports = {
       organize_imports,
       description = 'Organize Imports',
+    },
+    PyrightSetPythonPath = {
+      set_python_path,
+      description = 'Reconfigure pyright with the provided python path',
+      nargs = 1,
+      complete = 'file',
     },
   },
   docs = {


### PR DESCRIPTION
The new command accepts a single path for a python executable that will be used to reconfigure the pyright language server. This is useful to change which python will be used by pyright without having to activate the python environment beforehand. The act of finding which python executable to use isn't handled here.