### PR TITLE
feat(tsserver): add _typescript.rename handler

### DIFF
--- a/lua/lspconfig/server_configurations/tsserver.lua
+++ b/lua/lspconfig/server_configurations/tsserver.lua
@@ -17,6 +17,33 @@ return {
         or util.root_pattern('package.json', 'jsconfig.json', '.git')(fname)
     end,
     single_file_support = true,
+    handlers = {
+      ['_typescript.rename'] = function(_, result, ctx)
+        if not result then
+          return {}
+        end
+
+        local client = vim.lsp.get_client_by_id(ctx.client_id)
+
+        if client then
+          vim.lsp.util.jump_to_location({
+            uri = result.textDocument.uri,
+            range = {
+              start = result.position,
+              ['end'] = result.position,
+            },
+          }, client.offset_encoding, true)
+
+          vim.lsp.buf.rename(nil, {
+            filter = function(c)
+              return c == client
+            end,
+          })
+        end
+
+        return {}
+      end,
+    },
   },
   docs = {
     description = [[


### PR DESCRIPTION
tsserver calls this method after extracting a variable or function via code action. It enables giving extracted function or variable a name right away without requiring a separate step. Otherwise extracted variable or function is left with a generic name like "newLocal".