### PR TITLE
Add quarto and rmd filetype to ltex.lua

### DIFF
--- a/lua/lspconfig/server_configurations/ltex.lua
+++ b/lua/lspconfig/server_configurations/ltex.lua
@@ -18,7 +18,7 @@ end
 return {
   default_config = {
     cmd = { bin_name },
-    filetypes = { 'bib', 'gitcommit', 'markdown', 'org', 'plaintex', 'rst', 'rnoweb', 'tex', 'pandoc' },
+    filetypes = { 'bib', 'gitcommit', 'markdown', 'org', 'plaintex', 'rst', 'rnoweb', 'tex', 'pandoc', 'quarto' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
     get_language_id = function(_, filetype)

--- a/lua/lspconfig/server_configurations/ltex.lua
+++ b/lua/lspconfig/server_configurations/ltex.lua
@@ -18,7 +18,7 @@ end
 return {
   default_config = {
     cmd = { bin_name },
-    filetypes = { 'bib', 'gitcommit', 'markdown', 'org', 'plaintex', 'rst', 'rnoweb', 'tex', 'pandoc', 'quarto' },
+    filetypes = { 'bib', 'gitcommit', 'markdown', 'org', 'plaintex', 'rst', 'rnoweb', 'tex', 'pandoc', 'quarto', 'rmd' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
     get_language_id = function(_, filetype)


### PR DESCRIPTION
Since `ltex-ls` release 16.0 Quarto and R Markdown are now officially supported: https://github.com/valentjn/ltex-ls/releases/tag/16.0.0