### PR TITLE
fix(astro): correct the typescript.tsdk path

### DIFF
--- a/lua/lspconfig/server_configurations/astro.lua
+++ b/lua/lspconfig/server_configurations/astro.lua
@@ -2,8 +2,7 @@ local util = require 'lspconfig.util'
 
 local function get_typescript_server_path(root_dir)
   local project_root = util.find_node_modules_ancestor(root_dir)
-  return project_root and (util.path.join(project_root, 'node_modules', 'typescript', 'lib', 'tsserverlibrary.js'))
-    or ''
+  return project_root and (util.path.join(project_root, 'node_modules', 'typescript', 'lib')) or ''
 end
 
 return {


### PR DESCRIPTION
It's supposed to be a path to the TypeScript server folder, not a file.

Astro LSP should work now. Tested it this time.

Fixes https://github.com/withastro/language-tools/issues/559