### PR TITLE
feat: enable single file mode for nushell lsp

### DIFF
--- a/lua/lspconfig/server_configurations/nushell.lua
+++ b/lua/lspconfig/server_configurations/nushell.lua
@@ -5,6 +5,7 @@ return {
     cmd = { 'nu', '--lsp' },
     filetypes = { 'nu' },
     root_dir = util.find_git_ancestor,
+    single_file_support = true,
   },
   docs = {
     description = [[


### PR DESCRIPTION
This allows the nushell LSP to kick in when opening the current shell command in neovim (using CTRL+O by default)