### PR TITLE
perf: reduce an unnecessary function call

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -5,8 +5,8 @@ if vim.g.lspconfig ~= nil then
 end
 vim.g.lspconfig = 1
 
-local version_info = vim.version()
 if vim.fn.has 'nvim-0.7' ~= 1 then
+  local version_info = vim.version()
   local warning_str = string.format(
     '[lspconfig] requires neovim 0.7 or later. Detected neovim version: 0.%s.%s',
     version_info.minor,


### PR DESCRIPTION
The `local version_info = vim.version()` is currently only used in the `if vim.fn.has 'nvim-0.7' ~= 1 then` case.
This function call is useless. I have reduced it.