### PR TITLE
fix(server_configurations): yaml.docker-compose filetype

### DIFF
--- a/lua/lspconfig/server_configurations/docker_compose_language_service.lua
+++ b/lua/lspconfig/server_configurations/docker_compose_language_service.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'docker-compose-langserver', '--stdio' },
-    filetypes = { 'yaml' },
+    filetypes = { 'yaml.docker-compose' },
     root_dir = util.root_pattern 'docker-compose.yaml',
     single_file_support = true,
   },


### PR DESCRIPTION
The current configuration for `docker_compose_language_server` causes any/all YAML files to trigger loading of the docker-compose language server.

This PR replaces the default configuration FileType `yaml` with the very common (sub?) FileType `yaml.docker-compose`.

I believe the original _intention_ was to have all Docker-Compose files be recognized and have features as a FileType of `YAML`, but in reality the _inverse_ was configured (all YAML files are assumed to be Docker-Compose files).

The `yaml.docker-compose` filetype is well recognized, even in `nvim-lspconfig`:

- [lua/lspconfig/server_configurations/yamlls.lua](https://github.com/neovim/nvim-lspconfig/blob/67f151e84daddc86cc65f5d935e592f76b9f4496/lua/lspconfig/server_configurations/yamlls.lua#L6)
- [sheerun/vim-polyglot](https://github.com/sheerun/vim-polyglot/blob/bc8a81d3592dab86334f27d1d43c080ebf680d42/autoload/polyglot/sleuth.vim#L629)

More `yaml.docker-compose` Lua & VimScript examples: https://github.com/search?q=language%3Alua+OR+language%3A%22Vim+Script%22+%22yaml.docker-compose%22&type=code&ref=advsearch 