### PR TITLE
fix(pyright): fix PyrightSetPythonPath command

### DIFF
--- a/lua/lspconfig/server_configurations/pyright.lua
+++ b/lua/lspconfig/server_configurations/pyright.lua
@@ -31,7 +31,11 @@ local function set_python_path(path)
     name = 'pyright',
   }
   for _, client in ipairs(clients) do
-    client.config.settings = vim.tbl_deep_extend('force', client.config.settings, { python = { pythonPath = path } })
+    if client.settings then
+      client.settings.python = vim.tbl_deep_extend('force', client.settings.python, { pythonPath = path })
+    else
+      client.config.settings = vim.tbl_deep_extend('force', client.config.settings, { python = { pythonPath = path } })
+    end
     client.notify('workspace/didChangeConfiguration', { settings = nil })
   end
 end


### PR DESCRIPTION
`PyrightSetPythonPath` command no longer works due to https://github.com/neovim/neovim/commit/9f8c96240dc0318bd92a646966917e8fe0641144.

