### PR TITLE
ci: remove copy_directories input from luarocks-tag-release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,4 @@ jobs:
             This plugin allows for declaratively configuring,
             launching, and initializing language servers you have installed on your system.
             Language server configurations are community-maintained.
-          copy_directories: |
-            doc
           licence: "Apache/2.0"


### PR DESCRIPTION
It should no longer be needed as per
https://github.com/neovim/nvim-lspconfig/pull/2527#issuecomment-1484563558.
