### PR TITLE
docs: add visual mode in vim.lsp.buf.code_action section

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ vim.api.nvim_create_autocmd('LspAttach', {
     end, opts)
     vim.keymap.set('n', '<space>D', vim.lsp.buf.type_definition, opts)
     vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, opts)
-    vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, opts)
+    vim.keymap.set({ 'n', 'v' }, '<space>ca', vim.lsp.buf.code_action, opts)
     vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
     vim.keymap.set('n', '<space>f', function()
       vim.lsp.buf.format { async = true }


### PR DESCRIPTION
Problem: code_action support in visual more , this is missing in readme example config
Solution: add visual mode in example config.