### PR TITLE
fix(rubocop): don't auto-detect bundler, to avoid surprising configuration behavior

### DIFF
--- a/lua/lspconfig/server_configurations/rubocop.lua
+++ b/lua/lspconfig/server_configurations/rubocop.lua
@@ -6,13 +6,6 @@ return {
     filetypes = { 'ruby' },
     root_dir = util.root_pattern('Gemfile', '.git'),
   },
-  on_new_config = function(config, root_dir)
-    -- prepend 'bundle exec' to cmd if bundler is being used
-    local gemfile_path = util.path.join(root_dir, 'Gemfile')
-    if util.path.exists(gemfile_path) then
-      config.cmd = { 'bundle', 'exec', unpack(config.cmd) }
-    end
-  end,
   docs = {
     description = [[
 https://github.com/rubocop/rubocop

--- a/lua/lspconfig/server_configurations/rubocop.lua
+++ b/lua/lspconfig/server_configurations/rubocop.lua
@@ -2,10 +2,17 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'bundle', 'exec', 'rubocop', '--lsp' },
+    cmd = { 'rubocop', '--lsp' },
     filetypes = { 'ruby' },
     root_dir = util.root_pattern('Gemfile', '.git'),
   },
+  on_new_config = function(config, root_dir)
+    -- prepend 'bundle exec' to cmd if bundler is being used
+    local gemfile_path = util.path.join(root_dir, 'Gemfile')
+    if util.path.exists(gemfile_path) then
+      config.cmd = { 'bundle', 'exec', unpack(config.cmd) }
+    end
+  end,
   docs = {
     description = [[
 https://github.com/rubocop/rubocop


### PR DESCRIPTION
My earlier PR #2706 added an on_new_config handler which auto-detects whether bundler is used in a project, and calls rubocop through bundler or not based on the result.

This had some issues:
* may override the user's custom configuration due to the use of on_new_config
* has surprising side effect when overridden because the `on_new_config` handler runs twice
* incorrectly configures 'bundle exec rubocop --lsp' command if the project has a Gemfile that does not include rubocop

After some [discussion](https://github.com/neovim/nvim-lspconfig/pull/2706#issuecomment-1627767073)  it seems that this simpler configuration is best.
This PR deletes the `on_new_config` handler, leaving the lsp command to be `rubocop --lsp`.
This will also match the behaviour of the solargraph and ruby_ls configurations.

Users who want to use 'bundle exec rubocop --lsp` can get this with a simple custom lsp configuration, or by using a plugin such as https://github.com/mihyaeru21/nvim-lspconfig-bundler .