### PR TITLE
feat: consider .mjs and .cjs in tailwindcss root_pattern

### DIFF
--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -98,11 +98,13 @@ return {
       end
     end,
     root_dir = function(fname)
-      return util.root_pattern('tailwind.config.js', 'tailwind.config.ts')(fname)
-        or util.root_pattern('postcss.config.js', 'postcss.config.ts')(fname)
-        or util.find_package_json_ancestor(fname)
-        or util.find_node_modules_ancestor(fname)
-        or util.find_git_ancestor(fname)
+      return util.root_pattern('tailwind.config.js', 'tailwind.config.cjs', 'tailwind.config.mjs', 'tailwind.config.ts')(
+        fname
+      ) or util.root_pattern('postcss.config.js', 'postcss.config.cjs', 'postcss.config.mjs', 'postcss.config.ts')(
+        fname
+      ) or util.find_package_json_ancestor(fname) or util.find_node_modules_ancestor(fname) or util.find_git_ancestor(
+        fname
+      )
     end,
   },
   docs = {
@@ -115,7 +117,7 @@ npm install -g @tailwindcss/language-server
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern('tailwind.config.js', 'tailwind.config.ts', 'postcss.config.js', 'postcss.config.ts', 'package.json', 'node_modules', '.git')]],
+      root_dir = [[root_pattern('tailwind.config.js', 'tailwind.config.cjs', 'tailwind.config.mjs', 'tailwind.config.ts', 'postcss.config.js', 'postcss.config.cjs', 'postcss.config.mjs', 'postcss.config.ts', 'package.json', 'node_modules', '.git')]],
     },
   },
 }


### PR DESCRIPTION
Also consider `.mjs` and `.cjs` extensions in Tailwind CSS language server's `root_pattern`.