### PR TITLE
fix(perlls): remove --version argument

### DIFF
--- a/lua/lspconfig/server_configurations/perlls.lua
+++ b/lua/lspconfig/server_configurations/perlls.lua
@@ -10,7 +10,6 @@ return {
       '--',
       '--port 13603',
       '--nostdio 0',
-      '--version 2.1.0',
     },
     settings = {
       perl = {


### PR DESCRIPTION
Current version is 2.6.1. It is not needed at all to run the server, and most people have only one version installed at a time. Also updating this argument is tedious every time richterger/Perl-LanguageServer publishes a release.