### PR TITLE
feat: enable single file mode for vale_ls

### DIFF
--- a/lua/lspconfig/server_configurations/vale_ls.lua
+++ b/lua/lspconfig/server_configurations/vale_ls.lua
@@ -5,6 +5,7 @@ return {
     cmd = { 'vale-ls' },
     filetypes = { 'markdown', 'text' },
     root_dir = util.root_pattern '.vale.ini',
+    single_file_support = true,
   },
   docs = {
     description = [[


### PR DESCRIPTION
[as of vale 3.0.0, vale can be used with a system default `.vale.ini`](https://vale.sh/docs/topics/config/), which means vale_ls can also be used in single file mode