### PR TITLE
fix: vim.lsp.rpc.connect is not allowed in cmd

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -86,7 +86,7 @@ function configs.__newindex(t, config_name, config_def)
 
     local config = tbl_deep_extend('keep', user_config, default_config)
 
-    if config.cmd then
+    if config.cmd and type(config.cmd) == 'table' then
       local original = config.cmd[1]
       config.cmd[1] = vim.fn.exepath(config.cmd[1])
       if #config.cmd[1] == 0 then


### PR DESCRIPTION
I think only table need to expand

only allow table to expand. this will still allow `vim.lsp.rpc.connection`  to work