### PR TITLE
Fixup 3051: Allow terraform-ls to start properly

### DIFF
--- a/lua/lspconfig/server_configurations/terraformls.lua
+++ b/lua/lspconfig/server_configurations/terraformls.lua
@@ -5,7 +5,6 @@ return {
     cmd = { 'terraform-ls', 'serve' },
     filetypes = { 'terraform', 'terraform-vars' },
     root_dir = util.root_pattern('.terraform', '.git'),
-    init_options = {},
   },
   docs = {
     description = [[


### PR DESCRIPTION
When setting `init_options' to an empty array terraform-ls fails to start and throws a trace.

See [3051](https://github.com/neovim/nvim-lspconfig/issues/3051) for details.

Removing `init_options' here is quick solution to make it work again.