### PR TITLE
fix(pyright): set `useLibraryCodeForTypes` to false

### DIFF
--- a/lua/lspconfig/server_configurations/pyright.lua
+++ b/lua/lspconfig/server_configurations/pyright.lua
@@ -45,7 +45,7 @@ return {
       python = {
         analysis = {
           autoSearchPaths = true,
-          useLibraryCodeForTypes = true,
+          useLibraryCodeForTypes = false,
           diagnosticMode = 'workspace',
         },
       },

--- a/lua/lspconfig/server_configurations/pyright.lua
+++ b/lua/lspconfig/server_configurations/pyright.lua
@@ -45,7 +45,6 @@ return {
       python = {
         analysis = {
           autoSearchPaths = true,
-          useLibraryCodeForTypes = false,
           diagnosticMode = 'workspace',
         },
       },


### PR DESCRIPTION
According to the official setting document, the default value of `python.analysis.useLibraryCodeForTypes` should be `false`. See [pyright/docs/settings.md](https://github.com/microsoft/pyright/blob/main/docs/settings.md)

When this option's value is true, it will significantly affect the completion speed of the code, and I hope to merge it as soon as possible.