### PR TITLE
feat: add `pug` to emmet_ls

### DIFF
--- a/lua/lspconfig/server_configurations/emmet_ls.lua
+++ b/lua/lspconfig/server_configurations/emmet_ls.lua
@@ -18,6 +18,7 @@ return {
       'htmldjango',
       'javascriptreact',
       'less',
+      'pug',
       'sass',
       'scss',
       'svelte',


### PR DESCRIPTION
Adds `pug` support to the `emmet_ls` server configuration so that `*.pug` files can get completions.