### PR TITLE
[Biome] Make biome only run in projects with an existing biome.json

### DIFF
--- a/lua/lspconfig/server_configurations/biome.lua
+++ b/lua/lspconfig/server_configurations/biome.lua
@@ -12,12 +12,8 @@ return {
       'typescript.tsx',
       'typescriptreact',
     },
-    root_dir = function(fname)
-      return util.find_package_json_ancestor(fname)
-        or util.find_node_modules_ancestor(fname)
-        or util.find_git_ancestor(fname)
-    end,
-    single_file_support = true,
+    root_dir = util.root_pattern 'biome.json',
+    single_file_support = false,
   },
   docs = {
     description = [[
@@ -30,7 +26,7 @@ npm install [-g] @biomejs/biome
 ```
 ]],
     default_config = {
-      root_dir = [[root_pattern('package.json', 'node_modules', '.git', 'biome.json')]],
+      root_dir = [[root_pattern('biome.json')]],
     },
   },
 }


### PR DESCRIPTION
Closes https://github.com/neovim/nvim-lspconfig/issues/2980

This PR adjusts the configuration for the biome LSP to only attach if there is an existing `biome.json` found. 

This helps prevent conflicts in ESLint projects since biome would attach and start providing diagnostics and would format files which could conflict with the ESLint/Prettier rules that are defined.