### PR TITLE
fix(omnisharp): root_dir again uses proper pattern priority

### DIFF
--- a/lua/lspconfig/server_configurations/omnisharp.lua
+++ b/lua/lspconfig/server_configurations/omnisharp.lua
@@ -40,7 +40,12 @@ return {
     filetypes = { 'cs', 'vb' },
     root_dir = function(fname)
       local root_patterns = { '*.sln', '*.csproj', 'omnisharp.json', 'function.json' }
-      return util.root_pattern(root_patterns)(fname)
+      for _, pattern in ipairs(root_patterns) do
+        local found = util.root_pattern(pattern)(fname)
+        if found then
+          return found
+        end
+      end
     end,
     on_new_config = function(new_config, _)
       -- Get the initially configured value of `cmd`


### PR DESCRIPTION
There was a regression in `root_dir` for omnisharp caused by https://github.com/neovim/nvim-lspconfig/pull/2715

See https://github.com/neovim/nvim-lspconfig/pull/2715#issuecomment-1652774935 for a good problem explanation.

This MR implements pattern priority left-to-right which fixes the issue.