### PR TITLE
ci: clarify misleading comment from bot

### DIFF
--- a/.github/workflows/comment-config-changes.yml
+++ b/.github/workflows/comment-config-changes.yml
@@ -15,6 +15,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: |
           if ! git diff origin/$GITHUB_BASE_REF...$(git branch --show-current) --exit-code -- doc/server_configurations.md doc/server_configurations.txt; then
-            gh pr comment $PR_NUMBER --body 'Do not change `server_configurations.md` directly. Edit the lua source file instead. See https://github.com/neovim/nvim-lspconfig/blob/master/CONTRIBUTING.md#generating-docs'
+            gh pr comment $PR_NUMBER --body 'Do not change `server_configurations.md` or `server_configurations.txt` directly as these are automatically generated. Edit the lua source file instead. See https://github.com/neovim/nvim-lspconfig/blob/master/CONTRIBUTING.md#generating-docs'
             exit 1
           fi


### PR DESCRIPTION
The job `comment-config-changes.yml` fails if either
`doc/server_configurations.md` or `doc/server_configurations.txt`, but
the comment never mentions not to change
`doc/server_configurations.txt`.
