### PR TITLE
refactor: default_opts for border

### DIFF
--- a/lua/lspconfig/ui/windows.lua
+++ b/lua/lspconfig/ui/windows.lua
@@ -39,19 +39,8 @@ function win_float.default_opts(options)
     width = width,
     height = height,
     style = 'minimal',
-    border = {
-      { ' ', 'NormalFloat' },
-      { ' ', 'NormalFloat' },
-      { ' ', 'NormalFloat' },
-      { ' ', 'NormalFloat' },
-      { ' ', 'NormalFloat' },
-      { ' ', 'NormalFloat' },
-      { ' ', 'NormalFloat' },
-      { ' ', 'NormalFloat' },
-    },
+    border = options.border,
   }
-
-  opts.border = options.border and options.border
 
   return opts
 end


### PR DESCRIPTION
the default border config is not used, and `options.border and options.border` is not necessary