### PR TITLE
feat: add twig-language-server

### DIFF
--- a/lua/lspconfig/server_configurations/twig_language_server.lua
+++ b/lua/lspconfig/server_configurations/twig_language_server.lua
@@ -1,0 +1,21 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'twig-language-server', '--stdio' },
+    filetypes = { 'twig' },
+    root_dir = util.root_pattern('composer.json', '.git'),
+    single_file_support = true,
+  },
+  docs = {
+    description = [[
+https://github.com/moetelo/twiggy
+
+Can be installed via Mason, which uses the server bundled with the VSCode extension.
+```
+]],
+    default_config = {
+      root_dir = [[root_pattern("composer.json", ".git")]],
+    },
+  },
+}


### PR DESCRIPTION
The docs describe the installation via Mason based on my PR over there: https://github.com/mason-org/mason-registry/pull/3855

While twiggy is a fork of https://github.com/kaermorchen/twig-language-server, it's maintainer adds features much faster.