### PR TITLE
refactor(bashls): migrate to a workspace config

### DIFF
--- a/lua/lspconfig/server_configurations/bashls.lua
+++ b/lua/lspconfig/server_configurations/bashls.lua
@@ -10,12 +10,17 @@ end
 return {
   default_config = {
     cmd = cmd,
-    cmd_env = {
-      -- Prevent recursive scanning which will cause issues when opening a file
-      -- directly in the home directory (e.g. ~/foo.sh).
-      --
-      -- Default upstream pattern is "**/*@(.sh|.inc|.bash|.command)".
-      GLOB_PATTERN = vim.env.GLOB_PATTERN or '*@(.sh|.inc|.bash|.command)',
+    settings = {
+      bashIde = {
+        -- Glob pattern for finding and parsing shell script files in the workspace.
+        -- Used by the background analysis features across files.
+
+        -- Prevent recursive scanning which will cause issues when opening a file
+        -- directly in the home directory (e.g. ~/foo.sh).
+        --
+        -- Default upstream pattern is "**/*@(.sh|.inc|.bash|.command)".
+        globPattern = vim.env.GLOB_PATTERN or '*@(.sh|.inc|.bash|.command)',
+      },
     },
     filetypes = { 'sh' },
     root_dir = util.find_git_ancestor,


### PR DESCRIPTION
As suggested by upstream, see bash-lsp/bash-language-server#599
> Environment variable configuration is being deprecated, please use workspace configuration.
