### PR TITLE
feat(eslint): add support for .cjs, .ts, .mts, .cts config files

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -41,6 +41,10 @@ local root_file = {
   '.eslintrc.json',
   'eslint.config.js',
   'eslint.config.mjs',
+  'eslint.config.cjs',
+  'eslint.config.ts',
+  'eslint.config.mts',
+  'eslint.config.cts',
 }
 
 return {
@@ -110,6 +114,10 @@ return {
       if
         vim.fn.filereadable(new_root_dir .. '/eslint.config.js') == 1
         or vim.fn.filereadable(new_root_dir .. '/eslint.config.mjs') == 1
+        or vim.fn.filereadable(new_root_dir .. '/eslint.config.cjs') == 1
+        or vim.fn.filereadable(new_root_dir .. '/eslint.config.ts') == 1
+        or vim.fn.filereadable(new_root_dir .. '/eslint.config.mts') == 1
+        or vim.fn.filereadable(new_root_dir .. '/eslint.config.cts') == 1
       then
         config.settings.experimental.useFlatConfig = true
       end


### PR DESCRIPTION
This pull request adds eslint config support for `cjs`, `{,c,m}ts` .

### Js file type

From eslint `8.57.0`, `cjs` is supported. See: https://eslint.org/blog/2024/02/eslint-v8.57.0-released/

### Ts file type

ESLint does not natively support `{,c,m}ts` configuration files. However, there is an [npm dependency](https://www.npmjs.com/package/eslint-ts-patch) that can enable this functionality. I believe most people working with TypeScript configuration files are aware of this issue, but if you think it should not be added to lspconfig because it is not natively supported, please let me know, and I will retain only the cjs part.

Thank you.