### PR TITLE
feat: Enable F# LSP for *.fsx files on any folder

### DIFF
--- a/lua/lspconfig/server_configurations/fsautocomplete.lua
+++ b/lua/lspconfig/server_configurations/fsautocomplete.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'fsautocomplete', '--adaptive-lsp-server-enabled' },
-    root_dir = util.root_pattern('*.sln', '*.fsproj', '.git'),
+    root_dir = util.root_pattern('*.sln', '*.fsproj', '*.fsx', '.git'),
     filetypes = { 'fsharp' },
     init_options = {
       AutomaticWorkspaceInit = true,


### PR DESCRIPTION
I have used this config for some time. I think that can be added to the default configs, since I didn't notice drawbacks:

```lua
local util = require 'lspconfig.util'
lspconfig.fsautocomplete.setup({
    on_attach = my_on_attach,
    root_dir = util.root_pattern('*.sln', '*.fsproj', '.git', '*.fsx'),
    capabilities = my_capabilities,
    filetypes = { 'fsharp' }
})
```