### PR TITLE
fix(pyright): Fix root_dir detection

### DIFF
--- a/lua/lspconfig/server_configurations/pyright.lua
+++ b/lua/lspconfig/server_configurations/pyright.lua
@@ -33,8 +33,8 @@ return {
   default_config = {
     cmd = { 'pyright-langserver', '--stdio' },
     filetypes = { 'python' },
-    root_dir = function()
-      return util.root_pattern(unpack(root_files))() or vim.loop.cwd()
+    root_dir = function(fname)
+      return util.root_pattern(unpack(root_files))(fname) or vim.loop.cwd()
     end,
     single_file_support = true,
     settings = {


### PR DESCRIPTION
fname was missing from arguments, leading to always using cwd.