### PR TITLE
fix(beancount): rename journalFile to journal_file

### DIFF
--- a/lua/lspconfig/server_configurations/beancount.lua
+++ b/lua/lspconfig/server_configurations/beancount.lua
@@ -8,7 +8,7 @@ return {
     single_file_support = true,
     init_options = {
       -- this is the path to the beancout journal file
-      journalFile = '',
+      journal_file = '',
     },
   },
   docs = {


### PR DESCRIPTION
As is shown in the README (https://github.com/polarmutex/beancount-language-server#neovim),  `journal_file` instead of `journalFile` should be used. 

It might due to a documentation bug fixed in https://github.com/polarmutex/beancount-language-server/commit/d99351b6e6bf04c015d7cab173b3a523ca59d6e4