### PR TITLE
Revert "feat: add `javascript` to emmet_ls"

### DIFF
--- a/lua/lspconfig/server_configurations/emmet_ls.lua
+++ b/lua/lspconfig/server_configurations/emmet_ls.lua
@@ -9,7 +9,6 @@ return {
       'eruby',
       'html',
       'htmldjango',
-      'javascript',
       'javascriptreact',
       'less',
       'pug',


### PR DESCRIPTION
Reverts neovim/nvim-lspconfig#2720

As pointed out by @TheBlckbird in #2720 , the original PR was more annoying than helpful to the majority of users, so including `javascript` 
in `emmet_ls` should remain optional.