### PR TITLE
fix: cleanup root patterns

### DIFF
--- a/lua/lspconfig/server_configurations/cairo_ls.lua
+++ b/lua/lspconfig/server_configurations/cairo_ls.lua
@@ -8,10 +8,7 @@ return {
     init_options = { hostInfo = 'neovim' },
     cmd = cmd,
     filetypes = { 'cairo' },
-    root_dir = function(fname)
-      return util.root_pattern 'Scarb.toml'(fname)
-        or util.root_pattern('Scarb.toml', 'cairo_project.toml', '.git')(fname)
-    end,
+    root_dir = util.root_pattern('Scarb.toml', 'cairo_project.toml', '.git'),
   },
   docs = {
     description = [[
@@ -27,7 +24,7 @@ require'lspconfig'.cairo_ls.setup{}
 *cairo-language-server is still under active development, some features might not work yet !*
 ]],
     default_config = {
-      root_dir = [[root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")]],
+      root_dir = [[root_pattern("Scarb.toml", "cairo_project.toml", ".git")]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/custom_elements_ls.lua
+++ b/lua/lspconfig/server_configurations/custom_elements_ls.lua
@@ -4,10 +4,7 @@ return {
   default_config = {
     init_options = { hostInfo = 'neovim' },
     cmd = { 'custom-elements-languageserver', '--stdio' },
-    root_dir = function(fname)
-      return util.root_pattern 'tsconfig.json'(fname)
-        or util.root_pattern('package.json', 'jsconfig.json', '.git')(fname)
-    end,
+    root_dir = util.root_pattern('tsconfig.json', 'package.json', 'jsconfig.json', '.git'),
   },
   docs = {
     description = [[
@@ -36,7 +33,7 @@ Here's an example that disables type checking in JavaScript files.
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")]],
+      root_dir = [[root_pattern("tsconfig.json", "package.json", "jsconfig.json", ".git")]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/gopls.lua
+++ b/lua/lspconfig/server_configurations/gopls.lua
@@ -20,7 +20,7 @@ return {
           return clients[#clients].config.root_dir
         end
       end
-      return util.root_pattern 'go.work'(fname) or util.root_pattern('go.mod', '.git')(fname)
+      return util.root_pattern('go.work', 'go.mod', '.git')(fname)
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/server_configurations/gradle_ls.lua
+++ b/lua/lspconfig/server_configurations/gradle_ls.lua
@@ -7,18 +7,13 @@ end
 
 local root_files = {
   'settings.gradle', -- Gradle (multi-project)
-}
-
-local fallback_root_files = {
   'build.gradle', -- Gradle
 }
 
 return {
   default_config = {
     filetypes = { 'groovy' },
-    root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname) or util.root_pattern(unpack(fallback_root_files))(fname)
-    end,
+    root_dir = util.root_pattern(unpack(root_files)),
     cmd = { bin_name },
     -- gradle-language-server expects init_options.settings to be defined
     init_options = {
@@ -36,7 +31,7 @@ Microsoft's lsp server for gradle files
 If you're setting this up manually, build vscode-gradle using `./gradlew installDist` and point `cmd` to the `gradle-language-server` generated in the build directory
 ]],
     default_config = {
-      root_dir = [[root_pattern("settings.gradle")]],
+      root_dir = [[root_pattern("settings.gradle", "build.gradle")]],
       cmd = { 'gradle-language-server' },
       init_options = {
         settings = {

--- a/lua/lspconfig/server_configurations/hls.lua
+++ b/lua/lspconfig/server_configurations/hls.lua
@@ -4,12 +4,7 @@ return {
   default_config = {
     cmd = { 'haskell-language-server-wrapper', '--lsp' },
     filetypes = { 'haskell', 'lhaskell' },
-    root_dir = function(filepath)
-      return (
-        util.root_pattern('hie.yaml', 'stack.yaml', 'cabal.project')(filepath)
-        or util.root_pattern('*.cabal', 'package.yaml')(filepath)
-      )
-    end,
+    root_dir = util.root_pattern('hie.yaml', 'stack.yaml', 'cabal.project', '*.cabal', 'package.yaml'),
     single_file_support = true,
     settings = {
       haskell = {
@@ -51,14 +46,7 @@ require('lspconfig')['hls'].setup{
     ]],
 
     default_config = {
-      root_dir = [[
-function (filepath)
-  return (
-    util.root_pattern('hie.yaml', 'stack.yaml', 'cabal.project')(filepath)
-    or util.root_pattern('*.cabal', 'package.yaml')(filepath)
-  )
-end
-      ]],
+      root_dir = [[root_pattern("hie.yaml", "stack.yaml", "cabal.project", "*.cabal", "package.yaml")]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/kotlin_language_server.lua
+++ b/lua/lspconfig/server_configurations/kotlin_language_server.lua
@@ -15,9 +15,6 @@ local root_files = {
   'settings.gradle.kts', -- Gradle (multi-project)
   'build.xml', -- Ant
   'pom.xml', -- Maven
-}
-
-local fallback_root_files = {
   'build.gradle', -- Gradle
   'build.gradle.kts', -- Gradle
 }
@@ -25,9 +22,7 @@ local fallback_root_files = {
 return {
   default_config = {
     filetypes = { 'kotlin' },
-    root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname) or util.root_pattern(unpack(fallback_root_files))(fname)
-    end,
+    root_dir = util.root_pattern(unpack(root_files)),
     cmd = { bin_name },
   },
   docs = {

--- a/lua/lspconfig/server_configurations/omnisharp.lua
+++ b/lua/lspconfig/server_configurations/omnisharp.lua
@@ -38,15 +38,7 @@ return {
     analyze_open_documents_only = false,
 
     filetypes = { 'cs', 'vb' },
-    root_dir = function(fname)
-      local root_patterns = { '*.sln', '*.csproj', 'omnisharp.json', 'function.json' }
-      for _, pattern in ipairs(root_patterns) do
-        local found = util.root_pattern(pattern)(fname)
-        if found then
-          return found
-        end
-      end
-    end,
+    root_dir = util.root_pattern('*.sln', '*.csproj', 'omnisharp.json', 'function.json'),
     on_new_config = function(new_config, _)
       -- Get the initially configured value of `cmd`
       new_config.cmd = { unpack(new_config.cmd or {}) }
@@ -149,7 +141,7 @@ require'lspconfig'.omnisharp.setup {
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern(".sln") or root_pattern(".csproj")]],
+      root_dir = [[root_pattern("*.sln", "*.csproj", "omnisharp.json", "function.json")]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/syntax_tree.lua
+++ b/lua/lspconfig/server_configurations/syntax_tree.lua
@@ -4,9 +4,7 @@ return {
   default_config = {
     cmd = { 'stree', 'lsp' },
     filetypes = { 'ruby' },
-    root_dir = function(fname)
-      return util.root_pattern '.streerc'(fname) or util.root_pattern('Gemfile', '.git')(fname)
-    end,
+    root_dir = util.root_pattern('.streerc', 'Gemfile', '.git'),
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -100,11 +100,16 @@ return {
       end
     end,
     root_dir = function(fname)
-      return util.root_pattern('tailwind.config.js', 'tailwind.config.cjs', 'tailwind.config.mjs', 'tailwind.config.ts')(
-        fname
-      ) or util.root_pattern('postcss.config.js', 'postcss.config.cjs', 'postcss.config.mjs', 'postcss.config.ts')(
-        fname
-      ) or util.find_package_json_ancestor(fname) or util.find_node_modules_ancestor(fname) or util.find_git_ancestor(
+      return util.root_pattern(
+        'tailwind.config.js',
+        'tailwind.config.cjs',
+        'tailwind.config.mjs',
+        'tailwind.config.ts',
+        'postcss.config.js',
+        'postcss.config.cjs',
+        'postcss.config.mjs',
+        'postcss.config.ts'
+      )(fname) or util.find_package_json_ancestor(fname) or util.find_node_modules_ancestor(fname) or util.find_git_ancestor(
         fname
       )
     end,

--- a/lua/lspconfig/server_configurations/tsserver.lua
+++ b/lua/lspconfig/server_configurations/tsserver.lua
@@ -12,10 +12,7 @@ return {
       'typescriptreact',
       'typescript.tsx',
     },
-    root_dir = function(fname)
-      return util.root_pattern 'tsconfig.json'(fname)
-        or util.root_pattern('package.json', 'jsconfig.json', '.git')(fname)
-    end,
+    root_dir = util.root_pattern('tsconfig.json', 'package.json', 'jsconfig.json', '.git'),
     single_file_support = true,
   },
   docs = {
@@ -48,7 +45,7 @@ Here's an example that disables type checking in JavaScript files.
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")]],
+      root_dir = [[root_pattern("tsconfig.json", "package.json", "jsconfig.json", ".git")]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/vtsls.lua
+++ b/lua/lspconfig/server_configurations/vtsls.lua
@@ -11,10 +11,7 @@ return {
       'typescriptreact',
       'typescript.tsx',
     },
-    root_dir = function(fname)
-      return util.root_pattern 'tsconfig.json'(fname)
-        or util.root_pattern('package.json', 'jsconfig.json', '.git')(fname)
-    end,
+    root_dir = util.root_pattern('tsconfig.json', 'package.json', 'jsconfig.json', '.git'),
     single_file_support = true,
   },
   docs = {
@@ -32,7 +29,7 @@ or [`jsconfig.json`](https://code.visualstudio.com/docs/languages/jsconfig) to
 the root of your project.
 ]],
     default_config = {
-      root_dir = [[root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")]],
+      root_dir = [[root_pattern("tsconfig.json", "package.json", "jsconfig.json", ".git")]],
     },
   },
 }


### PR DESCRIPTION
Simplify `root_dir` in multiple language server configurations where root patterns needed to be prioritised. `util.root_pattern` now prioritises root patterns provided first - see #2885.

Closes #2904 