### PR TITLE
Revert "fix(pyright): set `useLibraryCodeForTypes` to false"

### DIFF
--- a/lua/lspconfig/server_configurations/pyright.lua
+++ b/lua/lspconfig/server_configurations/pyright.lua
@@ -45,6 +45,7 @@ return {
       python = {
         analysis = {
           autoSearchPaths = true,
+          useLibraryCodeForTypes = true,
           diagnosticMode = 'workspace',
         },
       },


### PR DESCRIPTION
Reverts neovim/nvim-lspconfig#2522