### PR TITLE
feat: add pyright-python support

### DIFF
--- a/lua/lspconfig/server_configurations/pyright_python.lua
+++ b/lua/lspconfig/server_configurations/pyright_python.lua
@@ -1,0 +1,67 @@
+local util = require 'lspconfig.util'
+
+local root_files = {
+  'pyproject.toml',
+  'setup.py',
+  'setup.cfg',
+  'requirements.txt',
+  'Pipfile',
+  'pyrightconfig.json',
+}
+
+local function organize_imports()
+  local params = {
+    command = 'pyright.organizeimports',
+    arguments = { vim.uri_from_bufnr(0) },
+  }
+  vim.lsp.buf.execute_command(params)
+end
+
+local function set_python_path(path)
+  local clients = vim.lsp.get_active_clients {
+    bufnr = vim.api.nvim_get_current_buf(),
+    name = 'pyright',
+  }
+  for _, client in ipairs(clients) do
+    client.config.settings = vim.tbl_deep_extend('force', client.config.settings, { python = { pythonPath = path } })
+    client.notify('workspace/didChangeConfiguration', { settings = nil })
+  end
+end
+
+return {
+  default_config = {
+    cmd = { 'pyright-python-langserver', '--stdio' },
+    filetypes = { 'python' },
+    root_dir = util.root_pattern(unpack(root_files)),
+    single_file_support = true,
+    settings = {
+      python = {
+        analysis = {
+          autoSearchPaths = true,
+          useLibraryCodeForTypes = true,
+          diagnosticMode = 'workspace',
+        },
+      },
+    },
+  },
+  commands = {
+    PyrightOrganizeImports = {
+      organize_imports,
+      description = 'Organize Imports',
+    },
+    PyrightSetPythonPath = {
+      set_python_path,
+      description = 'Reconfigure pyright with the provided python path',
+      nargs = 1,
+      complete = 'file',
+    },
+  },
+  docs = {
+    description = [[
+https://github.com/RobertCraigie/pyright-python
+
+Python command line wrapper for `pyright`, a static type checker and
+language server for Python.
+]],
+  },
+}


### PR DESCRIPTION
Reasoning: https://github.com/RobertCraigie/pyright-python is an unofficial Python wrapper for Pyright, that installs node and npm in a small venv in ~/.cache/pyright-python and runs Pyright from there.

Is there a conflict with regular Pyright? Shouldn't be, because:
1. pip and pipx (no idea about conda) install executables in `~/.local/bin`, which isn't used by npm;
2. Python wrapper has two extra executables, `pyright-python` and `pyright-python-langserver`, which are identical to the originally called ones.

Users can install Pyright with pip/pipx/conda and still use the original `pyright` name for a setup, this file is for compatibility with Mason users (cf. [chris@machine's example setup](https://github.com/LunarVim/nvim-basic-ide/blob/master/lua/user/lsp.lua#L46-L60), feeding each server with same on_attach and capabilities). Also, if users install `pyright-python` and set it up explicitly under this name, it'll be easier to bisect issues for PyPI and npm packages.

A parallel PR was created at [mason-org/mason-registry](https://github.com/mason-org/mason-registry/pull/2138), which will expose to nvim-lspconfig only the new executables.