### PR TITLE
fix: remove outdated progress message handler

### DIFF
--- a/lua/lspconfig/server_configurations/jdtls.lua
+++ b/lua/lspconfig/server_configurations/jdtls.lua
@@ -120,7 +120,6 @@ return {
       ['textDocument/rename'] = on_textdocument_rename,
       ['workspace/applyEdit'] = on_workspace_applyedit,
       ['language/status'] = vim.schedule_wrap(on_language_status),
-      ['$/progress'] = vim.schedule_wrap(on_language_status),
     },
   },
   docs = {


### PR DESCRIPTION
[ISSUE]
previously the message type of progress event was

{
  message = "0% Starting Java Language Server",
  type = "Starting"
}

however in the latest (1.29.0) use the proper data structure like below. so the custom handler is no longer needed.

{
  token = string,
  value = {
    kind = "report",
    message = "Initialize Workspace - 30% ",
    percentage = 30
  }
}

By removing the custom handler in jdtls config, vim.lsp.handlers['$/progress'] will be used.