### PR TITLE
feat(denols): enable import completion from registries

### DIFF
--- a/lua/lspconfig/server_configurations/denols.lua
+++ b/lua/lspconfig/server_configurations/denols.lua
@@ -74,9 +74,19 @@ return {
       'typescript.tsx',
     },
     root_dir = util.root_pattern('deno.json', 'deno.jsonc', '.git'),
-    init_options = {
-      enable = true,
-      unstable = false,
+    settings = {
+      deno = {
+        enable = true,
+        suggest = {
+          imports = {
+            hosts = {
+              ["https://deno.land"] = true,
+              ["https://crux.land"] = true,
+              ["https://x.nest.land"] = true
+            }
+          }
+        }
+      },
     },
     handlers = {
       ['textDocument/definition'] = denols_handler,

--- a/lua/lspconfig/server_configurations/denols.lua
+++ b/lua/lspconfig/server_configurations/denols.lua
@@ -80,12 +80,12 @@ return {
         suggest = {
           imports = {
             hosts = {
-              ["https://deno.land"] = true,
-              ["https://crux.land"] = true,
-              ["https://x.nest.land"] = true
-            }
-          }
-        }
+              ['https://deno.land'] = true,
+              ['https://crux.land'] = true,
+              ['https://x.nest.land'] = true,
+            },
+          },
+        },
       },
     },
     handlers = {


### PR DESCRIPTION
same as the vscode extension https://github.com/denoland/vscode_deno/blob/abd33d2edcf752d69e0c53f244ee549a04a6eba5/package.json#L247

`init_options` fails, it needs to be `settings = {deno`

Also I removed the `unstable = false`, since that is the default