### PR TITLE
feat: enable single file support for ruby-lsp

### DIFF
--- a/lua/lspconfig/server_configurations/ruby_ls.lua
+++ b/lua/lspconfig/server_configurations/ruby_ls.lua
@@ -8,6 +8,7 @@ return {
     init_options = {
       formatter = 'auto',
     },
+    single_file_support = true,
   },
   docs = {
     description = [[


### PR DESCRIPTION
Self explanatory, this PR enables single file support for ruby-lsp. 