### PR TITLE
feat: add lwc-language-server support

### DIFF
--- a/lua/lspconfig/server_configurations/lwc_ls.lua
+++ b/lua/lspconfig/server_configurations/lwc_ls.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'lwc-language-server', '--stdio' }
+    cmd = { 'lwc-language-server', '--stdio' },
     filetypes = { 'javascript', 'html' },
     root_dir = util.root_pattern 'sfdx-project.json',
     init_options = {

--- a/lua/lspconfig/server_configurations/lwc_ls.lua
+++ b/lua/lspconfig/server_configurations/lwc_ls.lua
@@ -1,0 +1,38 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'lwc-language-server', '--stdio' }
+    filetypes = { 'javascript', 'html' },
+    root_dir = util.root_pattern 'sfdx-project.json',
+    init_options = {
+      embeddedLanguages = {
+        javascript = true,
+      },
+    },
+  },
+  docs = {
+    description = [[
+https://github.com/forcedotcom/lightning-language-server/
+
+Language server for Lightning Web Components.
+
+For manual installation, utilize the official 
+[NPM package](https://www.npmjs.com/package/@salesforce/lwc-language-server). 
+Then, configure `cmd` to run the Node script at the unpacked location:
+
+```lua
+require'lspconfig'.lwc_ls.setup {
+  cmd = {
+    'node',
+    '/path/to/node_modules/@salesforce/lwc-language-server/bin/lwc-language-server.js',
+    '--stdio'
+  }
+}
+```
+]],
+    default_config = {
+      root_dir = [[root_pattern('sfdx-project.json')]],
+    },
+  },
+}

--- a/lua/lspconfig/server_configurations/lwc_ls.lua
+++ b/lua/lspconfig/server_configurations/lwc_ls.lua
@@ -17,8 +17,7 @@ https://github.com/forcedotcom/lightning-language-server/
 
 Language server for Lightning Web Components.
 
-For manual installation, utilize the official 
-[NPM package](https://www.npmjs.com/package/@salesforce/lwc-language-server). 
+For manual installation, utilize the official [NPM package](https://www.npmjs.com/package/@salesforce/lwc-language-server).
 Then, configure `cmd` to run the Node script at the unpacked location:
 
 ```lua


### PR DESCRIPTION
This feature adds support for the LWC LS using the official [npm package](https://www.npmjs.com/package/@salesforce/lwc-language-server), I've included instructions on how to configure it manually as well if that was desired. 

Root_dir is based off of other Salesforce LS's, namely apex_ls and visualforce_ls. I've also created a separate PR which added the LS to the mason registry here: [mason-org/mason-registry#3862](https://github.com/mason-org/mason-registry/pull/3862)

I'm also on windows so I've been unable to run docgen or check lua using luacheck.... can't seem to get it working :( 