### PR TITLE
feat(kotlin_language_server): Add storagePath to initilaztion options

### DIFF
--- a/lua/lspconfig/server_configurations/kotlin_language_server.lua
+++ b/lua/lspconfig/server_configurations/kotlin_language_server.lua
@@ -24,6 +24,9 @@ return {
     filetypes = { 'kotlin' },
     root_dir = util.root_pattern(unpack(root_files)),
     cmd = { bin_name },
+    init_options = {
+      storagePath = util.root_pattern(unpack(root_files))(vim.fn.expand '%:p:h'),
+    },
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/kotlin_language_server.lua
+++ b/lua/lspconfig/server_configurations/kotlin_language_server.lua
@@ -42,28 +42,16 @@ return {
     You could refer for this capability to:
     https://github.com/udalov/kotlin-vim (recommended)
     Note that there is no LICENSE specified yet.
+
+    For faster startup, you can setup caching by specifying a storagePath
+    in the init_options. The default is your home directory.
     ]],
     default_config = {
-      root_dir = [[root_pattern("settings.gradle")]],
+      root_dir = [[See source]],
       cmd = { 'kotlin-language-server' },
-      capabilities = [[
-      smart code completion,
-      diagnostics,
-      hover,
-      document symbols,
-      definition lookup,
-      method signature help,
-      dependency resolution,
-      additional plugins from: https://github.com/fwcd
-
-      Snipped of License (refer to source for full License):
-
-      The MIT License (MIT)
-
-      Copyright (c) 2016 George Fraser
-      Copyright (c) 2018 fwcd
-
-      ]],
+      init_options = {
+        storagePath = [[Enables caching and use project root to store cache data. See source]],
+      },
     },
   },
 }

--- a/lua/lspconfig/server_configurations/psalm.lua
+++ b/lua/lspconfig/server_configurations/psalm.lua
@@ -1,9 +1,8 @@
 local util = require 'lspconfig.util'
 
-
 return {
   default_config = {
-    cmd = {'psalm', '--language-server'},
+    cmd = { 'psalm', '--language-server' },
     filetypes = { 'php' },
     root_dir = util.root_pattern('psalm.xml', 'psalm.xml.dist'),
   },
@@ -17,7 +16,7 @@ composer global require vimeo/psalm
 ```
 ]],
     default_config = {
-      cmd = {'psalm', '--language-server'},
+      cmd = { 'psalm', '--language-server' },
       root_dir = [[root_pattern("psalm.xml", "psalm.xml.dist")]],
     },
   },


### PR DESCRIPTION
- Add default value for storagePath to enable caching. This feature is important for Kotlin project because the LSP start takes too long because of indexing on each start. I'm not sure if this option fits the [boundary](https://github.com/neovim/nvim-lspconfig/blob/master/CONTRIBUTING.md#scope-of-lspconfig) or not. For me it's a sane default
- Update docs

feature was added in https://github.com/fwcd/kotlin-language-server/pull/337 to help with caching and speeding up the language server.

I did not find the feature documented in the LSP repo to link but it has been used in:
- https://github.com/fwcd/vscode-kotlin/pull/86/
- https://github.com/emacs-lsp/lsp-mode/pull/4197