### PR TITLE
fix(rust_analyzer): check active clients is empty

### DIFF
--- a/lua/lspconfig/server_configurations/rust_analyzer.lua
+++ b/lua/lspconfig/server_configurations/rust_analyzer.lua
@@ -20,7 +20,7 @@ local function is_library(fname)
   for _, item in ipairs { toolchains, registry } do
     if fname:sub(1, #item) == item then
       local clients = vim.lsp.get_active_clients { name = 'rust_analyzer' }
-      return clients[#clients].config.root_dir
+      return #clients > 0 and clients[#clients].config.root_dir or nil
     end
   end
 end


### PR DESCRIPTION
Problme: when open a library file directly there is no active clients will cause an error

Solution: check clients is empty or not 

Fix #2681 