### PR TITLE
Add pico8 language server

### DIFF
--- a/lua/lspconfig/server_configurations/pico8_ls.lua
+++ b/lua/lspconfig/server_configurations/pico8_ls.lua
@@ -1,0 +1,17 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'pico8-ls', '--stdio' },
+    filetypes = { 'p8' },
+    root_dir = util.root_pattern '*.p8',
+    settings = {},
+  },
+  docs = {
+    description = [[
+https://github.com/japhib/pico8-ls
+
+Full language support for the PICO-8 dialect of Lua.
+]],
+  },
+}


### PR DESCRIPTION
Add support for [pico8-ls](https://github.com/japhib/pico8-ls)

PICO-8 is a [fantasy console](https://www.lexaloffle.com/pico-8.php?page=faq) for making, sharing and playing tiny games and other computer programs.