### PR TITLE
fix: register workspace before attaching to buffer

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -338,8 +338,8 @@ function M.server_per_root_dir_manager(make_config)
       local supported = vim.tbl_get(client, 'server_capabilities', 'workspace', 'workspaceFolders', 'supported')
       local client_id
       if supported then
-        lsp.buf_attach_client(bufnr, client.id)
         register_workspace_folders(client)
+        lsp.buf_attach_client(bufnr, client.id)
         client_id = client.id
       else
         client_id = start_new_client()


### PR DESCRIPTION
## Description

Problem: workspace settings aren't shared until the buffer is refreshed

Solution: register/update workspace folders _before_ attaching to the buffer

### How to test

- open `lua/lspconfig/configs.lua`
- open another lua file in a different directory/workspace
- see how the workspace settings, e.g. `require` is a global keyword, are shared immediately without
  the need to refresh/re-enter the buffer (`:e`)
