### PR TITLE
Support ESlint mjs flat config file

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -107,8 +107,10 @@ return {
       }
 
       -- Support flat config
-      if vim.fn.filereadable(new_root_dir .. '/eslint.config.js') == 1
-          or vim.fn.filereadable(new_root_dir .. '/eslint.config.mjs') == 1 then
+      if
+        vim.fn.filereadable(new_root_dir .. '/eslint.config.js') == 1
+        or vim.fn.filereadable(new_root_dir .. '/eslint.config.mjs') == 1
+      then
         config.settings.experimental.useFlatConfig = true
       end
 

--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -40,6 +40,7 @@ local root_file = {
   '.eslintrc.yml',
   '.eslintrc.json',
   'eslint.config.js',
+  'eslint.config.mjs',
 }
 
 return {
@@ -106,7 +107,8 @@ return {
       }
 
       -- Support flat config
-      if vim.fn.filereadable(new_root_dir .. '/eslint.config.js') == 1 then
+      if vim.fn.filereadable(new_root_dir .. '/eslint.config.js') == 1
+          or vim.fn.filereadable(new_root_dir .. '/eslint.config.mjs') == 1 then
         config.settings.experimental.useFlatConfig = true
       end
 


### PR DESCRIPTION
ESlint flat config files can also come as `.mjs` files, this PR supports them.