### PR TITLE
fix(rust-analyzier): avoid "attempt to index nil" error

### DIFF
--- a/lua/lspconfig/server_configurations/rust_analyzer.lua
+++ b/lua/lspconfig/server_configurations/rust_analyzer.lua
@@ -20,7 +20,9 @@ local function is_library(fname)
   for _, item in ipairs { toolchains, registry } do
     if fname:sub(1, #item) == item then
       local clients = vim.lsp.get_active_clients { name = 'rust_analyzer' }
-      return clients[#clients].config.root_dir
+      if clients[#clients].config then
+        return clients[#clients].config.root_dir
+      end
     end
   end
 end


### PR DESCRIPTION
This issue was introduced in https://github.com/neovim/nvim-lspconfig/pull/2645

I've no idea if this is the right fix, but it may be.
