### PR TITLE
feat: add gdshader-lsp support

### DIFF
--- a/lua/lspconfig/server_configurations/gdshader_lsp.lua
+++ b/lua/lspconfig/server_configurations/gdshader_lsp.lua
@@ -1,0 +1,16 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'gdshader-lsp', '--stdio' },
+    filetypes = { 'gdshader', 'gdshaderinc' },
+    root_dir = util.root_pattern 'project.godot',
+  },
+  docs = {
+    description = [[
+https://github.com/godofavacyn/gdshader-lsp
+
+A language server for the Godot Shading language.
+]],
+  },
+}


### PR DESCRIPTION
gdshader-lsp is a language server for the Godot shading language.