### PR TITLE
fix(docs): Add note about filetype for docker-compose

### DIFF
--- a/lua/lspconfig/server_configurations/docker_compose_language_service.lua
+++ b/lua/lspconfig/server_configurations/docker_compose_language_service.lua
@@ -17,6 +17,8 @@ This project contains a language service for Docker Compose.
 ```sh
 npm install @microsoft/compose-language-service
 ```
+
+Note: If the docker-compose-langserver doesn't startup when entering a `docker-compose.yaml` file, make sure that the filetype is `yaml.docker-compose`. You can set with: `:set filetype=yaml.docker-compose`.
 ]],
     default_config = {
       root_dir = [[root_pattern("docker-compose.yaml")]],


### PR DESCRIPTION
I propose adding a note about the filetype, as I just spent a few hours trying to figure out why the lsp didn't run when entering a docker-compose.yaml file. I think this would avoid anyone doing the same. 