### PR TITLE
fix(pyright): set diagnosticMode = openFilesOnly

### DIFF
--- a/lua/lspconfig/server_configurations/pyright.lua
+++ b/lua/lspconfig/server_configurations/pyright.lua
@@ -42,7 +42,7 @@ return {
         analysis = {
           autoSearchPaths = true,
           useLibraryCodeForTypes = true,
-          diagnosticMode = 'workspace',
+          diagnosticMode = 'openFilesOnly',
         },
       },
     },


### PR DESCRIPTION
When you go to definition of a library function, pyright will analyze the entire packages to report diagnostic information. This is extremely slow and heavy https://www.reddit.com/r/neovim/comments/135fqp9/why_is_pyright_constantly_analyzing_files_it/ Switch to the default value, similar to in VSCode.

![Screenshot 2023-08-24 at 11 36 33](https://github.com/neovim/nvim-lspconfig/assets/12573521/80dca878-6eea-4778-bf13-dcde42eef6c0)

Changing this setting does not affect the type inference from library code, does not affect the diagnostic of the opened files from user or library code.
As far as I know, "openFilesOnly" only report diagnostic information for the file you have opened, i.e workspace diagnostics won't report for files you have not opened in this session.
This seems like an acceptable tradeoff for me.

P/s: Or considering delete everything analysis setting to use the default value. This will keep it in sync with VSCode as well.
