### PR TITLE
docs: update broken link volar (vue.js)

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -10268,7 +10268,7 @@ npm install -g @volar/vue-language-server
 ```
 
 Volar by default supports Vue 3 projects. Vue 2 projects need
-[additional configuration](https://github.com/johnsoncodehk/volar/blob/master/extensions/vscode-vue-language-features/README.md?plain=1#L28-L63).
+[additional configuration](https://github.com/vuejs/language-tools/tree/master/packages/vscode-vue#usage).
 
 **Take Over Mode**
 


### PR DESCRIPTION
An URL pointing to some specific config necessary for usage with older Vue.js versions got moved (see https://github.com/vuejs/language-tools/issues/2583) updated the link to reflect the change