### PR TITLE
fix: autostart=false: attach when editing new, nonexistent file

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -98,7 +98,7 @@ function configs.__newindex(t, config_name, config_def)
 
     if config.autostart == true then
       local event_conf = config.filetypes and { event = 'FileType', pattern = config.filetypes }
-        or { event = 'BufReadPost' }
+        or { event = { 'BufReadPost', 'BufNewFile' } }
       api.nvim_create_autocmd(event_conf.event, {
         pattern = event_conf.pattern or '*',
         callback = function(opt)
@@ -139,7 +139,7 @@ function configs.__newindex(t, config_name, config_def)
         end
 
         if root_dir then
-          api.nvim_create_autocmd('BufReadPost', {
+          api.nvim_create_autocmd({ 'BufReadPost', 'BufNewFile' }, {
             pattern = fn.fnameescape(root_dir) .. '/*',
             callback = function(arg)
               if #M.manager:clients() == 0 then

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -102,7 +102,11 @@ function configs.__newindex(t, config_name, config_def)
       api.nvim_create_autocmd(event_conf.event, {
         pattern = event_conf.pattern or '*',
         callback = function(opt)
-          M.manager:try_add(opt.buf)
+          -- Use vim.schedule() to ensure filetype detection happens first.
+          -- Sometimes, BufNewFile triggers before 'filetype' is set.
+          vim.schedule(function()
+            M.manager:try_add(opt.buf)
+          end)
         end,
         group = lsp_group,
         desc = string.format(
@@ -145,7 +149,12 @@ function configs.__newindex(t, config_name, config_def)
               if #M.manager:clients() == 0 then
                 return true
               end
-              M.manager:try_add_wrapper(arg.buf, root_dir)
+
+              -- Use vim.schedule() to ensure filetype detection happens first.
+              -- Sometimes, BufNewFile triggers before 'filetype' is set.
+              vim.schedule(function()
+                M.manager:try_add_wrapper(arg.buf, root_dir)
+              end)
             end,
             group = lsp_group,
             desc = string.format(


### PR DESCRIPTION
## Problem
Currently, `nvim-lspconfig` tries to attach servers automatically via two autocommands:
1. Created if `config.autostart == true` and triggered by `FileType`, if `config.filetypes` is set, else `BufReadPost`. Calls `try_add()`.
2. Created for each workspace root, triggered by `BufReadPost` matching paths starting with the root. Calls `try_add_wrapper()`.

`BufReadPost` does not fire when creating a buffer for a file that doesn't exist. This means that if `config.autostart == true` and `config.filetypes` is set and includes the detected filetype for the buffer, the server is attached automatically regardless of whether the file exists, but in all other cases the server is only attached for existing files.

## Solution
1. Where these autocommands trigger on `BufReadPost`, also trigger on `BufNewFile`.
2. Wrap the autocommand callbacks in `vim.schedule()` to ensure `filetype` is set first, as the `BufReadPost`/`BufNewFile` autocommands will trigger before `FileType` if `nvim-lspconfig` is set up early enough during Nvim init (see https://github.com/neovim/neovim/issues/7367 and https://github.com/neovim/nvim-lspconfig/pull/2712#discussion_r1261063555).

I did consider including a test with this PR, but there doesn't seem to be any existing test infrastructure for tests involving actually running a language server (or a mock of one).

Fixes #2711