### PR TITLE
fix(blueprint_ls): remove non-existent subcommand

### DIFF
--- a/lua/lspconfig/server_configurations/blueprint_ls.lua
+++ b/lua/lspconfig/server_configurations/blueprint_ls.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'blueprint-compiler', vim.fn.has 'win32' and 'start' or 'lsp' },
+    cmd = { 'blueprint-compiler', 'lsp' },
     cmd_env = {
       -- Prevent recursive scanning which will cause issues when opening a file
       -- directly in the home directory (e.g. ~/foo.sh).


### PR DESCRIPTION
The blueprint-compiler doesn't have a "start" subcommand. And the condition in the cmd was incorrect as in lua any number, including 0, is truthy meaning it was always executing `blueprint-compiler start`, which is incorrect and thus blueprint_ls was unusable.