### PR TITLE
Add mesonlsp

### DIFF
--- a/lua/lspconfig/server_configurations/mesonlsp.lua
+++ b/lua/lspconfig/server_configurations/mesonlsp.lua
@@ -1,0 +1,19 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'mesonlsp', '--lsp' },
+    filetypes = { 'meson' },
+    root_dir = util.root_pattern('meson_options.txt', 'meson.options', '.git'),
+  },
+  docs = {
+    description = [[
+https://github.com/JCWasmx86/mesonlsp
+
+An unofficial, unendorsed language server for meson written in C++
+]],
+    default_config = {
+      root_dir = [[util.root_pattern("meson_options.txt", "meson.options", ".git")]],
+    },
+  },
+}


### PR DESCRIPTION
mesonlsp is a new language server for Meson by the same author as Swift-MesonLSP. Swift-MesonLSP is no longer developed.