### PR TITLE
fix(ocaml): trigger by filetype, not language id

### DIFF
--- a/lua/lspconfig/server_configurations/ocamllsp.lua
+++ b/lua/lspconfig/server_configurations/ocamllsp.lua
@@ -16,7 +16,7 @@ end
 return {
   default_config = {
     cmd = { 'ocamllsp' },
-    filetypes = { 'ocaml', 'ocaml.menhir', 'ocaml.interface', 'ocaml.ocamllex', 'reason', 'dune' },
+    filetypes = { 'ocaml', 'menhir', 'ocamlinterface', 'ocamllex', 'reason', 'dune' },
     root_dir = util.root_pattern('*.opam', 'esy.json', 'package.json', '.git', 'dune-project', 'dune-workspace'),
     get_language_id = get_language_id,
   },


### PR DESCRIPTION
`filetypes` should trigger on `&ft`, not on language id.

Fixes a bug introduced in 946d4a7be1b88e0d44d3d196a524bda8bb27a8c0 (#1088), by inlining the wrong side of the mapping.