### PR TITLE
chore: check version 0.8+

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -5,10 +5,10 @@ if vim.g.lspconfig ~= nil then
 end
 vim.g.lspconfig = 1
 
-if vim.fn.has 'nvim-0.7' ~= 1 then
+if vim.fn.has 'nvim-0.8' ~= 1 then
   local version_info = vim.version()
   local warning_str = string.format(
-    '[lspconfig] requires neovim 0.7 or later. Detected neovim version: 0.%s.%s',
+    '[lspconfig] requires neovim 0.8 or later. Detected neovim version: 0.%s.%s',
     version_info.minor,
     version_info.patch
   )


### PR DESCRIPTION
As documented in README.md(after 5a871409199d585b52b69952532e3fb435e64566), nvim-lspconfig now supports version 0.8 or later. Update code to perform this version check.