### PR TITLE
fix(texlab): don't overly prioritize .latexmkrc

### DIFF
--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -70,9 +70,7 @@ return {
   default_config = {
     cmd = { 'texlab' },
     filetypes = { 'tex', 'plaintex', 'bib' },
-    root_dir = function(fname)
-      return util.root_pattern '.latexmkrc'(fname) or util.find_git_ancestor(fname)
-    end,
+    root_dir = util.root_pattern('.latexmkrc', '.git'),
     single_file_support = true,
     settings = {
       texlab = {


### PR DESCRIPTION
$HOME/.latexmkrc is per-user config, so it shouldn't be prioritized over closer directory containing .git.