### PR TITLE
fix(unocss): detect also uno.config

### DIFF
--- a/lua/lspconfig/server_configurations/unocss.lua
+++ b/lua/lspconfig/server_configurations/unocss.lua
@@ -12,7 +12,7 @@ return {
       'svelte',
     },
     root_dir = function(fname)
-      return util.root_pattern('unocss.config.js', 'unocss.config.ts')(fname)
+      return util.root_pattern('unocss.config.js', 'unocss.config.ts', 'uno.config.js', 'uno.config.ts')(fname)
     end,
   },
   docs = {
@@ -25,7 +25,7 @@ npm i unocss-language-server -g
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern('unocss.config.js', 'unocss.config.ts')]],
+      root_dir = [[root_pattern('unocss.config.js', 'unocss.config.ts', 'uno.config.js', 'uno.config.ts')]],
     },
   },
 }


### PR DESCRIPTION
:wave: A simple fix, UnoCSS last month decided to change the config filename from `unocss.config.js`/`unocss.config.ts` to `uno.config.js`/`uno.config.ts` so I added them to the root pattern matches.

I am trying to understand why this change has been made, [the commit](https://github.com/unocss/unocss/commit/174381f73cb56943f7343fb2392c484edec32d1e) itself doesn't explain why this change has been made and according to [the docs](https://unocss.dev/guide/config-file) both files are supported by default so I think that supporting both is the right call.