### PR TITLE
docs(nil_ls): add a link to an example

### DIFF
--- a/lua/lspconfig/server_configurations/nil_ls.lua
+++ b/lua/lspconfig/server_configurations/nil_ls.lua
@@ -15,6 +15,8 @@ A new language server for Nix Expression Language.
 
 If you are using Nix with Flakes support, run `nix profile install github:oxalica/nil` to install.
 Check the repository README for more information.
+
+_See an example config at https://github.com/oxalica/nil/blob/main/dev/nvim-lsp.nix._
     ]],
     default_config = {
       root_dir = [[root_pattern("flake.nix", ".git")]],


### PR DESCRIPTION
Unlike `rnix` that configure to use `nixpkgs-fmt` by default `nil` doesn't set it up by default which requires explicit setting which would be helpful to see the example config to set it correctly, hence the link.

```lua
-- ...
settings = {
  ['nil'] = {
    formatting = {
      command = { 'nixpkgs-fmt' }, -- default is nil
    },
  },
},
-- ...
```