### PR TITLE
fix(robotframework_ls): update root directory pattern

### DIFF
--- a/lua/lspconfig/server_configurations/robotframework_ls.lua
+++ b/lua/lspconfig/server_configurations/robotframework_ls.lua
@@ -5,7 +5,8 @@ return {
     cmd = { 'robotframework_ls' },
     filetypes = { 'robot' },
     root_dir = function(fname)
-      return util.root_pattern('robotidy.toml', 'pyproject.toml')(fname) or util.find_git_ancestor(fname)
+      return util.root_pattern('robotidy.toml', 'pyproject.toml', 'conda.yaml', 'robot.yaml')(fname)
+        or util.find_git_ancestor(fname)
     end,
   },
   docs = {
@@ -15,7 +16,8 @@ https://github.com/robocorp/robotframework-lsp
 Language Server Protocol implementation for Robot Framework.
 ]],
     default_config = {
-      root_dir = "util.root_pattern('robotidy.toml', 'pyproject.toml')(fname) or util.find_git_ancestor(fname)",
+      root_dir = "util.root_pattern('robotidy.toml', 'pyproject.toml', 'conda.yaml', 'robot.yaml')(fname)"
+        .. '\n  or util.find_git_ancestor(fname)',
     },
   },
 }


### PR DESCRIPTION
## Problem
When using the default configuration with robots created using templates available in [`rcc`](https://robocorp.com/docs/rcc/overview), I realized that the root directory was not identified. As a quick fix, I created an empty `pyproject.toml` file in the project root. However, that file must be manually created for (at least many) new projects, so updating the default configuration seems reasonable.

## Solution
I believe `robot.yaml` and `conda.yaml` can be added to the filename list when looking for the project root directory.

## Root directory pattern study
I used `rcc create` with all of the available templates:

```
Templates:
   1: Python - Assistant AI Chat
   2: Python - Browser automation with Playwright
   3: Python - Minimal
   4: Python - Producer-Consumer
   5: Robot Framework - Assistant (attended automation)
   6: Robot Framework - Browser automation with Playwright
   7: Robot Framework - Minimal
   8: Robot Framework - Producer-Consumer
   9: Robot Framework - Producer-Consumer Extended
```

Then, I observed the files included in the templates:

```bash
% ls {1..9}
1:
conda.yaml  LICENSE  README.md  robot.yaml  tasks.py

2:
conda.yaml  LICENSE  README.md  robot.yaml  tasks.py

3:
conda.yaml  LICENSE  README.md  robot.yaml  tasks.py

4:
conda.yaml  devdata  LICENSE  README.md  robot.yaml  tasks.py

5:
conda.yaml  LICENSE  mark.png  README.md  robot.yaml  tasks.robot

6:
conda.yaml  LICENSE  README.md  robot.yaml  tasks.robot

7:
conda.yaml  LICENSE  README.md  robot.yaml  tasks.robot

8:
conda.yaml  consumer.robot  devdata  LICENSE  producer.robot  README.md  robot.yaml

9:
bin  conda.yaml  consumer.robot  devdata  libraries  LICENSE  producer.robot  README.md  reporter.robot  resources  robot.yaml
```

I determined that `robot.yaml` as well as `conda.yaml` are common for every template, and I believe that they are good indicators for a Robot Framework project's root directory. Of course, the Python templates contain Python files instead of `.robot` files, and are thus irrelevant.

## Changes
I added the two filenames, `robot.yaml` and `conda.yaml`, in the root directory pattern in `robotframework_ls.lua`.
The updated pattern is also saved in the documentation table of the same file.

This change makes the default LSP configuration work with robots created using the `rcc` tool.