### PR TITLE
fix: disable autostart after :LspStop

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -139,6 +139,9 @@ function configs.__newindex(t, config_name, config_def)
           api.nvim_create_autocmd('BufReadPost', {
             pattern = fn.fnameescape(root_dir) .. '/*',
             callback = function(arg)
+              if #M.manager:clients() == 0 then
+                return true
+              end
               M.manager:try_add_wrapper(arg.buf, root_dir)
             end,
             group = lsp_group,


### PR DESCRIPTION
Remove autocmd BufReadPost on LspStop so that lsp won't be auto started on buf read after explicit stop with LspStop.