### PR TITLE
Update pyright.lua to use `cwd()` if no python config files are present.

### DIFF
--- a/lua/lspconfig/server_configurations/pyright.lua
+++ b/lua/lspconfig/server_configurations/pyright.lua
@@ -32,7 +32,9 @@ return {
   default_config = {
     cmd = { 'pyright-langserver', '--stdio' },
     filetypes = { 'python' },
-    root_dir = util.root_pattern(unpack(root_files)),
+    root_dir = function()
+      return util.root_pattern(unpack(root_files))() or vim.loop.cwd()
+    end,
     single_file_support = true,
     settings = {
       python = {


### PR DESCRIPTION
This behavior is more natural and the default in VS Code: https://github.com/microsoft/pyright/issues/5407#issuecomment-1619132310.