### PR TITLE
fix: ruby lsp features should be opt-out

### DIFF
--- a/lua/lspconfig/server_configurations/ruby_ls.lua
+++ b/lua/lspconfig/server_configurations/ruby_ls.lua
@@ -6,14 +6,6 @@ return {
     filetypes = { 'ruby' },
     root_dir = util.root_pattern('Gemfile', '.git'),
     init_options = {
-      enabledFeatures = {
-        'codeActions',
-        'diagnostics',
-        'documentHighlights',
-        'documentSymbols',
-        'formatting',
-        'inlayHint',
-      },
       formatter = 'auto',
     },
   },


### PR DESCRIPTION
Without the `enabledFeatures` init option, ruby lsp would enable all the supported features. This change was introduced in https://github.com/Shopify/ruby-lsp/pull/562
