### PR TITLE
feat(LspconfigServerLifeCycle): stop/start server upon demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ See [server_configurations.md](doc/server_configurations.md) (`:help lspconfig-a
 nvim-lspconfig does not set keybindings or enable completion by default. The following example configuration provides suggested keymaps for the most commonly used language server functions, and manually triggered completion with omnifunc (\<c-x\>\<c-o\>).
 
 ```lua
+-- Uncomment to automatically start/stop servers when nvim is idle (non-focused) 
+-- See :h lspconfig-lifecycle for details
+-- vim.g.lspconfigServerLifeCycle = { timeout = 1000 * 60 * 30 }
+
 -- Setup language servers.
 local lspconfig = require('lspconfig')
 lspconfig.pyright.setup {}

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -473,6 +473,28 @@ contained in `:LspInfo`:
   will attempt to reattach to all previously attached buffers.
 
 ==============================================================================
+SERVER LIFECYCLE MANAGEMENT                                *lspconfig-lifecycle*
+
+`lspconfig` may automatically stop or restart workspace LSP servers by using 
+`:LspStart` / `:LspStop` commands. When `nvim` loses focus it will automatically
+stop buffer-bound LSP server upon clearing timeout threshold and restart
+otherwise. 
+
+Disabled by default. To turn it on set the following global config option.
+Make sure it's set before |load-plugins| cycle and any |lspconfig-setup|.
+
+>
+  -- Table is expected
+  vim.g.lspconfigServerLifeCycle = {
+    -- ms before server is stopped (30 minutes by default)
+    timeout = 1000 * 60 * 30
+  }
+  ...
+  local lspconfig = require('lspconfig')
+  ....
+
+
+==============================================================================
 EXAMPLE KEYBINDINGS                                      *lspconfig-keybindings*
 
 `lspconfig`, and the core client, do not map any keybindings by default. The

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -150,3 +150,54 @@ api.nvim_create_user_command('LspLog', function()
 end, {
   desc = 'Opens the Nvim LSP client log.',
 })
+
+--- Start/stop servers when nvim session looses focus and restart them on demand.
+-- This features is motivated by the fact that some servers may gain serious
+-- memory footprint and may incur performance issues. Added on May 12, 2023
+vim.api.nvim_create_augroup('LspconfigServerLifeCycle', { clear = true })
+vim.api.nvim_create_autocmd({
+  'FocusGained',
+}, {
+  pattern = '*',
+  group = 'LspconfigServerLifeCycle',
+  desc = 'Lspconfig: restart halted lsp servers for given',
+  callback = function()
+    if _G.nvimLspconfigTimer then
+      _G.nvimLspconfigTimer:stop()
+      _G.nvimLspconfigTimer:close()
+      _G.nvimLspconfigTimer = nil
+    end
+    if #vim.lsp.get_active_clients() <= 1 then
+      vim.cmd 'LspStart'
+    end
+  end,
+})
+
+vim.api.nvim_create_autocmd({
+  'FocusLost',
+}, {
+  pattern = '*',
+  group = 'LspconfigServerLifeCycle',
+  desc = 'Lspconfig: halt lsp servers when focus is lost',
+  callback = function()
+    if not _G.nvimLspconfigTimer and #vim.lsp.get_active_clients() > 0 then
+      local timeout = 1000 * 60 * 5 -- 5 minutes
+      _G.nvimLspconfigTimer = vim.loop.new_timer()
+      _G.nvimLspconfigTimer:start(
+        timeout,
+        0,
+        vim.schedule_wrap(function()
+          local activeServers = #vim.lsp.get_active_clients()
+          vim.cmd 'LspStop'
+          vim.notify(
+            ('[lspconfig]: nvim has lost focus, stop current language servers. Number of servers left: %s'):format(
+              activeServers
+            ),
+            vim.log.levels.INFO
+          )
+          _G.nvimLspconfigTimer = nil
+        end)
+      )
+    end
+  end,
+})


### PR DESCRIPTION
Start/stop servers when nvim session looses focus and restart them on demand.
This features is motivated by the fact that some servers may gain serious
memory footprint and may incur performance issues.