### PR TITLE
Add support for gjs and gts files for the ember language server

### DIFF
--- a/lua/lspconfig/server_configurations/ember.lua
+++ b/lua/lspconfig/server_configurations/ember.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'ember-language-server', '--stdio' },
-    filetypes = { 'handlebars', 'typescript', 'javascript' },
+    filetypes = { 'handlebars', 'typescript', 'javascript', 'typescript.glimmer', 'javascript.glimmer' },
     root_dir = util.root_pattern('ember-cli-build.js', '.git'),
   },
   docs = {


### PR DESCRIPTION
As an aside, I need to add a second root_dir pattern -- is there a way to have two root_patterns?

or is that what the args are in util.root_pattern? if first not found, use second? 