### PR TITLE
feat: add delphilsp support

### DIFF
--- a/lua/lspconfig/server_configurations/delphi_ls.lua
+++ b/lua/lspconfig/server_configurations/delphi_ls.lua
@@ -1,29 +1,11 @@
 local util = require 'lspconfig.util'
 
-local function get_lsp_config_path()
-  -- first find *.dpr project file, as lsp config might not be present
-  local dpr_path = vim.fs.find(function(name)
-    return name:match '.*%.dpr$'
-  end, { type = 'file', upward = true })[1]
-
-  -- if found, then lsp config should be located in the same folder
-  if dpr_path then
-    return vim.fs.find(function(name)
-      return name:match '.*%.delphilsp.json$'
-    end, { type = 'file', path = vim.fs.dirname(dpr_path), upward = false })[1]
-  end
-end
-
 return {
   default_config = {
     cmd = { 'DelphiLSP.exe' },
     filetypes = { 'pascal' },
     root_dir = util.root_pattern '*.dpr',
-    single_file_support = true,
-    settings = {
-      -- set *.delphilsp.json - Delphi lsp config file path
-      settingsFile = get_lsp_config_path(),
-    },
+    single_file_support = false,
   },
   docs = {
     description = [[
@@ -32,6 +14,36 @@ https://marketplace.visualstudio.com/items?itemName=EmbarcaderoTechnologies.delp
 
 Note, the '*.delphilsp.json' file is required, more details at:
 https://docwiki.embarcadero.com/RADStudio/Alexandria/en/Using_DelphiLSP_Code_Insight_with_Other_Editors
+
+Below, you'll find a sample configuration for the lazy manager.
+When on_attach is triggered, it signals DelphiLSP to load settings from a configuration file.
+Without this step, DelphiLSP initializes but remains non-functional:
+
+```lua
+"neovim/nvim-lspconfig",
+lazy = false,
+config = function()
+  local capabilities = require("cmp_nvim_lsp").default_capabilities()
+  local lspconfig = require("lspconfig")
+
+  lspconfig.delphi_ls.setup({
+    capabilities = capabilities,
+
+    on_attach = function(client)
+      local lsp_config = vim.fs.find(function(name)
+        return name:match(".*%.delphilsp.json$")
+      end, { type = "file", path = client.config.root_dir, upward = false })[1]
+
+      if lsp_config then
+        client.config.settings = { settingsFile = lsp_config }
+        client.notify("workspace/didChangeConfiguration", { settings = client.config.settings })
+      else
+        vim.notify_once("delphi_ls: '*.delphilsp.json' config file not found")
+      end
+    end,
+  })
+end,
+```
 ]],
   },
 }

--- a/lua/lspconfig/server_configurations/delphi_ls.lua
+++ b/lua/lspconfig/server_configurations/delphi_ls.lua
@@ -1,0 +1,37 @@
+local util = require 'lspconfig.util'
+
+local function get_lsp_config_path()
+  -- first find *.dpr project file, as lsp config might not be present
+  local dpr_path = vim.fs.find(function(name)
+    return name:match '.*%.dpr$'
+  end, { type = 'file', upward = true })[1]
+
+  -- if found, then lsp config should be located in the same folder
+  if dpr_path then
+    return vim.fs.find(function(name)
+      return name:match '.*%.delphilsp.json$'
+    end, { type = 'file', path = vim.fs.dirname(dpr_path), upward = false })[1]
+  end
+end
+
+return {
+  default_config = {
+    cmd = { 'DelphiLSP.exe' },
+    filetypes = { 'pascal' },
+    root_dir = util.root_pattern '*.dpr',
+    single_file_support = true,
+    settings = {
+      -- set *.delphilsp.json - Delphi lsp config file path
+      settingsFile = get_lsp_config_path(),
+    },
+  },
+  docs = {
+    description = [[
+Language server for Delphi from Embarcadero.
+https://marketplace.visualstudio.com/items?itemName=EmbarcaderoTechnologies.delphilsp
+
+Note, the '*.delphilsp.json' file is required, more details at:
+https://docwiki.embarcadero.com/RADStudio/Alexandria/en/Using_DelphiLSP_Code_Insight_with_Other_Editors
+]],
+  },
+}


### PR DESCRIPTION
Add support for Delphi Language Server, which is available only for Windows.
The config file for the language server *.delphilsp.json is located in the root_dir.
Unfortunately the root_dir is not available at the configuration creation time,
so I had to look for it. Maybe, there is a better solution?