### PR TITLE
fix(sourcekit): add buildserver.json and compile_commands as root pattern

### DIFF
--- a/lua/lspconfig/server_configurations/sourcekit.lua
+++ b/lua/lspconfig/server_configurations/sourcekit.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'sourcekit-lsp' },
     filetypes = { 'swift', 'c', 'cpp', 'objective-c', 'objective-cpp' },
-    root_dir = util.root_pattern('Package.swift', '.git'),
+    root_dir = util.root_pattern('Package.swift', 'buildServer.json', 'compile_commands.json', '.git'),
   },
   docs = {
     description = [[


### PR DESCRIPTION
Fix #2619 