### PR TITLE
fix(rubocop) support projects that do not use bundler

### DIFF
--- a/lua/lspconfig/server_configurations/rubocop.lua
+++ b/lua/lspconfig/server_configurations/rubocop.lua
@@ -2,10 +2,17 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'bundle', 'exec', 'rubocop', '--lsp' },
+    cmd = { 'rubocop', '--lsp' },
     filetypes = { 'ruby' },
     root_dir = util.root_pattern('Gemfile', '.git'),
   },
+  on_new_config = function(config, root_dir)
+    -- prepend 'bundle exec' to cmd if bundler is being used
+    local gemfile_path = util.path.join(root_dir, 'Gemfile')
+    if util.path.exists(gemfile_path) then
+      config.cmd = { 'bundle', 'exec', unpack(config.cmd) }
+    end
+  end,
   docs = {
     description = [[
 https://github.com/rubocop/rubocop


### PR DESCRIPTION
The  existing rubocop lsp configuration uses the 'bundle exec' command as a prefix to run rubocop.
This is the correct way to do it for projects using the bundler gem (including all rails projects.)

However that configuration is broken for ruby projects not using bundler.  The LSP fails to start and an error message is shown on startup.  

This PR makes the default configuration work for either case, by detecting whether bundler is in use and using the correct command.