### PR TITLE
fix(cssls): enable enabling of formatting capabilities

### DIFF
--- a/lua/lspconfig/server_configurations/cssls.lua
+++ b/lua/lspconfig/server_configurations/cssls.lua
@@ -4,6 +4,7 @@ return {
   default_config = {
     cmd = { 'vscode-css-language-server', '--stdio' },
     filetypes = { 'css', 'scss', 'less' },
+    init_options = { provideFormatter = true }, -- needed to enable formatting capabilities
     root_dir = util.root_pattern('package.json', '.git'),
     single_file_support = true,
     settings = {


### PR DESCRIPTION
For some reason not entirely clear to me, simply adding `css.settings.format.enable = true` does not work to enable the formatting capabilities of the LSP.

the css-lsp's documentation isn't great, but [in the repo of the sublime-client for cssls](https://github.com/sublimelsp/LSP-css/blob/be5f00bc7f64fa8dc6b74a214b82486209fef0e6/language-server/css-language-features/server/out/cssServer.js#L102), I found that apparently you need add `provideFormatter = true` as an initialization option. not sure where exactly that options comes from though, as it does not seem to be included [in the code of the vscode language server](https://github.com/search?q=repo%3Amicrosoft%2Fvscode-css-languageservice%20provdeFormatter&type=code), so I assume it has sth to do with the language server extraction?

Anyway, adding `provideFormatter = true` to the init_options works and enables enabling (no typo) the formatting capabilities.