### PR TITLE
docs: update URL for bash-language-server repo

### DIFF
--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -896,7 +896,7 @@ require'lspconfig'.azure_pipelines_ls.setup{}
 
 ## bashls
 
-https://github.com/mads-hartmann/bash-language-server
+https://github.com/bash-lsp/bash-language-server
 
 `bash-language-server` can be installed via `npm`:
 ```sh

--- a/lua/lspconfig/server_configurations/bashls.lua
+++ b/lua/lspconfig/server_configurations/bashls.lua
@@ -21,7 +21,7 @@ return {
   },
   docs = {
     description = [[
-https://github.com/mads-hartmann/bash-language-server
+https://github.com/bash-lsp/bash-language-server
 
 `bash-language-server` can be installed via `npm`:
 ```sh


### PR DESCRIPTION
It wasn't clear to me from the docs if `lua/lspconfig/server_configurations/bashls.lua` should be included in this PR.