### PR TITLE
feat(elixirls): Update elixirls.lua to work better with umbrella apps

### DIFF
--- a/lua/lspconfig/server_configurations/elixirls.lua
+++ b/lua/lspconfig/server_configurations/elixirls.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
     root_dir = function(fname)
-      return util.root_pattern('mix.exs', '.git')(fname) or vim.loop.os_homedir()
+      return util.find_git_ancestor(fname) or util.root_pattern 'mix.exs'(fname) or vim.loop.os_homedir()
     end,
   },
   docs = {
@@ -33,7 +33,7 @@ require'lspconfig'.elixirls.setup{
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern("mix.exs", ".git") or vim.loop.os_homedir()]],
+      root_dir = [[util.find_git_ancestor(fname) or util.root_pattern 'mix.exs'(fname) or vim.loop.os_homedir()]],
     },
   },
 }


### PR DESCRIPTION
In Elixir, it's usual to work with umbrella apps, which works as like a monorepo:

```
blog/
├── .git/
├── config/
├── apps/
│   ├── blog_web/
│   │   ├── mix.exs
│   │   ├── lib/
│   │   └── test/
│   └── blog/
│       ├── mix.exs
│       ├── lib/
│       └── test/
└── mix.exs
```

With the current config, neovim would create a new elixirls server for each directory inside apps/. Unfortunately, there's no good way to know if we're dealing with a umbrella structure or a single-app structure without checking the contents of `mix.exs`.

So, I propose to give a higher priority to detecting `.git` in the root folder and using that as the root for lsp. I'm already using this config in my neovim config.