### PR TITLE
feat: add pest_ls support

### DIFF
--- a/lua/lspconfig/server_configurations/pest_ls.lua
+++ b/lua/lspconfig/server_configurations/pest_ls.lua
@@ -1,0 +1,17 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'pest-language-server' },
+    filetypes = { 'pest' },
+    root_dir = util.find_git_ancestor,
+    single_file_support = true,
+  },
+  docs = {
+    description = [[
+https://github.com/pest-parser/pest-ide-tools
+
+Language server for pest grammars.
+]],
+  },
+}


### PR DESCRIPTION
Adds support for [pest-language-server](https://github.com/pest-parser/pest-ide-tools). Towards https://github.com/pest-parser/pest-ide-tools/issues/10

- [x] ran lints
- [x] tested by installing locally and opened a .pest file