### PR TITLE
feat(phpactor): attach language client if config found

### DIFF
--- a/lua/lspconfig/server_configurations/phpactor.lua
+++ b/lua/lspconfig/server_configurations/phpactor.lua
@@ -6,7 +6,7 @@ return {
     filetypes = { 'php' },
     root_dir = function(pattern)
       local cwd = vim.loop.cwd()
-      local root = util.root_pattern('composer.json', '.git')(pattern)
+      local root = util.root_pattern('composer.json', '.git', '.phpactor.json', '.phpactor.yml')(pattern)
 
       -- prefer cwd if root is a descendant
       return util.path.is_descendant(cwd, root) and cwd or root


### PR DESCRIPTION
Based on presence of phpactor-specific configuration files, allow client to attach, even if we are not inside a composer package or a git repository.