### PR TITLE
feat: add `javascript` to emmet_ls

### DIFF
--- a/lua/lspconfig/server_configurations/emmet_ls.lua
+++ b/lua/lspconfig/server_configurations/emmet_ls.lua
@@ -9,6 +9,7 @@ return {
       'eruby',
       'html',
       'htmldjango',
+      'javascript',
       'javascriptreact',
       'less',
       'pug',


### PR DESCRIPTION
Adds  `javascript` support to emmet_ls as it was missing and emmet_ls implemented support for it (as seen in https://github.com/aca/emmet-ls#supported-filetypes)