### PR TITLE
fix: typos root directory indicator

### DIFF
--- a/lua/lspconfig/server_configurations/typos_lsp.lua
+++ b/lua/lspconfig/server_configurations/typos_lsp.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'typos-lsp' },
     filetypes = { '*' },
-    root_dir = util.root_pattern('typos.toml', '_typos.toml', '.typos.toml', '.git'),
+    root_dir = util.root_pattern('typos.toml', '_typos.toml', '.typos.toml'),
     single_file_support = true,
     settings = {},
   },


### PR DESCRIPTION
This PR removes `.git` as root pattern. Doing so fixes some issues associated with nested workspaces / repos with multiple `typos.toml` configuration file, that are further elaborated here: https://github.com/tekumara/typos-vscode/issues/23 Long story short, having `.git` as root indicator can in some situations lead to not detecting `typos.toml` configuration files. 

`typos-lsp` runs fine in single-file-mode when no root pattern can be found. In fact, as far as I can tell, picking up a configuration file is the only reason the `typos-lsp` actually needs a root pattern for, otherwise single file mode works fine, probably since the LSP is only a wrapper around the `typos` cli. Thus, there should be no downside to removing `.git` as root pattern, and the only consequence would be to fix issues with multiple `typos.toml` files.