### PR TITLE
fix(lspinfo): match server workspace

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -54,6 +54,7 @@ for group, hi in pairs {
   LspInfoTip = { link = 'Comment', default = true },
   LspInfoTitle = { link = 'Title', default = true },
   LspInfoFiletype = { link = 'Type', default = true },
+  LspInfoCurrentWorkspace = { link = 'Boolean', default = true },
 } do
   api.nvim_set_hl(0, group, hi)
 end


### PR DESCRIPTION
1. since we support reuse server by check `WorkspaceFolders`  show root not correctly .  now show all workspace Folders in lspinfo .  and make current workspace as first and highlight it . 
2.  add current buffer in title and make it highlight.

when have two projects in `lua_ls` 

![image](https://github.com/neovim/nvim-lspconfig/assets/41671631/f9519051-9473-4211-8a39-9c6872f8fc6d)
