### PR TITLE
fix: enforce single file mode check when root_dir differs from client

### DIFF
--- a/lua/lspconfig/manager.lua
+++ b/lua/lspconfig/manager.lua
@@ -203,7 +203,8 @@ function M:add(root_dir, single_file, bufnr)
   local new_config = self.make_config(root_dir)
   local client = self:_get_client_from_cache(root_dir, new_config.name)
 
-  if not client then
+  ---If single_file_mode is false then root_dir should match client otherwise start a new client
+  if not client or (not single_file and client.config.root_dir and client.config.root_dir ~= root_dir) then
     return self:_start_new_client(bufnr, new_config, root_dir, single_file)
   end
 


### PR DESCRIPTION
fixes issue [#2959](https://github.com/neovim/nvim-lspconfig/issues/2959#issue-2068768094)

---

After executing `:LspRestart` **nvim-lspconfig** tries to reuse the same client (tsserver, ...) but this causes buffers from different root_dirs to fall into single_file_mode (1 tsserver per buffer) even if single file mode is turn off. This PR enforces the single file mode check before trying to reuse a client from other root_dir.
