### PR TITLE
git bash fix with go env GOMODCACHE

### DIFF
--- a/lua/lspconfig/server_configurations/gopls.lua
+++ b/lua/lspconfig/server_configurations/gopls.lua
@@ -9,7 +9,7 @@ return {
     root_dir = function(fname)
       -- see: https://github.com/neovim/nvim-lspconfig/issues/804
       if not mod_cache then
-        local result = async.run_command 'go env GOMODCACHE'
+        local result = async.run_command { 'go', 'env', 'GOMODCACHE' }
         if result and result[1] then
           mod_cache = vim.trim(result[1])
         end


### PR DESCRIPTION
When using neovim in git bash I got this [error](https://imgur.com/a/8cXYYWs) due to the command being processed as a single string by git bash's bash.exe.
This PR fixes the Issue for me by passing the command and arguments as a table rather than as a single string.

Haven't tested it on linux though.

