### PR TITLE
fix(lspconfig): updating csharp-ls to look for sln when in a project structure

### DIFF
--- a/lua/lspconfig/server_configurations/csharp_ls.lua
+++ b/lua/lspconfig/server_configurations/csharp_ls.lua
@@ -3,7 +3,12 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'csharp-ls' },
-    root_dir = util.root_pattern('*.sln', '*.csproj', '*.fsproj', '.git'),
+    root_dir = function(fname)
+      return util.root_pattern '*.sln'(fname)
+        or util.root_pattern('*.csproj', '*.fsproj', '.git')(fname)
+        or util.root_pattern '*.fsproj'(fname)
+        or util.root_pattern '.git'(fname)
+    end,
     filetypes = { 'cs' },
     init_options = {
       AutomaticWorkspaceInit = true,

--- a/lua/lspconfig/server_configurations/csharp_ls.lua
+++ b/lua/lspconfig/server_configurations/csharp_ls.lua
@@ -4,10 +4,8 @@ return {
   default_config = {
     cmd = { 'csharp-ls' },
     root_dir = function(fname)
-      return util.root_pattern '*.sln'(fname)
-        or util.root_pattern('*.csproj', '*.fsproj', '.git')(fname)
-        or util.root_pattern '*.fsproj'(fname)
-        or util.root_pattern '.git'(fname)
+      return util.root_pattern '*.sln' (fname)
+          or util.root_pattern('*.csproj')(fname)
     end,
     filetypes = { 'cs' },
     init_options = {


### PR DESCRIPTION
Fixing an issue when loading a project in the lsp that it wasn't detecting the sln - it was only detecting the current csproj file 