### PR TITLE
fix(zls): use workspace zls.json if available

### DIFF
--- a/lua/lspconfig/configs/zls.lua
+++ b/lua/lspconfig/configs/zls.lua
@@ -3,6 +3,11 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'zls' },
+    on_new_config = function(new_config, new_root_dir)
+      if vim.fn.filereadable(vim.fs.joinpath(new_root_dir, 'zls.json')) ~= 0 then
+        new_config.cmd = { 'zls', '--config-path', 'zls.json' }
+      end
+    end,
     filetypes = { 'zig', 'zir' },
     root_dir = util.root_pattern('zls.json', 'build.zig', '.git'),
     single_file_support = true,
@@ -14,6 +19,7 @@ https://github.com/zigtools/zls
 Zig LSP implementation + Zig Language Server
         ]],
     default_config = {
+      cmd = { 'zls' },
       root_dir = [[util.root_pattern("zls.json", "build.zig", ".git")]],
     },
   },


### PR DESCRIPTION
Language server config is read from `zls.json`. By default common global and user config directories are searched. However, this omits per-project configuration, which can be available in the workspace dir.

We already look for `zls.json` to determine root dir, but we don't use it when starting the language server.

This change appends `cmd` with `--config-path "zls.json"`, which uses the file when it's available and fall-backs to default logic when file is not available.