### PR TITLE
refactor: improve get_clients_from_cmd_args

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -40,12 +40,12 @@ end
 local get_clients_from_cmd_args = function(arg)
   local result = {}
   for id in (arg or ''):gmatch '(%d+)' do
-    result[id] = lsp.get_client_by_id(tonumber(id))
+    result[#result + 1] = lsp.get_client_by_id(tonumber(id))
   end
-  if vim.tbl_isempty(result) then
+  if #result == 0 then
     return require('lspconfig.util').get_managed_clients()
   end
-  return vim.tbl_values(result)
+  return result
 end
 
 for group, hi in pairs {


### PR DESCRIPTION
improve the get_clients_from_cmd_args for better readability and consistency.

- Replaced dictionary-based storage with a table for clients in the get_clients_from_cmd_args function.
- Utilized the '#' operator to accurately count clients and enhance code readability.
- Updated the condition for checking if the result table is empty using the '#' operator.