### PR TITLE
fix(dafny): add default cmd for Dafny 4

### DIFF
--- a/lua/lspconfig/server_configurations/dafny.lua
+++ b/lua/lspconfig/server_configurations/dafny.lua
@@ -2,6 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
+    cmd = { 'dafny', 'server' },
     filetypes = { 'dfy', 'dafny' },
     root_dir = function(fname)
       util.find_git_ancestor(fname)
@@ -10,11 +11,12 @@ return {
   },
   docs = {
     description = [[
-    NeoVim support for the Dafny language server.
-    Please follow the instructions and compile the language server from source:
-    https://github.com/dafny-lang/language-server-csharp
+    Support for the Dafny language server.
 
-    Note that there is no default cmd set. You must set it yourself. The recommended way is to use `{"dotnet", "<Path to your language server>"}`.
-]],
+    The default `cmd` uses "dafny server", which works on Dafny 4.0.0+. For
+    older versions of Dafny, you can compile the language server from source at
+    [dafny-lang/language-server-csharp](https://github.com/dafny-lang/language-server-csharp)
+    and set `cmd = {"dotnet", "<Path to your language server>"}`.
+    ]],
   },
 }


### PR DESCRIPTION
Dafny now ships with the language server, so a default `cmd` can be provided that will work out of the box if you have the latest version.