### PR TITLE
feat(lua_ls): add main.lua as a root file

### DIFF
--- a/lua/lspconfig/server_configurations/lua_ls.lua
+++ b/lua/lspconfig/server_configurations/lua_ls.lua
@@ -8,6 +8,7 @@ local root_files = {
   'stylua.toml',
   'selene.toml',
   'selene.yml',
+  'main.lua',
 }
 
 return {


### PR DESCRIPTION
Some types of lua projects uses `main.lua` as the main entry-point, so it should be considered as a root file. Example: Love2D, mpv plugins, etc.