### PR TITLE
fix(sqls): sqls is unarchived

### DIFF
--- a/lua/lspconfig/server_configurations/sqls.lua
+++ b/lua/lspconfig/server_configurations/sqls.lua
@@ -7,10 +7,6 @@ return {
     root_dir = util.root_pattern 'config.yml',
     single_file_support = true,
     settings = {},
-    deprecate = {
-      to = 'sqlls',
-      version = '0.2.0',
-    },
   },
   docs = {
     description = [[


### PR DESCRIPTION
sqls has been deprecated with #2544.
Recently sqls is transferred from [lighttiger2505/sqls](https://github.com/lighttiger2505/sqls) to [sqls-server/sqls](https://github.com/sqls-server/sqls) and maintained.