### PR TITLE
Fix(terraform): Add 'tf' to filetypes

### DIFF
--- a/lua/lspconfig/server_configurations/terraform_lsp.lua
+++ b/lua/lspconfig/server_configurations/terraform_lsp.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'terraform-lsp' },
-    filetypes = { 'terraform', 'hcl' },
+    filetypes = { 'terraform', 'hcl', 'tf' },
     root_dir = util.root_pattern('.terraform', '.git'),
   },
   docs = {

--- a/lua/lspconfig/server_configurations/terraformls.lua
+++ b/lua/lspconfig/server_configurations/terraformls.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'terraform-ls', 'serve' },
-    filetypes = { 'terraform', 'terraform-vars' },
+    filetypes = { 'terraform', 'terraform-vars', 'tf' },
     root_dir = util.root_pattern('.terraform', '.git'),
   },
   docs = {


### PR DESCRIPTION
Seems like neovim sets a "*.tf" file to filetype "tf".