### PR TITLE
fix: update lua types to match latest nightly

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -5,14 +5,14 @@ local tbl_deep_extend = vim.tbl_deep_extend
 
 local configs = {}
 
---- @class lspconfig.Config : lsp.ClientConfig
+--- @class lspconfig.Config : vim.lsp.ClientConfig
 --- @field enabled? boolean
 --- @field single_file_support? boolean
 --- @field filetypes? string[]
 --- @field filetype? string
 --- @field on_new_config? function
 --- @field autostart? boolean
---- @field package _on_attach? fun(client: lsp.Client, bufnr: integer)
+--- @field package _on_attach? fun(client: vim.lsp.Client, bufnr: integer)
 
 --- @param cmd any
 local function sanitize_cmd(cmd)

--- a/lua/lspconfig/manager.lua
+++ b/lua/lspconfig/manager.lua
@@ -5,7 +5,7 @@ local uv = vim.loop
 local async = require 'lspconfig.async'
 local util = require 'lspconfig.util'
 
----@param client lsp.Client
+---@param client vim.lsp.Client
 ---@param root_dir string
 ---@return boolean
 local function check_in_workspace(client, root_dir)
@@ -88,7 +88,7 @@ end
 --- @private
 --- @param bufnr integer
 --- @param root_dir string
---- @param client lsp.Client
+--- @param client vim.lsp.Client
 function M:_register_workspace_folders(bufnr, root_dir, client)
   local params = {
     event = {
@@ -160,7 +160,7 @@ end
 --- @param bufnr integer
 --- @param new_config lspconfig.Config
 --- @param root_dir string
---- @param client lsp.Client
+--- @param client vim.lsp.Client
 --- @param single_file boolean
 function M:_attach_or_spawn(bufnr, new_config, root_dir, client, single_file)
   if check_in_workspace(client, root_dir) then
@@ -178,7 +178,7 @@ end
 --- @param bufnr integer
 --- @param new_config lspconfig.Config
 --- @param root_dir string
---- @param client lsp.Client
+--- @param client vim.lsp.Client
 --- @param single_file boolean
 function M:_attach_after_client_initialized(bufnr, new_config, root_dir, client, single_file)
   local timer = assert(vim.loop.new_timer())
@@ -222,7 +222,7 @@ function M:add(root_dir, single_file, bufnr)
   end
 end
 
---- @return lsp.Client[]
+--- @return vim.lsp.Client[]
 function M:clients()
   local res = {}
   for _, client_ids in pairs(self._clients) do


### PR DESCRIPTION
From https://github.com/neovim/neovim/commit/a5fe8f59d98398d04bed8586cee73864bbcdde92, types were renamed.
Thanks for all your work!