### PR TITLE
docs: add lua to runtime path

### DIFF
--- a/lua/lspconfig/server_configurations/lua_ls.lua
+++ b/lua/lspconfig/server_configurations/lua_ls.lua
@@ -59,11 +59,11 @@ require'lspconfig'.lua_ls.setup {
             checkThirdParty = false,
             library = {
               vim.env.VIMRUNTIME
-              -- "${3rd}/luv/library"
+              -- "${3rd}/luv/library",
               -- "${3rd}/busted/library",
             }
             -- or pull in all of 'runtimepath'. NOTE: this is a lot slower
-            -- library = vim.api.nvim_get_runtime_file("", true)
+            -- library = vim.api.nvim_get_runtime_file("lua", true)
           }
         }
       })


### PR DESCRIPTION
👋 hey! I think I found a typo in the configuration instructions.

Using plenary.nvim as an example, when I have 

```lua
library = vim.api.nvim_get_runtime_file('', true),
```

it includes the path `/Users/mike/.local/share/nvim/lazy/plenary.nvim` which lua_ls does not seem to pickup on the child lua directory.

Changing it to 

```lua
library = vim.api.nvim_get_runtime_file('lua', true),
```

it includes the path `/Users/mike/.local/share/nvim/lazy/plenary.nvim/lua` and everything works as expected. lua_ls picks up on the plenary plugins functions `it`, `describe`, etc.

Please let me know if you need any other info.

