### PR TITLE
feat: add LspReconfigure command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Most of the time, the reason for failure is present in the logs.
 * `:LspStart <config_name>` Start the requested server name. Will only successfully start if the command detects a root directory matching the current config. Pass `autostart = false` to your `.setup{}` call for a language server if you would like to launch clients solely with this command. Defaults to all servers matching current buffer filetype.
 * `:LspStop <client_id>` Defaults to stopping all buffer clients.
 * `:LspRestart <client_id>` Defaults to restarting all buffer clients.
+* `:LspReconfigure <nested_key=value>...` Temporarily override LSP server settings, until stopped or restarted.
 
 ## Wiki
 

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -463,14 +463,46 @@ The following commands support tab-completion for all arguments. All commands
 that require a client id can either leverage tab-completion or the info
 contained in `:LspInfo`:
 
+                                                             *:LspStart*
 - `:LspStart <config_name>` launches the requested (configured) client, but only
   if it successfully resolves a root directory. Note: Defaults to all
   configured servers matching the current buffer filetype.
+                                                             *:LspStop*
 - `:LspStop <client_id>` stops the server with the given client id. Defaults to
   stopping all servers active on the current buffer. if you want to force stop
   a language server you can do it like `:LspStop <client_id> ++force`
+                                                             *:LspRestart*
 - `:LspRestart <client_id>` restarts the client with the given client id, and
   will attempt to reattach to all previously attached buffers.
+                                                             *:LspReconfigure*
+- `:LspReconfigure <nested_key=value>...` temporarily overrides LSP server
+  settings, until the server is stopped or restarted, for the server(s)
+  attached to the current buffer. See |lspconfig-lspreconfigure| for usage.
+
+==============================================================================
+LspReconfigure                                        *lspconfig-lspreconfigure*
+
+`:LspReconfigure <nested_key=value>...` has one or more arguments to assign
+new settings to the language server(s) attached to the current buffer. Each
+argument is in a `nested_key=value` format, and the syntax of keys and values
+is:
+
+- `nested_key`: The format of {nested_key} can usually be copied directly from
+  the server's documentation (e.g. `language-server.diagnostics.disable`).
+- `value`: The format of {value} is a JSON literal, with the some exceptions:
+
+  - For convenience, a bare string literal does not need to be quoted.
+    Example: `lang.setting=string_value`
+  - Lists of strings can be comma-separated without brackets or quotes.
+    Example: `lang.diagnostics.disable=E101,E505`
+  - A list value with a single item can be assigned by adding a trailing
+    comma: `lang.diagnostics.disable=E101,`
+
+  Strings in lists and mappings must be quoted, i.e. `["first","second"]` and
+  `{"key":"value"}`.
+
+Note: In both parameters, all spaces must be escaped with backslash, even in a
+quoted string, because the command line splits arguments on spaces.
 
 ==============================================================================
 EXAMPLE KEYBINDINGS                                      *lspconfig-keybindings*


### PR DESCRIPTION
Add command `LspReconfigure` that allows overriding settings for LSP servers attached to the current buffer.

Does some command-line parsing so that:
- Bare string literals don't have to be quoted:
  `:LspReconfigure Lua.hint.paramName=Disable` ➡️ `Lua.hint.paramName="Disable"`
- Non-Lua-Name characters get properly quoted, and JSON literals (`true`/`false`/`null`) do not:
  `rust-analyzer.assist.emitMustUse=true` ➡️ `["rust-analyzer"].assist.emitMustUse=true`
- List-based settings can be assigned without using JSON syntax:
  `Lua.diagnostics.disable=cast-local-type,cast-type-mismatch` ➡️ `Lua.diagnostics.disable=["cast-local-type","cast-type-mismatch"]`
  `Lua.diagnostics.disable=cast-local-type,` ➡️ `Lua.diagnostics.disable=["cast-local-type"]`

In all of these cases, an "autotable" is generated so that arbitrarily-nested settings keys can be used, and the value can be any legal JSON expression so complex lists and mappings can be used if necessary.