### PR TITLE
add util.containing_dir, allow enabling typst_lsp outside of git repos

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -375,11 +375,15 @@ below returns a function that takes as its argument the current buffer path.
 >
    root_dir = util.root_pattern('pyproject.toml', 'requirements.txt')
 <
+- `util.containing_dir`: a function that returns the first parent directory.
+>
+   root_dir = util.containing_dir
+<
 - `util.find_git_ancestor`: a function that locates the first parent directory
   containing a `.git` directory.
 >
    root_dir = util.find_git_ancestor
-
+<
 - `util.find_node_modules_ancestor`: a function that locates the first parent
   directory containing a `node_modules` directory.
 >

--- a/lua/lspconfig/server_configurations/typst_lsp.lua
+++ b/lua/lspconfig/server_configurations/typst_lsp.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'typst-lsp' },
     filetypes = { 'typst' },
     root_dir = function(fname)
-      return util.find_git_ancestor(fname)
+      return util.find_git_ancestor(fname) or util.containing_dir(fname)
     end,
   },
   docs = {

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -265,6 +265,10 @@ function M.root_pattern(...)
   end
 end
 
+function M.containing_dir(path)
+  return M.path.dirname(path)
+end
+
 function M.find_git_ancestor(startpath)
   return M.search_ancestors(startpath, function(path)
     -- Support git directories and git files (worktrees)


### PR DESCRIPTION
- feat: add util.containing_dir function
    - this allows LSP configurations to use the first parent directory as the root_dir or as a fallback for the root_dir.
- docs: document util.containing_dir
- fix(typst_lsp): allow enabling outside of a git repo
    - typst-lsp does not support single files, as typst files can import other typst files in the same path. However, as a typesetting engine, typst documents don't always exist in a git repo. This allows typst-lsp to be enabled outside of git repos by adding a fallback to the first parent directory.

