### PR TITLE
feat: add `biome` (`rome` successor)

### DIFF
--- a/lua/lspconfig/server_configurations/biome.lua
+++ b/lua/lspconfig/server_configurations/biome.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'rome', 'lsp-proxy' },
+    cmd = { 'biome', 'lsp-proxy' },
     filetypes = {
       'javascript',
       'javascriptreact',

--- a/lua/lspconfig/server_configurations/biome.lua
+++ b/lua/lspconfig/server_configurations/biome.lua
@@ -20,18 +20,16 @@ return {
   },
   docs = {
     description = [[
-https://rome.tools
+https://biomejs.dev
 
-Language server for the Rome Frontend Toolchain.
-
-(Unmaintained, use [Biome](https://biomejs.dev/blog/annoucing-biome) instead.)
+Toolchain of the web. [Successor of Rome](https://biomejs.dev/blog/annoucing-biome).
 
 ```sh
-npm install [-g] rome
+npm install [-g] @biomejs/biome
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern('package.json', 'node_modules', '.git')]],
+      root_dir = [[root_pattern('package.json', 'node_modules', '.git', 'biome.json')]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/biome.lua
+++ b/lua/lspconfig/server_configurations/biome.lua
@@ -7,6 +7,7 @@ return {
       'javascript',
       'javascriptreact',
       'json',
+      'jsonc',
       'typescript',
       'typescript.tsx',
       'typescriptreact',


### PR DESCRIPTION
`rome` is unmaintained, and `biome` is the new fork/successor: https://biomejs.dev/blog/annoucing-biome

Since `biome` is mostly a clone of rome at this point, not much changed other than the name. The announcement also confirms that for now, it's basically just a package name change which I adopted.

I tested the branch, and the config works just fine for `biome`.

I also ran `make lint`, and added a short notice that `rome` is unmaintained.