### PR TITLE
feat: add astro,svelte and vue to emmet_ls

### DIFF
--- a/lua/lspconfig/server_configurations/emmet_ls.lua
+++ b/lua/lspconfig/server_configurations/emmet_ls.lua
@@ -10,7 +10,7 @@ end
 return {
   default_config = {
     cmd = cmd,
-    filetypes = { 'html', 'typescriptreact', 'javascriptreact', 'css', 'sass', 'scss', 'less', 'eruby' },
+    filetypes = { 'astro', 'css', 'eruby', 'html', 'javascriptreact', 'less', 'sass', 'scss', 'typescriptreact', 'vue' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
   },

--- a/lua/lspconfig/server_configurations/emmet_ls.lua
+++ b/lua/lspconfig/server_configurations/emmet_ls.lua
@@ -10,7 +10,19 @@ end
 return {
   default_config = {
     cmd = cmd,
-    filetypes = { 'astro', 'css', 'eruby', 'html', 'javascriptreact', 'less', 'sass', 'scss', 'typescriptreact', 'vue' },
+    filetypes = {
+      'astro',
+      'css',
+      'eruby',
+      'html',
+      'javascriptreact',
+      'less',
+      'sass',
+      'scss',
+      'svelte',
+      'typescriptreact',
+      'vue',
+    },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
   },


### PR DESCRIPTION
Adds `astro`, `svelte` and `vue` support to the `emmet_ls` server configuration so that `*.astro`, `*.svelte` and `*.vue` can get completions.

(also I've sorted the filetypes)