### PR TITLE
fix: CSS Variables LSP default settings

### DIFF
--- a/lua/lspconfig/server_configurations/css_variables.lua
+++ b/lua/lspconfig/server_configurations/css_variables.lua
@@ -44,23 +44,21 @@ npm i -g css-variables-language-server
     default_config = {
       root_dir = [[root_pattern("package.json", ".git") or bufdir]],
       settings = [[
-settings = {
-  cssVariables = {
-    lookupFiles = { '**/*.less', '**/*.scss', '**/*.sass', '**/*.css' },
-    blacklistFolders = {
-      '**/.cache',
-      '**/.DS_Store',
-      '**/.git',
-      '**/.hg',
-      '**/.next',
-      '**/.svn',
-      '**/bower_components',
-      '**/CVS',
-      '**/dist',
-      '**/node_modules',
-      '**/tests',
-      '**/tmp',
-    },
+cssVariables = {
+  lookupFiles = { '**/*.less', '**/*.scss', '**/*.sass', '**/*.css' },
+  blacklistFolders = {
+    '**/.cache',
+    '**/.DS_Store',
+    '**/.git',
+    '**/.hg',
+    '**/.next',
+    '**/.svn',
+    '**/bower_components',
+    '**/CVS',
+    '**/dist',
+    '**/node_modules',
+    '**/tests',
+    '**/tmp',
   },
 },
       ]],

--- a/lua/lspconfig/server_configurations/css_variables.lua
+++ b/lua/lspconfig/server_configurations/css_variables.lua
@@ -5,6 +5,27 @@ return {
     cmd = { 'css-variables-language-server', '--stdio' },
     filetypes = { 'css', 'scss', 'less' },
     root_dir = util.root_pattern('package.json', '.git'),
+    -- Same as inlined defaults that don't seem to work without hardcoding them in the lua config
+    -- https://github.com/vunguyentuan/vscode-css-variables/blob/763a564df763f17aceb5f3d6070e0b444a2f47ff/packages/css-variables-language-server/src/CSSVariableManager.ts#L31-L50
+    settings = {
+      cssVariables = {
+        lookupFiles = { '**/*.less', '**/*.scss', '**/*.sass', '**/*.css' },
+        blacklistFolders = {
+          '**/.cache',
+          '**/.DS_Store',
+          '**/.git',
+          '**/.hg',
+          '**/.next',
+          '**/.svn',
+          '**/bower_components',
+          '**/CVS',
+          '**/dist',
+          '**/node_modules',
+          '**/tests',
+          '**/tmp',
+        },
+      },
+    },
   },
   docs = {
     description = [[
@@ -22,6 +43,27 @@ npm i -g css-variables-language-server
 ]],
     default_config = {
       root_dir = [[root_pattern("package.json", ".git") or bufdir]],
+      settings = [[
+settings = {
+  cssVariables = {
+    lookupFiles = { '**/*.less', '**/*.scss', '**/*.sass', '**/*.css' },
+    blacklistFolders = {
+      '**/.cache',
+      '**/.DS_Store',
+      '**/.git',
+      '**/.hg',
+      '**/.next',
+      '**/.svn',
+      '**/bower_components',
+      '**/CVS',
+      '**/dist',
+      '**/node_modules',
+      '**/tests',
+      '**/tmp',
+    },
+  },
+},
+      ]],
     },
   },
 }


### PR DESCRIPTION
Without providing default values via the lua config, you get an error similar to this:

```
TypeError: Cannot read properties of null (reading 'lookupFiles')
  at CSSVariableManager.parseAndSyncVariables (/Users/gegoune/.pnpm-global/5/.pnpm/css-variables-language-server@2.7.0/node_modules/css-variables-language-server/dist/index.js:250:54)
  at /Users/gegoune/.pnpm-global/5/.pnpm/css-variables-language-server@2.7.0/node_modules/css-variables-language-server/dist/index.js:328:22\n\nNode.js v21.6.2\n"
```

The LSP provides a default (https://github.com/vunguyentuan/vscode-css-variables/blob/763a564df763f17aceb5f3d6070e0b444a2f47ff/packages/css-variables-language-server/src/CSSVariableManager.ts#L31-L50) but it doesn't seem to work when run in Neovim. I'm not sure of the best way to resolve this (does something need to be addressed in the language server?) but an easy fix is to hardcode the settings in the lspconfig.