### PR TITLE
docs: update broken link volar (vue.js)

### DIFF
--- a/lua/lspconfig/server_configurations/volar.lua
+++ b/lua/lspconfig/server_configurations/volar.lua
@@ -41,7 +41,7 @@ npm install -g @volar/vue-language-server
 ```
 
 Volar by default supports Vue 3 projects. Vue 2 projects need
-[additional configuration](https://github.com/johnsoncodehk/volar/blob/master/extensions/vscode-vue-language-features/README.md?plain=1#L28-L63).
+[additional configuration](https://github.com/vuejs/language-tools/tree/master/packages/vscode-vue#usage).
 
 **Take Over Mode**
 


### PR DESCRIPTION
A URL pointing to specific configuration necessary for older Vue.js versions got moved (see ) updated the link here to reflect the change