### PR TITLE
fix(ccls): add cuda filetype support

### DIFF
--- a/lua/lspconfig/server_configurations/ccls.lua
+++ b/lua/lspconfig/server_configurations/ccls.lua
@@ -8,7 +8,7 @@ local root_files = {
 return {
   default_config = {
     cmd = { 'ccls' },
-    filetypes = { 'c', 'cpp', 'objc', 'objcpp' },
+    filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda' },
     root_dir = function(fname)
       return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
     end,


### PR DESCRIPTION
I used to use clangd as my language server, and today I changed to ccls.  However, I found that ccls did not offer support to cuda.
In the configuration of clangd, the cuda filetype is added by default. So maybe it is better for ccls to support cuda by default? 