### PR TITLE
fix(pyright): add `.git` to list of root file

### DIFF
--- a/lua/lspconfig/server_configurations/pyright.lua
+++ b/lua/lspconfig/server_configurations/pyright.lua
@@ -7,6 +7,7 @@ local root_files = {
   'requirements.txt',
   'Pipfile',
   'pyrightconfig.json',
+  '.git',
 }
 
 local function organize_imports()


### PR DESCRIPTION
Notice this sensible default is missing from pyright when creating new python project.