### PR TITLE
fix(quick_lint_js): enable for typescript

### DIFF
--- a/lua/lspconfig/server_configurations/quick_lint_js.lua
+++ b/lua/lspconfig/server_configurations/quick_lint_js.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'quick-lint-js', '--lsp-server' },
-    filetypes = { 'javascript' },
+    filetypes = { 'javascript', 'typescript' },
     root_dir = util.root_pattern('package.json', 'jsconfig.json', '.git'),
     single_file_support = true,
   },


### PR DESCRIPTION
`quick-lint` works for typescript as well, but the config did not include typescript in the filetypes.