### PR TITLE
fix(elixirls): root_dir priority: mix.exs > .git

### DIFF
--- a/lua/lspconfig/server_configurations/elixirls.lua
+++ b/lua/lspconfig/server_configurations/elixirls.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
     root_dir = function(fname)
-      return util.find_git_ancestor(fname) or util.root_pattern 'mix.exs'(fname) or vim.loop.os_homedir()
+      return util.root_pattern 'mix.exs'(fname) or util.find_git_ancestor(fname) or vim.loop.os_homedir()
     end,
   },
   docs = {


### PR DESCRIPTION
If we're in a subdirectory of a git repo, and that subdirectory contains a mix.exs file, it makes sense to assume the subdirectory is the project root, rather than the git repo root.