### PR TITLE
Add nushell built-in language server support

### DIFF
--- a/lua/lspconfig/server_configurations/nushell.lua
+++ b/lua/lspconfig/server_configurations/nushell.lua
@@ -1,0 +1,19 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'nu', '--lsp' },
+    filetypes = { 'nu' },
+    root_dir = util.find_git_ancestor,
+  },
+  docs = {
+    description = [[
+https://github.com/nushell/nushell
+
+Nushell built-in language server.
+]],
+    default_config = {
+      root_dir = [[util.find_git_ancestor]],
+    },
+  },
+}


### PR DESCRIPTION
Fixes #2592 (Originally closed due to no language server being available)
This adds support for the built-in language server that was [added to nushell a week ago](https://github.com/nushell/nushell/pull/10723), which will be available in an upcoming release.

Seems like currently it only supports function hover
![image](https://github.com/neovim/nvim-lspconfig/assets/52386117/2c29dd0f-63b5-4593-abac-b234d0ceb4df)
