### PR TITLE
fix(ols): remove single_file_support

### DIFF
--- a/lua/lspconfig/server_configurations/ols.lua
+++ b/lua/lspconfig/server_configurations/ols.lua
@@ -5,7 +5,6 @@ return {
     cmd = { 'ols' },
     filetypes = { 'odin' },
     root_dir = util.root_pattern('ols.json', '.git', '*.odin'),
-    single_file_support = false,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/ols.lua
+++ b/lua/lspconfig/server_configurations/ols.lua
@@ -4,8 +4,8 @@ return {
   default_config = {
     cmd = { 'ols' },
     filetypes = { 'odin' },
-    root_dir = util.root_pattern('ols.json', '.git'),
-    single_file_support = true,
+    root_dir = util.root_pattern('ols.json', '.git', '*.odin'),
+    single_file_support = false,
   },
   docs = {
     description = [[
@@ -14,7 +14,7 @@ return {
            `Odin Language Server`.
         ]],
     default_config = {
-      root_dir = [[util.root_pattern("ols.json", ".git")]],
+      root_dir = [[util.root_pattern("ols.json", ".git", "*.odin")]],
     },
   },
 }


### PR DESCRIPTION
It doesn't seem like ols really has support for single_file_support. The ols application crashes with the following message: "ols/src/server/requests.odin(1494:28) Index 0 is out of range 0..<0\n"

This happens on workspace/didChangeConfiguration when settings are provided in the users' ols setup.

To work around this, essentially turning off single_file_support & adding *.odin as a way to detect a root_dir. This isn't very common but at least one other language server uses this method, qml_ls. However, without this, the ols doesn't really work out of the box for projects that lack a .git directory or ols.json file.