### PR TITLE
fix(launch): check buffer is valid before get_name

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -115,6 +115,9 @@ function configs.__newindex(t, config_name, config_def)
 
     function M.launch(bufnr)
       bufnr = bufnr or api.nvim_get_current_buf()
+      if not api.nvim_buf_is_valid(bufnr) then
+        return
+      end
       local bufname = api.nvim_buf_get_name(bufnr)
       if (#bufname == 0 and not config.single_file_support) or (#bufname ~= 0 and not util.bufname_valid(bufname)) then
         return


### PR DESCRIPTION
I'm using the plugin, that manages sessions using builtin `:mksession` and race lead to error on line 118, where 
`api.nvim_buf_get_name(bufnr)` called on not existing buffer. 
This PR adds check `api.nvim_buf_is_valid` to fix this error.

This fix works on this line, but sometimes I see also an error message from [neovim](https://github.com/neovim/neovim/blob/1e7e9ee91f73c62b8c5ba9dbdabba3a3b6dc0130/runtime/lua/vim/lsp/semantic_tokens.lua#L582) itself:
`[LSP] No client with id: `

it should be fixed too. But this is not related to nvim-lspconfig