### PR TITLE
fix: remove outdated jdtls progress message handler (#2897)

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -4856,11 +4856,10 @@ require'lspconfig'.jdtls.setup{}
   - `handlers` : 
   ```lua
   {
-    ["$/progress"] = <function 1>,
-    ["language/status"] = <function 2>,
-    ["textDocument/codeAction"] = <function 3>,
-    ["textDocument/rename"] = <function 4>,
-    ["workspace/applyEdit"] = <function 5>
+    ["language/status"] = <function 1>,
+    ["textDocument/codeAction"] = <function 2>,
+    ["textDocument/rename"] = <function 3>,
+    ["workspace/applyEdit"] = <function 4>
   }
   ```
   - `init_options` : 

--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -4856,11 +4856,10 @@ require'lspconfig'.jdtls.setup{}
   - `handlers` : 
   ```lua
   {
-    ["$/progress"] = <function 1>,
-    ["language/status"] = <function 2>,
-    ["textDocument/codeAction"] = <function 3>,
-    ["textDocument/rename"] = <function 4>,
-    ["workspace/applyEdit"] = <function 5>
+    ["language/status"] = <function 1>,
+    ["textDocument/codeAction"] = <function 2>,
+    ["textDocument/rename"] = <function 3>,
+    ["workspace/applyEdit"] = <function 4>
   }
   ```
   - `init_options` : 

--- a/lua/lspconfig/server_configurations/jdtls.lua
+++ b/lua/lspconfig/server_configurations/jdtls.lua
@@ -120,7 +120,6 @@ return {
       ['textDocument/rename'] = on_textdocument_rename,
       ['workspace/applyEdit'] = on_workspace_applyedit,
       ['language/status'] = vim.schedule_wrap(on_language_status),
-      ['$/progress'] = vim.schedule_wrap(on_language_status),
     },
   },
   docs = {


### PR DESCRIPTION
progress message

**before**
![screenshot 23-11-16 22:09:33](https://github.com/neovim/nvim-lspconfig/assets/18459807/507976cf-b691-4f15-b8e8-07677cbc8cf9)

**After**
![screenshot 23-11-16 22:19:08](https://github.com/neovim/nvim-lspconfig/assets/18459807/c3208c6d-e840-41a7-a9db-d4af0e844201)
