### PR TITLE
fix(texlab): search for default texlab root files

### DIFF
--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -70,7 +70,7 @@ return {
   default_config = {
     cmd = { 'texlab' },
     filetypes = { 'tex', 'plaintex', 'bib' },
-    root_dir = util.root_pattern('.git', '.latexmkrc'),
+    root_dir = util.root_pattern('.git', '.latexmkrc', '.texlabroot', 'texlabroot', 'Tectonic.toml'),
     single_file_support = true,
     settings = {
       texlab = {


### PR DESCRIPTION
Texlab looks for

* `.texlabroot`
* `texlabroot`
* `Tectonic.toml`

when searching for the project root: [https://github.com/latex-lsp/texlab/wiki/Project-Detection#root-directory](https://github.com/latex-lsp/texlab/wiki/Project-Detection#root-directory).
It would be nice if the default `root_dir` discovery method matched that of TexLab.