### PR TITLE
fix(zls): include `build.zig` in root dir search

### DIFF
--- a/lua/lspconfig/server_configurations/zls.lua
+++ b/lua/lspconfig/server_configurations/zls.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'zls' },
     filetypes = { 'zig', 'zir' },
-    root_dir = util.root_pattern('zls.json', '.git'),
+    root_dir = util.root_pattern('zls.json', 'build.zig', '.git'),
     single_file_support = true,
   },
   docs = {
@@ -14,7 +14,7 @@ https://github.com/zigtools/zls
 Zig LSP implementation + Zig Language Server
         ]],
     default_config = {
-      root_dir = [[util.root_pattern("zls.json", ".git")]],
+      root_dir = [[util.root_pattern("zls.json", "build.zig", ".git")]],
     },
   },
 }


### PR DESCRIPTION
File `build.zig` by convention sits at the root dir and thus can be used to correctly identify the root directory.

This is particularly useful if `zls` has `enable_build_on_save` set to `true`, since then the language server uses workspace path (root_dir) to execute `zig build` command, output of which is then used to publish diagnostic errors.

Without `build.zig` root directory can incorrectly be deduced some layers too high at the root of the git repo. In such case `enable_build_on_save` silently fails and does not report build error diagnostics.