### PR TITLE
fix(typos_lsp): use configuration file for root detection

### DIFF
--- a/lua/lspconfig/server_configurations/typos_lsp.lua
+++ b/lua/lspconfig/server_configurations/typos_lsp.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'typos-lsp' },
     filetypes = { '*' },
-    root_dir = util.root_pattern('pyproject.toml', '.git'),
+    root_dir = util.root_pattern('typos.toml', '_typos.toml', '.typos.toml', '.git'),
     single_file_support = true,
     settings = {},
   },


### PR DESCRIPTION
I'm not sure why the root detection for this language server was based on `pyproject.toml` since it has nothing to do with python projects. This updates the root detection to detect the root using the typos configuration file instead.