### PR TITLE
fix(sqls): deprecate sqls suggest sqlls instead

### DIFF
--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -33,7 +33,7 @@ function mt:__index(k)
   if configs[k] == nil then
     local alias = server_alias(k)
     if alias then
-      vim.deprecate(k, alias.to, alias.version, 'lspconfig')
+      vim.deprecate(k, alias.to, alias.version, 'lspconfig', false)
       k = alias.to
     end
 

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -12,6 +12,17 @@ function configs.__newindex(t, config_name, config_def)
     on_attach = { config_def.on_attach, 'f', true },
     commands = { config_def.commands, 't', true },
   }
+
+  if config_def.default_config.deprecate then
+    vim.deprecate(
+      config_name,
+      config_def.default_config.deprecate.to,
+      config_def.default_config.deprecate.version,
+      'lspconfig',
+      false
+    )
+  end
+
   if config_def.commands then
     for k, v in pairs(config_def.commands) do
       validate {

--- a/lua/lspconfig/server_configurations/sqls.lua
+++ b/lua/lspconfig/server_configurations/sqls.lua
@@ -7,6 +7,10 @@ return {
     root_dir = util.root_pattern 'config.yml',
     single_file_support = true,
     settings = {},
+    deprecate = {
+      to = 'sqlls',
+      version = '0.2.0',
+    },
   },
   docs = {
     description = [[


### PR DESCRIPTION
## Problem 
  [sqls](https://github.com/lighttiger2505/sqls) has been archived. 

## Solution
   add `deprecate` field in sqls config and show a notify when register this server to lspconfig and suggest use sqlls instead of.

Fix #2530 