### PR TITLE
fix(arduino_language_server): disable semantic tokens for arduino_language_server

### DIFF
--- a/lua/lspconfig/server_configurations/arduino_language_server.lua
+++ b/lua/lspconfig/server_configurations/arduino_language_server.lua
@@ -1,5 +1,9 @@
 local util = require 'lspconfig.util'
 
+local default_capabilities = vim.lsp.protocol.make_client_capabilities()
+default_capabilities.textDocument.semanticTokens = vim.NIL
+default_capabilities.workspace.semanticTokens = vim.NIL
+
 return {
   default_config = {
     filetypes = { 'arduino' },
@@ -7,6 +11,7 @@ return {
     cmd = {
       'arduino-language-server',
     },
+    capabilities = default_capabilities,
   },
   docs = {
     description = [[


### PR DESCRIPTION
arduino_language_server crash after the merge of [#21100](https://github.com/neovim/neovim/pull/21100) in neovim.
Disabling semantic tokens capabilities fix this issue.

I tested this changes on v0.8.4 release branch and  v0.9.0-dev-1295 master branch.
