### PR TITLE
feat(tailwindcss): add `gohtmltmpl` to filetypes

### DIFF
--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -20,6 +20,7 @@ return {
       'erb',
       'eruby', -- vim ft
       'gohtml',
+      'gohtmltmpl',
       'haml',
       'handlebars',
       'hbs',


### PR DESCRIPTION
Adding `gohtmltmpl` to the default filetypes for tailwindcss. This is a filetype added by [vim-go](https://github.com/fatih/vim-go).

This was added to tailwindcss-intellisense in https://github.com/tailwindlabs/tailwindcss-intellisense/pull/473.