### PR TITLE
docs(lua_ls): change suggested setup to work on both nightly and 0.9.5

### DIFF
--- a/lua/lspconfig/server_configurations/lua_ls.lua
+++ b/lua/lspconfig/server_configurations/lua_ls.lua
@@ -46,32 +46,33 @@ settings.
 require'lspconfig'.lua_ls.setup {
   on_init = function(client)
     local path = client.workspace_folders[1].name
-    if not vim.loop.fs_stat(path..'/.luarc.json') and not vim.loop.fs_stat(path..'/.luarc.jsonc') then
-      client.config.settings = vim.tbl_deep_extend('force', client.config.settings, {
-        Lua = {
-          runtime = {
-            -- Tell the language server which version of Lua you're using
-            -- (most likely LuaJIT in the case of Neovim)
-            version = 'LuaJIT'
-          },
-          -- Make the server aware of Neovim runtime files
-          workspace = {
-            checkThirdParty = false,
-            library = {
-              vim.env.VIMRUNTIME
-              -- Depending on the usage, you might want to add additional paths here.
-              -- E.g.: For using `vim.*` functions, add vim.env.VIMRUNTIME/lua.
-              -- "${3rd}/luv/library"
-              -- "${3rd}/busted/library",
-            }
-            -- or pull in all of 'runtimepath'. NOTE: this is a lot slower
-            -- library = vim.api.nvim_get_runtime_file("", true)
-          }
-        }
-      })
+    if vim.loop.fs_stat(path..'/.luarc.json') or vim.loop.fs_stat(path..'/.luarc.jsonc') then
+      return
     end
-    return true
-  end
+
+    client.config.settings.Lua = vim.tbl_deep_extend('force', client.config.settings.Lua, {
+      runtime = {
+        -- Tell the language server which version of Lua you're using
+        -- (most likely LuaJIT in the case of Neovim)
+        version = 'LuaJIT'
+      },
+      -- Make the server aware of Neovim runtime files
+      workspace = {
+        checkThirdParty = false,
+        library = {
+          vim.env.VIMRUNTIME
+          -- Depending on the usage, you might want to add additional paths here.
+          -- "${3rd}/luv/library"
+          -- "${3rd}/busted/library",
+        }
+        -- or pull in all of 'runtimepath'. NOTE: this is a lot slower
+        -- library = vim.api.nvim_get_runtime_file("", true)
+      }
+    })
+  end,
+  settings = {
+    Lua = {}
+  }
 }
 ```
 


### PR DESCRIPTION


https://github.com/neovim/nvim-lspconfig/assets/58370433/49425c0c-9b6a-461c-a434-2341b337ef6f


In `neovim` nightly, the current suggested config fails. I added a video demo, using this repro:
```lua
--- CHANGE THESE
local pattern = "lua"
local cmd = { "lua-language-server" }
-- Add files/folders here that indicate the root of a project
local root_markers = { ".git", ".editorconfig" }
-- Change to table with settings if required
local settings = {
  Lua = {
    runtime = {
      -- Tell the language server which version of Lua you're using
      -- (most likely LuaJIT in the case of Neovim)
      version = "LuaJIT",
    },
    -- Make the server aware of Neovim runtime files
    workspace = {
      checkThirdParty = false,
      library = {
        vim.env.VIMRUNTIME,
        -- Depending on the usage, you might want to add additional paths here.
        -- E.g.: For using `vim.*` functions, add vim.env.VIMRUNTIME/lua.
        -- "${3rd}/luv/library"
        -- "${3rd}/busted/library",
      },
      -- or pull in all of 'runtimepath'. NOTE: this is a lot slower
      -- library = vim.api.nvim_get_runtime_file("", true)
    },
  },
}
local function on_init(client) -- recommended in nvim-lspconfig
  local path = client.workspace_folders[1].name
  if not vim.loop.fs_stat(path .. "/.luarc.json") and not vim.loop.fs_stat(path .. "/.luarc.jsonc") then
    client.config.settings = vim.tbl_deep_extend("force", client.config.settings, settings)
  end
  return true
end

vim.api.nvim_create_autocmd("FileType", {
  pattern = pattern,
  callback = function(args)
    local match = vim.fs.find(root_markers, { path = args.file, upward = true })[1]
    local root_dir = match and vim.fn.fnamemodify(match, ":p:h") or nil
    vim.lsp.start({
      name = "bugged-ls",
      cmd = cmd,
      root_dir = root_dir,
      on_init = on_init, -- either use on_init
      -- settings = settings, -- or the settings directly
    })
  end,
})
```

I applied the config suggested in this [Neovim issue](https://github.com/neovim/neovim/issues/27740) and tested that it works on 0.9.5 and nightly. 