### PR TITLE
fix(vtsls): remove extra backticks in description

### DIFF
--- a/lua/lspconfig/server_configurations/vtsls.lua
+++ b/lua/lspconfig/server_configurations/vtsls.lua
@@ -30,7 +30,6 @@ To configure a Typescript project, add a
 [`tsconfig.json`](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html)
 or [`jsconfig.json`](https://code.visualstudio.com/docs/languages/jsconfig) to
 the root of your project.
-```
 ]],
     default_config = {
       root_dir = [[root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")]],


### PR DESCRIPTION
Extra backticks in the description cause the `server_configurations.md` to look like this
![image](https://github.com/neovim/nvim-lspconfig/assets/36294070/599ec93b-9b13-4072-8b83-2c1357cf4471)


After the fix
![image](https://github.com/neovim/nvim-lspconfig/assets/36294070/04113864-fc9b-4311-bb78-dc0309b1f18d)
