### PR TITLE
Draft: fix(astro): make astro also run on all tsserver's filetypes

### DIFF
--- a/lua/lspconfig/server_configurations/astro.lua
+++ b/lua/lspconfig/server_configurations/astro.lua
@@ -8,7 +8,15 @@ end
 return {
   default_config = {
     cmd = { 'astro-ls', '--stdio' },
-    filetypes = { 'astro' },
+    filetypes = {
+      'astro',
+      'javascript',
+      'javascriptreact',
+      'javascript.jsx',
+      'typescript',
+      'typescriptreact',
+      'typescript.tsx',
+    },
     root_dir = util.root_pattern('package.json', 'tsconfig.json', 'jsconfig.json', '.git'),
     init_options = {
       typescript = {},


### PR DESCRIPTION
Seems like Astro needs to be running on all tsserver's filetypes in order to realize that those buffers have changed. Else it just complains about not being able to find any changes.