### PR TITLE
Add 'spago.yaml' to the list of purescript-language-server's root_patterns

### DIFF
--- a/lua/lspconfig/server_configurations/purescriptls.lua
+++ b/lua/lspconfig/server_configurations/purescriptls.lua
@@ -4,7 +4,14 @@ return {
   default_config = {
     cmd = { 'purescript-language-server', '--stdio' },
     filetypes = { 'purescript' },
-    root_dir = util.root_pattern('bower.json', 'psc-package.json', 'spago.dhall', 'flake.nix', 'shell.nix'),
+    root_dir = util.root_pattern(
+      'bower.json',
+      'flake.nix',
+      'psc-package.json',
+      'shell.nix',
+      'spago.dhall',
+      'spago.yaml'
+    ),
   },
   docs = {
     description = [[
@@ -16,7 +23,7 @@ The `purescript-language-server` can be added to your project and `$PATH` via
 * Nix under the `nodePackages` and `nodePackages_latest` package sets
 ]],
     default_config = {
-      root_dir = [[root_pattern('spago.dhall', 'psc-package.json', 'bower.json', 'flake.nix', 'shell.nix'),]],
+      root_dir = [[root_pattern('bower.json', 'flake.nix', 'psc-package.json', 'shell.nix', 'spago.dhall', 'spago.yaml'),]],
     },
   },
 }


### PR DESCRIPTION
Following the footsteps of https://github.com/neovim/nvim-lspconfig/pull/1954 
[Spago](https://github.com/purescript/spago) has now migrated to `spago.yaml`. See the reference language server implementation: https://github.com/nwolverson/purescript-language-server/blob/2d98c1b3a2560968da8d0720095a5094279f5f3c/src/LanguageServer/IdePurescript/Main.purs#L372-L378 (current main).

I also took the liberty to sort the patterns alphabetically, as the order in default_config and docs wasn't synchronized.