### PR TITLE
feat: add contextive-language-server support

### DIFF
--- a/lua/lspconfig/server_configurations/contextive.lua
+++ b/lua/lspconfig/server_configurations/contextive.lua
@@ -1,0 +1,21 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'Contextive.LanguageServer' },
+    root_dir = util.root_pattern('.contextive', '.git'),
+  },
+  docs = {
+    description = [[
+https://github.com/dev-cycles/contextive
+
+Language Server for Contextive.
+
+Contextive allows you to define terms in a central file and provides auto-completion suggestions and hover panels for these terms wherever they're used.
+
+To install the language server, you need to download the appropriate [GitHub release asset](https://github.com/dev-cycles/contextive/releases/) for your operating system and architecture.
+
+After the download unzip the Contextive.LanguageServer binary and copy the file into a folder that is included in your system's PATH.
+]],
+  },
+}


### PR DESCRIPTION
Contextive language server provides domain terminology directly in the IDE by reading a terminology file.

> By defining terms in a central definitions file, Contextive can surface definitions and usage examples in auto-complete suggestions & hover panels wherever the terms are used - in code (of any language across the stack), comments, config, and documentation (e.g. markdown).
https://github.com/dev-cycles/contextive

How it looks:
<img width="923" alt="contextive-sample-nvim" src="https://github.com/dev-cycles/contextive/assets/15418377/1e73c2e4-2c95-43a4-8956-f005feb3c64a">