### PR TITLE
feat: implement workspace

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -264,7 +264,7 @@ function M.server_per_root_dir_manager(make_config)
     local function register_workspace_folders(client)
       local params = {
         event = {
-          added = { { uri = vim.uri_from_fname(root_dir), name = root_dir } },
+          added = { { uri = vim.uri_from_fname(root_dir), name = M.workspace.current } },
           removed = {},
         },
       }
@@ -317,6 +317,10 @@ function M.server_per_root_dir_manager(make_config)
       if single_file then
         new_config.root_dir = nil
         new_config.workspace_folders = nil
+      else
+        new_config.workspace_folders = {
+          { uri = vim.uri_from_fname(root_dir), name = M.workspace.current },
+        }
       end
       local client_id = lsp.start_client(new_config)
       if not client_id then
@@ -326,7 +330,7 @@ function M.server_per_root_dir_manager(make_config)
     end
 
     local function attach_or_spawn(client)
-      local space = M.workspace:find_space_by_client(client.id)
+      local space = M.workspace:find_space(client.id)
       if space and space == M.workspace.current then
         return attach_and_cache(root_dir, client.id)
       end

--- a/lua/lspconfig/workspace.lua
+++ b/lua/lspconfig/workspace.lua
@@ -1,0 +1,114 @@
+local wk = {}
+
+local function box()
+  local tbl = {}
+  tbl.__index = tbl
+  function tbl.__newindex(t, k, v)
+    rawset(t, k, v)
+  end
+
+  function tbl:list()
+    local res = {}
+    for _, item in ipairs(self) do
+      res[#res + 1] = item
+    end
+    return res
+  end
+
+  function tbl:append(tuple)
+    if not vim.tbl_contains(self, tuple) then
+      self[#self + 1] = tuple
+    end
+  end
+
+  function tbl:get(root_name)
+    for _, tuple in ipairs(self) do
+      if tuple[1] == root_name then
+        return tuple
+      end
+    end
+  end
+
+  function tbl:remove(name)
+    for idx, item in ipairs(self) do
+      if name == item then
+        table.remove(self, idx)
+        break
+      end
+    end
+  end
+
+  return tbl
+end
+
+function wk:create(name)
+  if self[name] then
+    vim.notify(string.format('[lspconfig] workspace %s already exist', name), vim.log.levels.WARN)
+    return
+  end
+  self[name] = setmetatable({}, box())
+  rawset(wk, 'current', name)
+end
+
+function wk:new()
+  local o = {}
+  o.default = setmetatable({}, box())
+  setmetatable(o, self)
+  self.__index = self
+  self.current = 'default'
+  return o
+end
+
+function wk:change(name)
+  if not self[name] then
+    self:create(name)
+  end
+  rawset(wk, 'current', name)
+end
+
+function wk:remove(name)
+  self[name] = nil
+end
+
+function wk:all_list()
+  local res = {}
+  for k, v in pairs(self) do
+    res[k] = {}
+    for _, item in ipairs(v) do
+      table.insert(res[k], item)
+    end
+  end
+  print(vim.inspect(res))
+end
+
+function wk:find_space_by_client(client_id)
+  for space, data in pairs(self) do
+    for _, tuple in ipairs(data) do
+      if vim.tbl_contains(tuple, client_id) then
+        return space
+      end
+    end
+  end
+end
+
+function wk:get_all_clients()
+  local res = {}
+  for _, data in pairs(self) do
+    vim.tbl_map(function(tuple)
+      for i = 2, #tuple do
+        res[#res + 1] = vim.lsp.get_client_by_id(tuple[i])
+      end
+    end, data)
+  end
+  return res
+end
+
+local function workspace_init()
+  local instance = wk:new()
+  instance:change 'default'
+  return instance
+end
+
+return {
+  workspace_init = workspace_init,
+}

--- a/lua/lspconfig/workspace.lua
+++ b/lua/lspconfig/workspace.lua
@@ -81,11 +81,15 @@ function wk:all_list()
   print(vim.inspect(res))
 end
 
-function wk:find_space_by_client(client_id)
+function wk:find_space(client_id, root)
   for space, data in pairs(self) do
     for _, tuple in ipairs(data) do
       if vim.tbl_contains(tuple, client_id) then
-        return space
+        if root and tuple[1] == root then
+          return space
+        else
+          return space
+        end
       end
     end
   end
@@ -104,9 +108,7 @@ function wk:get_all_clients()
 end
 
 local function workspace_init()
-  local instance = wk:new()
-  instance:change 'default'
-  return instance
+  return wk:new()
 end
 
 return {

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -151,3 +151,17 @@ api.nvim_create_user_command('LspLog', function()
 end, {
   desc = 'Opens the Nvim LSP client log.',
 })
+
+api.nvim_create_user_command('LspWorkspaceList', function()
+  require('lspconfig.util').workspace:all_list()
+end, {
+  desc = 'Show all workspaces',
+})
+
+api.nvim_create_user_command('LspWorkspaceAdd', function(arg)
+  local name = arg.args
+  require('lspconfig.util').workspace:create(name)
+end, {
+  nargs = '+',
+  desc = 'Create a workspace',
+})

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -54,6 +54,7 @@ for group, hi in pairs {
   LspInfoTip = { link = 'Comment', default = true },
   LspInfoTitle = { link = 'Title', default = true },
   LspInfoFiletype = { link = 'Type', default = true },
+  LspInfoCurrentWorkspace = { link = 'Boolean', default = true },
 } do
   api.nvim_set_hl(0, group, hi)
 end


### PR DESCRIPTION
The workspace of vscode does not exist in neovim. It is also not possible to simply set a workspace for each root. This is wrong behavior. So I implemented the concept of a workspace in lspconfig. The way it works is. You can create multiple worksapce. A default space is automatically created when the first project is opened. If you don't change the workspace. All open projects will belong to the default space. When you open the project after changing the workspace shown, it will check whether the server supports the workspace_folder feature. Send didchangeworkspacefolder notification if supported. Re-use the server. Otherwise a new server instance will be started.

eg: when open first file which will spawn a server then workspace is 

```
{ defaule = {  {ProjectA , client.id} --a tuple } }
```
run `LspWorkspaceAdd myspace` this will create a new workspace and change current workspace to `myspace`  then open a project it will be

```
{
  defaule = {  {ProjectA , client.id} --a tuple },
  myspace = { {ProjectB , client.id } }
}
```
- [ ] add test case
- [ ] write doc for new workspace

Ref: 
1. https://code.visualstudio.com/docs/editor/workspaces
2. https://github.com/emacs-lsp/lsp-mode/discussions/3095
3. https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_workspaceFolders

Fix #2518 