### PR TITLE
docs: rename deprecated `resolved_capabilities` -> `server_capabilities`

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -168,7 +168,7 @@ passed overrides to `setup {}` are:
 
   Callback invoked by Nvim's built-in client when attaching a buffer to a
   language server. Often used to set Nvim (buffer or global) options or to
-  override the Nvim client properties (`resolved_capabilities`) after a
+  override the Nvim client properties (`server_capabilities`) after a
   language server attaches. Most commonly used for settings buffer
   local keybindings. See |lspconfig-keybindings| for a usage example.
 


### PR DESCRIPTION
According to https://github.com/neovim/neovim/commit/c618b314c6a266806edf692122b16ba9ff7a8e10