### PR TITLE
feat(fennel-ls): allow utf-8 offsetEncoding

### DIFF
--- a/lua/lspconfig/server_configurations/fennel_ls.lua
+++ b/lua/lspconfig/server_configurations/fennel_ls.lua
@@ -1,5 +1,8 @@
 local util = require 'lspconfig.util'
 
+local default_capabilities = vim.lsp.protocol.make_client_capabilities()
+default_capabilities.offsetEncoding = { 'utf-8', 'utf-16' }
+
 return {
   default_config = {
     cmd = { 'fennel-ls' },
@@ -8,6 +11,7 @@ return {
       return util.find_git_ancestor(dir)
     end,
     settings = {},
+    capabilities = default_capabilities,
   },
   docs = {
     description = [[


### PR DESCRIPTION
The `fennel-ls` server can support `utf-8` offsetEncoding now, and is faster when it doesn't need to compute offsets.