### PR TITLE
fix(nginx-language-server): update root directory pattern

### DIFF
--- a/lua/lspconfig/server_configurations/nginx_language_server.lua
+++ b/lua/lspconfig/server_configurations/nginx_language_server.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'nginx-language-server' },
     filetypes = { 'nginx' },
     root_dir = function(fname)
-      return util.root_pattern('nginx.conf', '.git') or util.find_git_ancestor(fname)
+      return util.root_pattern('nginx.conf', '.git')(fname) or util.find_git_ancestor(fname)
     end,
     single_file_support = true,
   },


### PR DESCRIPTION
Add missing argument `fname` as loading the nginx server configuration  generates the following error:

```
[lspconfig] unhandled error: ...w/Cellar/neovim/0.9.4/share/nvim/runtime/lua/vim/uri.lua:64: attempt to index local 'path' (a function value)
```