### PR TITLE
Docs: Update links in `rust_analyzer`

### DIFF
--- a/lua/lspconfig/server_configurations/rust_analyzer.lua
+++ b/lua/lspconfig/server_configurations/rust_analyzer.lua
@@ -81,7 +81,7 @@ https://github.com/rust-lang/rust-analyzer
 rust-analyzer (aka rls 2.0), a language server for Rust
 
 
-See [docs](https://github.com/rust-analyzer/rust-analyzer/tree/master/docs/user#settings) for extra settings. The settings can be used like this:
+See [docs](https://github.com/rust-lang/rust-analyzer/blob/master/docs/user/generated_config.adoc) for extra settings. The settings can be used like this:
 ```lua
 require'lspconfig'.rust_analyzer.setup{
   settings = {

--- a/lua/lspconfig/server_configurations/rust_analyzer.lua
+++ b/lua/lspconfig/server_configurations/rust_analyzer.lua
@@ -76,7 +76,7 @@ return {
   },
   docs = {
     description = [[
-https://github.com/rust-analyzer/rust-analyzer
+https://github.com/rust-lang/rust-analyzer
 
 rust-analyzer (aka rls 2.0), a language server for Rust
 


### PR DESCRIPTION
Updated the link to the `rust-analyzer` repo to the current location. Also, updated the link to the settings reference. The current link only takes us to the folder and not to any specific file.