### PR TITLE
feat: allow sourcery for JS filetypes

### DIFF
--- a/lua/lspconfig/server_configurations/sourcery.lua
+++ b/lua/lspconfig/server_configurations/sourcery.lua
@@ -31,7 +31,7 @@ end
 return {
   default_config = {
     cmd = { 'sourcery', 'lsp' },
-    filetypes = { 'python' },
+    filetypes = { 'javascript', 'javascriptreact', 'python', 'typescript', 'typescriptreact' },
     init_options = {
       editor_version = 'vim',
       extension_version = 'vim.lsp',


### PR DESCRIPTION
Sourcery [released support for Javascript and Typescript](https://sourcery.ai/changelog/2023-04-14-2023-04-14/). So it makes sense to add those languages to the filetypes.