### PR TITLE
fix: remove vim.schedule for on_attach

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -193,7 +193,7 @@ function configs.__newindex(t, config_name, config_def)
 
       -- Save the old _on_attach so that we can reference it via the BufEnter.
       new_config._on_attach = new_config.on_attach
-      new_config.on_attach = vim.schedule_wrap(function(client, bufnr)
+      new_config.on_attach = function(client, bufnr)
         if bufnr == api.nvim_get_current_buf() then
           M._setup_buffer(client.id, bufnr)
         else
@@ -209,7 +209,7 @@ function configs.__newindex(t, config_name, config_def)
             })
           end
         end
-      end)
+      end
 
       new_config.root_dir = root_dir
       new_config.workspace_folders = {


### PR DESCRIPTION
## Problem 
  currently add on_attach function inside the `vim.schedule` function this may break the `semantic_token` request 

## Solution
  remove `vim.schedule` wrap 

Fix #2542 