### PR TITLE
Add texlab.cancelBuild command 

### DIFF
--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -21,7 +21,7 @@ local function buf_cancel_build()
       if err then
         error(tostring(err))
       end
-      print 'Cancel build'
+      print 'Build cancelled'
     end, 0)
   end
 end
@@ -130,7 +130,7 @@ return {
       function()
         buf_cancel_build()
       end,
-      description = 'Cancel the current build',
+      description = 'Cancel the current build, includes the onSave builds',
     },
   },
   docs = {

--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -17,12 +17,7 @@ local texlab_forward_status = vim.tbl_add_reverse_lookup {
 local function buf_cancel_build()
   local texlab_client = util.get_active_client_by_name(0, 'texlab')
   if texlab_client then
-    texlab_client.request('workspace/executeCommand', { command = 'texlab.cancelBuild' }, function(err, result)
-      if err then
-        error(tostring(err))
-      end
-      print('Cancel ' .. texlab_build_status[result.status])
-    end, 0)
+    texlab_client.request 'workspace/cancelBuild'
   end
 end
 

--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -14,6 +14,18 @@ local texlab_forward_status = vim.tbl_add_reverse_lookup {
   Unconfigured = 3,
 }
 
+local function buf_cancel_build()
+  local texlab_client = util.get_active_client_by_name(0, 'texlab')
+  if texlab_client then
+    texlab_client.request('workspace/executeCommand', { command = 'texlab.cancelBuild' }, function(err, result)
+      if err then
+        error(tostring(err))
+      end
+      print('Cancel ' .. texlab_build_status[result.status])
+    end, 0)
+  end
+end
+
 local function buf_build(bufnr)
   bufnr = util.validate_bufnr(bufnr)
   local texlab_client = util.get_active_client_by_name(bufnr, 'texlab')
@@ -113,6 +125,12 @@ return {
         buf_search(0)
       end,
       description = 'Forward search from current position',
+    },
+    TexlabCancel = {
+      function()
+        buf_cancel_build()
+      end,
+      description = 'Cancel the current build',
     },
   },
   docs = {

--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -17,7 +17,7 @@ local texlab_forward_status = vim.tbl_add_reverse_lookup {
 local function buf_cancel_build()
   local texlab_client = util.get_active_client_by_name(0, 'texlab')
   if texlab_client then
-    texlab_client.request('workspace/executeCommand', { command = 'texlab.cancelBuild' }, function(err, result)
+    texlab_client.request('workspace/executeCommand', { command = 'texlab.cancelBuild' }, function(err)
       if err then
         error(tostring(err))
       end

--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -17,7 +17,12 @@ local texlab_forward_status = vim.tbl_add_reverse_lookup {
 local function buf_cancel_build()
   local texlab_client = util.get_active_client_by_name(0, 'texlab')
   if texlab_client then
-    texlab_client.request 'workspace/cancelBuild'
+    texlab_client.request('workspace/executeCommand', { command = 'texlab.cancelBuild' }, function(err, result)
+      if err then
+        error(tostring(err))
+      end
+      print 'Cancel build'
+    end, 0)
   end
 end
 


### PR DESCRIPTION
Pull Request Description:
I have added a new command, texlab.cancelBuild, to the texlab Language Server Protocol (LSP). This feature is introduced in the [v5.6.0 release](https://github.com/latex-lsp/texlab/releases/tag/v5.6.0) of the texlab server.

Changes Made:

    Added texlab.cancelBuild command to the texlab LSP.

Why is this Change Useful:
This new command provides a convenient way to cancel ongoing builds in the workspace, which is particularly beneficial for longer documents where unwanted compilation can be a significant issue. It enhances the user experience by addressing the headache of unnecessary compilations.

Relevant Links:

    [texlab v5.6.0 release](https://github.com/latex-lsp/texlab/releases/tag/v5.6.0)
    [texlab repository](https://github.com/latex-lsp/texlab)

Additional Notes:
I believe this addition complements the existing set of commands and contributes to a smoother LaTeX editing experience. Your feedback is highly appreciated!
Thank you in advance and for your great effort regarding this repo :)