### PR TITLE
feat(swift_mesonls): add meson.options as a root marker

### DIFF
--- a/lua/lspconfig/server_configurations/swift_mesonls.lua
+++ b/lua/lspconfig/server_configurations/swift_mesonls.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'Swift-MesonLSP', '--lsp' },
     filetypes = { 'meson' },
-    root_dir = util.root_pattern('meson_options.txt', '.git'),
+    root_dir = util.root_pattern('meson_options.txt', 'meson.options', '.git'),
   },
   docs = {
     description = [[
@@ -13,7 +13,7 @@ https://github.com/JCWasmx86/Swift-MesonLSP
 Meson language server written in Swift
 ]],
     default_config = {
-      root_dir = [[util.root_pattern("meson_options.txt", ".git")]],
+      root_dir = [[util.root_pattern("meson_options.txt", "meson.options", ".git")]],
     },
   },
 }


### PR DESCRIPTION
This is the preferred filename for defining options for a few versions. meson_options.txt is legacy, but will continue to stick around.