### PR TITLE
docs(zk): consistent commands description

### DIFF
--- a/lua/lspconfig/server_configurations/zk.lua
+++ b/lua/lspconfig/server_configurations/zk.lua
@@ -14,7 +14,7 @@ return {
           arguments = { vim.api.nvim_buf_get_name(0) },
         }
       end,
-      description = 'Index',
+      description = 'ZkIndex',
     },
     ZkNew = {
       function(...)


### PR DESCRIPTION
Commands description for all servers allways start with the name of the server. Keep it consistent in zk.

See <https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md> and `<ctrl-f>Commands:` to verfied that all commands start with server name.