### PR TITLE
fix: lsprestart command faild

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -374,8 +374,7 @@ function M.get_managed_clients()
   local clients = {}
   for _, config in pairs(configs) do
     if config.manager then
-      vim.list_extend(clients, config.manager.clients())
-      vim.list_extend(clients, config.manager.clients(true))
+      vim.list_extend(clients, config.manager:clients())
     end
   end
   return clients


### PR DESCRIPTION
Fix #2778