### PR TITLE
feat: add support for slangd

### DIFF
--- a/lua/lspconfig/server_configurations/slangd.lua
+++ b/lua/lspconfig/server_configurations/slangd.lua
@@ -1,0 +1,44 @@
+local util = require 'lspconfig.util'
+local bin_name = 'slangd'
+
+if vim.fn.has 'win32' == 1 then
+  bin_name = 'slangd.exe'
+end
+
+return {
+  default_config = {
+    cmd = { bin_name },
+    filetypes = { 'hlsl', 'shaderslang' },
+    root_dir = util.find_git_ancestor,
+    single_file_support = true,
+  },
+  docs = {
+    description = [[
+https://github.com/shader-slang/slang
+
+The `slangd` binary can be downloaded as part of [slang releases](https://github.com/shader-slang/slang/releases) or
+by [building `slang` from source](https://github.com/shader-slang/slang/blob/master/docs/building.md).
+
+The server can be configured by passing a "settings" object to `slangd.setup{}`:
+
+```lua
+require('lspconfig').slangd.setup{
+  settings = {
+    slang = {
+      predefinedMacros = {"MY_VALUE_MACRO=1"},
+      inlayHints = {
+        deducedTypes = true,
+        parameterNames = true,
+      }
+    }
+  }
+}
+```
+Available options are documented [here](https://github.com/shader-slang/slang-vscode-extension/tree/main?tab=readme-ov-file#configurations)
+or in more detail [here](https://github.com/shader-slang/slang-vscode-extension/blob/main/package.json#L70).
+]],
+    default_config = {
+      root_dir = [[util.find_git_ancestor]],
+    },
+  },
+}


### PR DESCRIPTION
`slangd` is the language server for [slang](https://github.com/shader-slang/slang), a shader language that extends HLSL with additional features.

The filetype `shaderslang` is a invention of myself, but I plan to also use it for a tree-sitter parser https://github.com/nvim-treesitter/nvim-treesitter/pull/5659 and a TBD PR to vim for filetype detection. `shaderslang` is used because Vim/Neovim already has support for a filetype called `slang` which I assume is for https://en.wikipedia.org/wiki/S-Lang with extension `*.sl` while `shaderslang` uses `*.slang`. The language server also works with regular `hlsl` https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl / https://de.wikipedia.org/wiki/High_Level_Shading_Language (which would also require a PR to be detected by Vim/Neovim). I'm not aware of any Vim plugins for slang.

Please let me know when this PR should remain in draft status until the Vim PR is completed.