### PR TITLE
fix(omnisharp): update on_new_config

### DIFF
--- a/lua/lspconfig/server_configurations/omnisharp.lua
+++ b/lua/lspconfig/server_configurations/omnisharp.lua
@@ -42,6 +42,7 @@ return {
       return util.root_pattern '*.sln'(fname) or util.root_pattern '*.csproj'(fname)
     end,
     on_new_config = function(new_config, new_root_dir)
+      new_config.cmd = { 'omnisharp' }
       table.insert(new_config.cmd, '-z') -- https://github.com/OmniSharp/omnisharp-vscode/pull/4300
       vim.list_extend(new_config.cmd, { '-s', new_root_dir })
       vim.list_extend(new_config.cmd, { '--hostPID', tostring(vim.fn.getpid()) })


### PR DESCRIPTION
Save the initial value of cmd to be used in subsequent calls to on_new_config. Fixes #2392.