### PR TITLE
fix: remove single file support for ast-grep

### DIFF
--- a/lua/lspconfig/server_configurations/ast_grep.lua
+++ b/lua/lspconfig/server_configurations/ast_grep.lua
@@ -19,7 +19,6 @@ return {
       'lua',
     },
     root_dir = util.root_pattern('sgconfig.yaml', 'sgconfig.yml'),
-    single_file_support = true,
   },
   docs = {
     description = [[


### PR DESCRIPTION
ast-grep requires a project setup like sgconfig.yml. 

Otherwise it will report an error. This fix removes the single_file_support option.

reference: https://stackoverflow.com/questions/78169005/when-i-open-nvim-show-me-error-massage-from-ast-grep/78169923#78169923