### PR TITLE
fix(command): LspRestart should attached before buffers

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -116,8 +116,8 @@ function configs.__newindex(t, config_name, config_def)
 
     local get_root_dir = config.root_dir
 
-    function M.launch()
-      local bufnr = api.nvim_get_current_buf()
+    function M.launch(bufnr)
+      bufnr = bufnr or api.nvim_get_current_buf()
       local bufname = api.nvim_buf_get_name(bufnr)
       if (#bufname == 0 and not config.single_file_support) or (#bufname ~= 0 and not util.bufname_valid(bufname)) then
         return


### PR DESCRIPTION
Problem:  Now LspRestart call `launch` it use current buffer 
Solution: make it receive buffer param then new client attached before buffers

Fix #2670 