### PR TITLE
chore(volar): rename npm package name `@volar/vue-language-server` to `@vue/language-server`

### DIFF
--- a/lua/lspconfig/server_configurations/volar.lua
+++ b/lua/lspconfig/server_configurations/volar.lua
@@ -37,7 +37,7 @@ Volar language server for Vue
 Volar can be installed via npm:
 
 ```sh
-npm install -g @volar/vue-language-server
+npm install -g @vue/language-server
 ```
 
 Volar by default supports Vue 3 projects. Vue 2 projects need


### PR DESCRIPTION
The npm package `@volar/vue-language-server` has been renamed to `@vue/language-server`.
Therefore, I have corrected the NPM package name for volar in the documentation.
The source code is not changed by this pull request.

![-volar-vue-language-server-npm](https://github.com/neovim/nvim-lspconfig/assets/33865215/bcd48e9e-4599-4dfe-9427-b189f55cca94)


Ref: https://www.npmjs.com/package/@volar/vue-language-server

 