### PR TITLE
feat(solidity_ls)!: switch to first-party npm package

### DIFF
--- a/lua/lspconfig/server_configurations/solidity_ls.lua
+++ b/lua/lspconfig/server_configurations/solidity_ls.lua
@@ -1,24 +1,36 @@
 local util = require 'lspconfig.util'
 
-local bin_name = 'solidity-language-server'
-if vim.fn.has 'win32' == 1 then
-  bin_name = bin_name .. '.cmd'
-end
+local root_files = {
+  'hardhat.config.js',
+  'hardhat.config.ts',
+  'foundry.toml',
+  'remappings.txt',
+  'truffle.js',
+  'truffle-config.js',
+  'ape-config.yaml',
+}
 
 return {
   default_config = {
-    cmd = { bin_name, '--stdio' },
+    cmd = { 'vscode-solidity-server', '--stdio' },
     filetypes = { 'solidity' },
-    root_dir = util.root_pattern('.git', 'package.json'),
+    root_dir = util.root_pattern(unpack(root_files)) or util.root_pattern('.git', 'package.json'),
+    single_file_support = true,
   },
   docs = {
     description = [[
-npm install -g solidity-language-server
+https://github.com/juanfranblanco/vscode-solidity
 
-solidity-language-server is a language server for the solidity language ported from the vscode solidity extension
+`vscode-solidity-server` can be installed via `npm`:
+
+```sh
+npm install -g vscode-solidity-server
+```
+
+`vscode-solidity-server` is a language server for the Solidity language ported from the VSCode "solidity" extension.
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git", "package.json")]],
+      root_dir = [[root_pattern("]] .. table.concat(root_files, '", "') .. [[", ".git", "package.json")]],
     },
   },
 }


### PR DESCRIPTION
The unofficial npm package was only uploaded once, two years ago:

https://www.npmjs.com/package/solidity-language-server

There is now a first-party package:

https://github.com/juanfranblanco/vscode-solidity/issues/432#issuecomment-1943584107 https://www.npmjs.com/package/vscode-solidity-server

The binary name is different so users will have to install the new one or they will error.