### PR TITLE
chore(emmet_language_server): emove languages with emmet bundled by their language server

### DIFF
--- a/lua/lspconfig/server_configurations/emmet_language_server.lua
+++ b/lua/lspconfig/server_configurations/emmet_language_server.lua
@@ -4,7 +4,6 @@ return {
   default_config = {
     cmd = { 'emmet-language-server', '--stdio' },
     filetypes = {
-      'astro',
       'css',
       'eruby',
       'html',
@@ -14,9 +13,7 @@ return {
       'pug',
       'sass',
       'scss',
-      'svelte',
       'typescriptreact',
-      'vue',
     },
     root_dir = util.find_git_ancestor,
     single_file_support = true,


### PR DESCRIPTION
This PR removes `vue`, `astro`, and `svelte` from the list of filetypes since the language server used by those languages already bundle emmet in their implementation.

https://github.com/olrtg/emmet-language-server/pull/25