### PR TITLE
fix: util.root_pattern prioritises pattern order

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -371,7 +371,8 @@ below returns a function that takes as its argument the current buffer path.
 - `util.root_pattern`: function which takes multiple arguments, each 
   corresponding to a different root pattern against which the contents of the
   current directory are matched using |vim.fn.glob()| while traversing up the
-  filesystem.
+  filesystem. Parent directories are traversed once per pattern, in the order
+  the patterns are specified.
 >
    root_dir = util.root_pattern('pyproject.toml', 'requirements.txt')
 <

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -250,18 +250,21 @@ end
 
 function M.root_pattern(...)
   local patterns = vim.tbl_flatten { ... }
-  local function matcher(path)
-    for _, pattern in ipairs(patterns) do
-      for _, p in ipairs(vim.fn.glob(M.path.join(M.path.escape_wildcards(path), pattern), true, true)) do
-        if M.path.exists(p) then
-          return path
-        end
-      end
-    end
-  end
   return function(startpath)
     startpath = M.strip_archive_subpath(startpath)
-    return M.search_ancestors(startpath, matcher)
+    for _, pattern in ipairs(patterns) do
+      local match = M.search_ancestors(startpath, function(path)
+        for _, p in ipairs(vim.fn.glob(M.path.join(M.path.escape_wildcards(path), pattern), true, true)) do
+          if M.path.exists(p) then
+            return path
+          end
+        end
+      end)
+
+      if match ~= nil then
+        return match
+      end
+    end
   end
 end
 

--- a/test/lspconfig_spec.lua
+++ b/test/lspconfig_spec.lua
@@ -136,7 +136,7 @@ describe('lspconfig', function()
         -- change the working directory to test directory
         vim.api.nvim_command 'cd ./test/test_dir/a'
         local cwd = vim.fn.getcwd()
-        eq(true, cwd == lspconfig.util.root_pattern { 'root_marker.txt', 'a_marker.txt' }(cwd))
+        eq(true, cwd == lspconfig.util.root_pattern { 'a_marker.txt', 'root_marker.txt' }(cwd))
       end)
 
       it('resolves to root_marker.txt', function()


### PR DESCRIPTION
Because of the way `util.root_dir` is defined, `.csproj` files are found before `.sln` files and the incorrect root directory is set. This prevents go-to-definition between multiple projects in a single solution and causes a few other issues. See #2612 for a more in-depth explanation.

This updates the default configuration to avoid this footgun.

EDIT:

The changes now cover the above issue, but does so in a more general way by updating the `util.root_pattern` function.

closes #2612 
related to razzmatazz/csharp-language-server#57