### PR TITLE
feat: add Astro's class:list in tailwind class attributes

### DIFF
--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -80,6 +80,7 @@ return {
         classAttributes = {
           'class',
           'className',
+          'class:list',
           'classList',
           'ngClass',
         },


### PR DESCRIPTION
Add Astro's [`class:list`](https://docs.astro.build/en/reference/directives-reference/#classlist) in Tailwind's settings classAttributes.