### PR TITLE
fix(astro): update astro config for @astrojs/language-server v2.0.0

### DIFF
--- a/lua/lspconfig/server_configurations/astro.lua
+++ b/lua/lspconfig/server_configurations/astro.lua
@@ -12,18 +12,11 @@ return {
     filetypes = { 'astro' },
     root_dir = util.root_pattern('package.json', 'tsconfig.json', 'jsconfig.json', '.git'),
     init_options = {
-      typescript = {
-        serverPath = '',
-      },
-      configuration = {},
+      typescript = {},
     },
     on_new_config = function(new_config, new_root_dir)
-      if
-        new_config.init_options
-        and new_config.init_options.typescript
-        and new_config.init_options.typescript.serverPath == ''
-      then
-        new_config.init_options.typescript.serverPath = get_typescript_server_path(new_root_dir)
+      if vim.tbl_get(new_config.init_options, 'typescript') and not new_config.init_options.typescript.tsdk then
+        new_config.init_options.typescript.tsdk = get_typescript_server_path(new_root_dir)
       end
     end,
   },


### PR DESCRIPTION
`@astrojs/language-server@2.0.0` utilizes Volar language server under the hood. The LSP's init_options are located [here][1]. `typescript.serverPath` has been renamed to `typescript.tsdk`. There is no `configuration`; that option is for the VSCode extension, located in the `astro-vscode` package [here][2].

[1]: https://github.com/volarjs/volar.js/blob/dfc8ccefb6c3aa53bd0eb9755259538a11127edd/packages/language-server/src/types.ts#L50
[2]: https://github.com/withastro/language-tools/blob/eb2ce0b3effd00e49294be57ef0f3d1cb5f8f454/packages/vscode/package.json#L126