### PR TITLE
fix(lexical): lexical root directory config

### DIFF
--- a/lua/lspconfig/server_configurations/lexical.lua
+++ b/lua/lspconfig/server_configurations/lexical.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
     root_dir = function(fname)
-      return util.find_git_ancestor(fname) or util.root_pattern 'mix.exs'(fname)
+      return util.root_pattern 'mix.exs'(fname) or util.find_git_ancestor(fname)
     end,
     single_file_support = true,
   },


### PR DESCRIPTION
Should prefer a directory with `mix.exs` file as the lsp root directory.

If we have a mix project in a sub-folder of a git repo like this
```
. git_repo/
├── .git/
├── mix_project/
│   └── mix.exs
└── other_project/
```

The root directory should be `mix_project` rather than `gir_repo`, or the lexical lsp won't recognize the project correctly.