### PR TITLE
fix(rubocop): don't auto-detect bundler, to avoid surprising configuration behavior

### DIFF
--- a/lua/lspconfig/server_configurations/rubocop.lua
+++ b/lua/lspconfig/server_configurations/rubocop.lua
@@ -6,13 +6,6 @@ return {
     filetypes = { 'ruby' },
     root_dir = util.root_pattern('Gemfile', '.git'),
   },
-  on_new_config = function(config, root_dir)
-    -- prepend 'bundle exec' to cmd if bundler is being used
-    local gemfile_path = util.path.join(root_dir, 'Gemfile')
-    if util.path.exists(gemfile_path) then
-      config.cmd = { 'bundle', 'exec', unpack(config.cmd) }
-    end
-  end,
   docs = {
     description = [[
 https://github.com/rubocop/rubocop


### PR DESCRIPTION
Ref. #2716. The referenced PR changes got somehow lost when it came to the removal of the `on_new_config` function.

cc. @gongfarmer 