### PR TITLE
fix(rust_analyzer): use RUSTUP_HOME in library check

### DIFF
--- a/lua/lspconfig/server_configurations/rust_analyzer.lua
+++ b/lua/lspconfig/server_configurations/rust_analyzer.lua
@@ -51,7 +51,10 @@ end
 local function is_library(fname)
   local cargo_home = os.getenv 'CARGO_HOME' or util.path.join(vim.env.HOME, '.cargo')
   local registry = util.path.join(cargo_home, 'registry', 'src')
-  local toolchains = util.path.join(vim.env.HOME, '.rustup', 'toolchains')
+
+  local rustup_home = os.getenv 'RUSTUP_HOME' or util.path.join(vim.env.HOME, '.rustup')
+  local toolchains = util.path.join(rustup_home, 'toolchains')
+
   for _, item in ipairs { toolchains, registry } do
     if fname:sub(1, #item) == item then
       local clients = vim.lsp.get_active_clients { name = 'rust_analyzer' }


### PR DESCRIPTION
When checking if file is part of a library, use `RUSTUP_HOME` env variable if it is set, in the same way as `CARGO_HOME`.