### PR TITLE
fix(gopls): prioritise go.work at root_dir

### DIFF
--- a/lua/lspconfig/server_configurations/gopls.lua
+++ b/lua/lspconfig/server_configurations/gopls.lua
@@ -20,7 +20,7 @@ return {
           return clients[#clients].config.root_dir
         end
       end
-      return util.root_pattern('go.work', 'go.mod', '.git')(fname)
+      return util.root_pattern 'go.work'(fname) or util.root_pattern('go.mod', '.git')(fname)
     end,
     single_file_support = true,
   },


### PR DESCRIPTION
`go.work` should be prioritised as a root directory pattern over `go.mod`, otherwise you'll never match a `go.work` which is in a parent directory of a `go.mod` which is how `go.work` is intended to be used. I can see that this used to be the behaviour and it seems it was just accidentally broken as part of clean up in https://github.com/neovim/nvim-lspconfig/pull/2571.