### PR TITLE
feat(rust_analyzer): register serverStatus capability

### DIFF
--- a/lua/lspconfig/server_configurations/rust_analyzer.lua
+++ b/lua/lspconfig/server_configurations/rust_analyzer.lua
@@ -60,6 +60,14 @@ local function is_library(fname)
   end
 end
 
+local function register_cap()
+  local capabilities = vim.lsp.protocol.make_client_capabilities()
+  capabilities.experimental = {
+    serverStatusNotification = true,
+  }
+  return capabilities
+end
+
 return {
   default_config = {
     cmd = { 'rust-analyzer' },
@@ -88,6 +96,7 @@ return {
         or util.root_pattern 'rust-project.json'(fname)
         or util.find_git_ancestor(fname)
     end,
+    capabilities = register_cap(),
   },
   commands = {
     CargoReload = {


### PR DESCRIPTION
register `serverStatusNotification` capability . `rust analyzer` custom notify method called `experimental/serverStatus`. useful to show rust_analyzer status on statusline. usage  on config . need create a lsp handler for this method like this 

```lua
vim.lsp.handlers['experimental/serverStatus'] = function(_, result)
  print('Received serverStatus notification:', vim.inspect(result))
end
```

output of this method will be like

```
Received serverStatus notification: nil
Received serverStatus notification: {
  health = "ok",
  quiescent = false
}
Received serverStatus notification: nil
Received serverStatus notification: {
  health = "ok",
  quiescent = true
}
```

Ref doc https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#server-status