### PR TITLE
fix(LspRestart): check client attched_buffers count by using tbl_count

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -90,7 +90,7 @@ api.nvim_create_user_command('LspRestart', function(info)
   local detach_clients = {}
   for _, client in ipairs(get_clients_from_cmd_args(info.args)) do
     client.stop()
-    if #client.attached_buffers > 0 then
+    if vim.tbl_count(client.attached_buffers) > 0 then
       detach_clients[client.name] = { client, client.attached_buffers }
     end
   end


### PR DESCRIPTION
Problem: `attached_buffers` not list-like table should not use `#` for length check
Solution: use `vim.tbl_count`

Fix #2707 