### PR TITLE
fix(rust-analyzer): don't run cargo if Cargo.toml is not found

### DIFF
--- a/lua/lspconfig/server_configurations/rust_analyzer.lua
+++ b/lua/lspconfig/server_configurations/rust_analyzer.lua
@@ -50,19 +50,26 @@ return {
       end
 
       local cargo_crate_dir = util.root_pattern 'Cargo.toml'(fname)
-      local cmd = { 'cargo', 'metadata', '--no-deps', '--format-version', '1' }
-      if cargo_crate_dir ~= nil then
-        cmd[#cmd + 1] = '--manifest-path'
-        cmd[#cmd + 1] = util.path.join(cargo_crate_dir, 'Cargo.toml')
-      end
-
-      local result = async.run_command(cmd)
       local cargo_workspace_root
 
-      if result and result[1] then
-        result = vim.json.decode(table.concat(result, ''))
-        if result['workspace_root'] then
-          cargo_workspace_root = util.path.sanitize(result['workspace_root'])
+      if cargo_crate_dir ~= nil then
+        local cmd = {
+          'cargo',
+          'metadata',
+          '--no-deps',
+          '--format-version',
+          '1',
+          '--manifest-path',
+          util.path.join(cargo_crate_dir, 'Cargo.toml'),
+        }
+
+        local result = async.run_command(cmd)
+
+        if result and result[1] then
+          result = vim.json.decode(table.concat(result, ''))
+          if result['workspace_root'] then
+            cargo_workspace_root = util.path.sanitize(result['workspace_root'])
+          end
         end
       end
 


### PR DESCRIPTION
After commit https://github.com/neovim/nvim-lspconfig/commit/d5d7412ff267b92a11a94e6559d5507c43670a52 I started getting the message
```
[lspconfig] cmd failed with code 101: table: 0x0104f90fe0
error: could not find `Cargo.toml` in `<path>` or any parent directory
Press ENTER or type command to continue
```
every time I open a rust file in a project that doesn't use cargo. For some reason `cargo` is launched even if `Cargo.toml` is not found which seems wrong, so I moved all the cargo logic inside `if cargo_crate_dir ~= nil`.
rust-analyzer supports non-cargo projects via `rust-project.json` that nvim-lspconfig also supports, and it's what I use.
