### PR TITLE
docs(lua_ls): add `lua/` to runtime.path of lua_ls

### DIFF
--- a/lua/lspconfig/server_configurations/lua_ls.lua
+++ b/lua/lspconfig/server_configurations/lua_ls.lua
@@ -54,14 +54,18 @@ require'lspconfig'.lua_ls.setup {
       runtime = {
         -- Tell the language server which version of Lua you're using (most likely LuaJIT in the case of Neovim)
         version = 'LuaJIT',
-      },
-      diagnostics = {
-        -- Get the language server to recognize the `vim` global
-        globals = {'vim'},
+        -- Also searches for lua/ as Neovim does
+        path = {
+          '?.lua',
+          '?/init.lua',
+          'lua/?.lua',
+          'lua/?/init.lua',
+        },
       },
       workspace = {
         -- Make the server aware of Neovim runtime files
-        library = vim.api.nvim_get_runtime_file("", true),
+        -- Note: some plugin managers do not set run time paths early enough
+        library = vim.api.nvim_list_runtime_paths(),
       },
       -- Do not send telemetry data containing a randomized but unique identifier
       telemetry = {


### PR DESCRIPTION
I'm not pretty sure about how `package.path` works in Nvim. But this does improve the experience of editing Nvim config.

P.S.
Would it be better to put all these into something like `~/.config/nvim/.luarc.json` so that it would not contaminate other lua project, it doesn't seem to be possible though for that vim.api.nvim_get_...