### PR TITLE
fix(jedi): add .git to jedi_language_server root_dir

### DIFF
--- a/lua/lspconfig/server_configurations/jedi_language_server.lua
+++ b/lua/lspconfig/server_configurations/jedi_language_server.lua
@@ -6,6 +6,7 @@ local root_files = {
   'setup.cfg',
   'requirements.txt',
   'Pipfile',
+  '.git',
 }
 
 return {


### PR DESCRIPTION
Similar to #2722 . Detect .git as project root.