### PR TITLE
fix(eslint): get root patterns by given path

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -49,8 +49,6 @@ local root_file = {
   'eslint.config.js',
 }
 
-root_file = util.insert_package_json(root_file, 'eslintConfig')
-
 return {
   default_config = {
     cmd = cmd,
@@ -66,7 +64,10 @@ return {
       'astro',
     },
     -- https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats
-    root_dir = util.root_pattern(unpack(root_file)),
+    root_dir = function(fname)
+      root_file = util.insert_package_json(root_file, 'eslintConfig', fname)
+      return util.root_pattern(unpack(root_file))(fname)
+    end,
     -- Refer to https://github.com/Microsoft/vscode-eslint#settings-options for documentation.
     settings = {
       validate = 'on',

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -487,15 +487,16 @@ function M.find_package_json_ancestor(startpath)
   end)
 end
 
-function M.insert_package_json(config_files, field)
-  local root_with_package = M.find_package_json_ancestor(vim.fn.expand '%:p:h')
+function M.insert_package_json(config_files, field, fname)
+  local path = vim.fn.fnamemodify(fname, ':h')
+  local root_with_package = M.find_package_json_ancestor(path)
 
   if root_with_package then
     -- only add package.json if it contains field parameter
     local path_sep = is_windows and '\\' or '/'
     for line in io.lines(root_with_package .. path_sep .. 'package.json') do
       if line:find(field) then
-        table.insert(config_files, 'package.json')
+        config_files[#config_files + 1] = 'package.json'
         break
       end
     end


### PR DESCRIPTION
Problem: currently root patterns `package.json` file only check once. 
Solution: should check by given path when try to start server.

Fix #2554 