### PR TITLE
Add css-variables-language-server

### DIFF
--- a/lua/lspconfig/server_configurations/css-variables.lua
+++ b/lua/lspconfig/server_configurations/css-variables.lua
@@ -1,0 +1,27 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'css-variables-language-server', '--stdio' },
+    filetypes = { 'css', 'scss', 'less' },
+    root_dir = util.root_pattern('package.json', '.git'),
+  },
+  docs = {
+    description = [[
+https://github.com/vunguyentuan/vscode-css-variables/tree/master/packages/css-variables-language-server
+
+CSS variables autocompletion and go-to-definition
+
+`css-variables-language-server` can be installed via `npm`:
+
+```sh
+npm i -g css-variables-language-server
+```
+
+```
+]],
+    default_config = {
+      root_dir = [[root_pattern("package.json", ".git") or bufdir]],
+    },
+  },
+}


### PR DESCRIPTION
Add configuration for the css-variables-language-server.

Currently blocked by https://github.com/vunguyentuan/vscode-css-variables/pull/83

The CSS language server does not support CSS variables declared in other files. This augments that language server to provide autocompletion and go-to-definition support for CSS variables.