### PR TITLE
fix: remove usages of private (now deprecated) functions

### DIFF
--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -273,8 +273,6 @@ return function()
 
   local fmt_buf_lines = indent_lines(buf_lines, ' ')
 
-  fmt_buf_lines = vim.lsp.util._trim(fmt_buf_lines, {})
-
   api.nvim_buf_set_lines(bufnr, 0, -1, true, fmt_buf_lines)
   api.nvim_buf_set_option(bufnr, 'modifiable', false)
   api.nvim_buf_set_option(bufnr, 'filetype', 'lspinfo')
@@ -348,7 +346,6 @@ return function()
 
     local info = windows.percentage_range_window(0.8, 0.7)
     lines = indent_lines(lines, ' ')
-    lines = vim.lsp.util._trim(lines, {})
     api.nvim_buf_set_lines(info.bufnr, 0, -1, false, lines)
     api.nvim_buf_add_highlight(info.bufnr, 0, 'LspInfoTip', 0, 0, -1)
 


### PR DESCRIPTION
Functions prefixed with _ should not be used, as they have no stability
guarantees from Nvim and can be removed at anytime with no warning or
replacement. _trim was such a function that was recently removed.
