### PR TITLE
perf(gopls): lazy cache initialization

### DIFF
--- a/lua/lspconfig/server_configurations/gopls.lua
+++ b/lua/lspconfig/server_configurations/gopls.lua
@@ -1,12 +1,15 @@
 local util = require 'lspconfig.util'
 
-local mod_cache = vim.trim(vim.fn.system 'go env GOMODCACHE')
+local mod_cache = nil
 
 return {
   default_config = {
     cmd = { 'gopls' },
     filetypes = { 'go', 'gomod', 'gowork', 'gotmpl' },
     root_dir = function(fname)
+      if mod_cache == nil then
+        mod_cache = vim.trim(vim.fn.system 'go env GOMODCACHE')
+      end
       -- see: https://github.com/neovim/nvim-lspconfig/issues/804
       if fname:sub(1, #mod_cache) == mod_cache then
         local clients = vim.lsp.get_active_clients { name = 'gopls' }


### PR DESCRIPTION
On my machine, prior to this patch, gopls requires more than 38ms to
load (even after multiple starts of neovim):
```
077.729  038.355  038.355: require('lspconfig.server_configurations.gopls')
```
while the other servers take tens of millisecond.

After implementing this change, gopls takes about the same time as the
others:
```
033.563  000.163  000.163: require('lspconfig.server_configurations.gopls')
```

I have tried to replace `go env GOMODCACHE` with
`echo /home/cjoly/go/pkg/mod` but it’s just as slow. I suspect that the
call to `system()` is so slow because I use the fish shell. If I change
the 'shell' setting to 'sh', the issue disappears. Nonetheless, it’s
probably worth fixing, since this change is not very complex IMO, even
if my configuration is somewhat exotic.

I’ve checked that this change does not make using the 'sh' shell slower
and that the LSP still initializes properly.
