### PR TITLE
feat(marksman): enable for `markdown.mdx`

### DIFF
--- a/lua/lspconfig/server_configurations/marksman.lua
+++ b/lua/lspconfig/server_configurations/marksman.lua
@@ -6,7 +6,7 @@ local cmd = { bin_name, 'server' }
 return {
   default_config = {
     cmd = cmd,
-    filetypes = { 'markdown' },
+    filetypes = { 'markdown', 'markdown.mdx' },
     root_dir = function(fname)
       local root_files = { '.marksman.toml' }
       return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)


### PR DESCRIPTION
`marksman` works for MDX files. We don't want to `set ft=markdown`, since there exist tools that don't work for MDX, so we want to keep .md and .mdx as separate filetypes.