### PR TITLE
fix: let core handle 'workspace/didChangeConfiguration' after init

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -174,7 +174,7 @@ passed overrides to `setup {}` are:
 
 - {settings} `table <string, string|table|bool>`  
 
-  The `settings` table is sent in `on_init` via a
+  The `settings` table is sent after initialization via a
   `workspace/didChangeConfiguration` notification from the Nvim client to
   the language server. These settings allow a user to change optional runtime
   settings of the language server. 

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -225,9 +225,6 @@ function configs.__newindex(t, config_name, config_def)
             settings = settings,
           })
         end
-        if not vim.tbl_isempty(new_config.settings) then
-          client.workspace_did_change_configuration(new_config.settings)
-        end
       end)
 
       -- Save the old _on_attach so that we can reference it via the BufEnter.

--- a/lua/lspconfig/server_configurations/lua_ls.lua
+++ b/lua/lspconfig/server_configurations/lua_ls.lua
@@ -67,8 +67,6 @@ require'lspconfig'.lua_ls.setup {
           }
         }
       })
-
-      client.notify("workspace/didChangeConfiguration", { settings = client.config.settings })
     end
     return true
   end


### PR DESCRIPTION
Since https://github.com/neovim/neovim/pull/18847 there's no need to send the `workspace/didChangeConfiguration` manually after initialization, since neovim will automagically do it.

This PR removes documentation references recommending this behaviour, together with the implementation handling the redundant action (I might have missed places so please review carefully). 