### PR TITLE
Unexpected behaviour when executing ":LspStart lua" in "init.lua" file

### DIFF
--- a/lua/lspconfig/server_configurations/lua_ls.lua
+++ b/lua/lspconfig/server_configurations/lua_ls.lua
@@ -21,7 +21,7 @@ return {
       end
       root = util.root_pattern 'lua/'(fname)
       if root then
-        return root .. '/lua/'
+        return root
       end
       return util.find_git_ancestor(fname)
     end,


### PR DESCRIPTION
### Language server
lua_language_server

### Problem
I have nvim config, looking like this (which I believe is common):
```
nvim/
  lua/
    <a bunch of .lua files>
  init.lua
```
When I do `nvim init.lua` LSP client starts, but in single_file_mode. If I do `:LspStop` and then `:LspStart lua` it doesn't start, because it can't find the root directory.

### Proposed solution
If parent directory contains `lua/` directory, parent should be the root directory, not `parent .. "lua/"`.

### What happens
This way the root directory for `init.lua` is `nvim/` and for `lua/file.lua` is `nvim/` as well, instead of what happens now (can't find root directory for `init.lua` and for `lua/file.lua` root directory is `nvim/lua/`)