### PR TITLE
fix(efm): set `init_options` to enable format and code action.

### DIFF
--- a/lua/lspconfig/server_configurations/efm.lua
+++ b/lua/lspconfig/server_configurations/efm.lua
@@ -5,6 +5,12 @@ return {
     cmd = { 'efm-langserver' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
+    init_options = {
+      documentFormatting = true,
+      documentRangeFormatting = true,
+      hover = true,
+      codeAction = true,
+    },
   },
 
   docs = {


### PR DESCRIPTION
With the release of `v0.0.46` in efm, the `init_options` must be manually set to allow the format and code action abilities to be usable in neovim. I believe the format and code action are the most frequently used features of efm and should be enabled by default. The user shouldn't be bothered to manually set those options.