### PR TITLE
feat(texlab): send position when building

### DIFF
--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -17,8 +17,10 @@ local texlab_forward_status = vim.tbl_add_reverse_lookup {
 local function buf_build(bufnr)
   bufnr = util.validate_bufnr(bufnr)
   local texlab_client = util.get_active_client_by_name(bufnr, 'texlab')
+  local pos = vim.api.nvim_win_get_cursor(0)
   local params = {
     textDocument = { uri = vim.uri_from_bufnr(bufnr) },
+    position = { line = pos[1] - 1, character = pos[2] },
   }
   if texlab_client then
     texlab_client.request('textDocument/build', params, function(err, result)
@@ -35,9 +37,10 @@ end
 local function buf_search(bufnr)
   bufnr = util.validate_bufnr(bufnr)
   local texlab_client = util.get_active_client_by_name(bufnr, 'texlab')
+  local pos = vim.api.nvim_win_get_cursor(0)
   local params = {
     textDocument = { uri = vim.uri_from_bufnr(bufnr) },
-    position = { line = vim.fn.line '.' - 1, character = vim.fn.col '.' },
+    position = { line = pos[1] - 1, character = pos[2] },
   }
   if texlab_client then
     texlab_client.request('textDocument/forwardSearch', params, function(err, result)


### PR DESCRIPTION
Since Texlab v5.5.0, `textDocument/build` accepts `position` argument, which is going to be used if forwardSearchAfter is enabled. Using Texlab <5.5.0 it's not an issue, the argument gets skipped and no error is thrown. Same happens if forwardSearchAfter is not enabled.