### PR TITLE
feat: add the new Ruff language server

### DIFF
--- a/lua/lspconfig/server_configurations/ruff.lua
+++ b/lua/lspconfig/server_configurations/ruff.lua
@@ -1,0 +1,41 @@
+local util = require 'lspconfig.util'
+
+local root_files = {
+  'pyproject.toml',
+  'ruff.toml',
+  '.ruff.toml',
+}
+
+return {
+  default_config = {
+    cmd = { 'ruff', 'server', '--preview' },
+    filetypes = { 'python' },
+    root_dir = util.root_pattern(unpack(root_files)) or util.find_git_ancestor(),
+    single_file_support = true,
+    settings = {},
+  },
+  docs = {
+    description = [[
+https://github.com/astral-sh/ruff
+
+A Language Server Protocol implementation for Ruff, an extremely fast Python linter and code formatter, written in Rust. It can be installed via pip.
+
+```sh
+pip install ruff
+```
+
+_Requires Ruff v0.3.3 or later._
+
+This is the new Rust-based version of the original `ruff-lsp` implementation. It's currently in alpha, meaning that some features are under development. Currently, the following capabilities are supported:
+
+1. Diagnostics
+2. Code actions
+3. Formatting
+4. Range Formatting
+
+Please note that the `ruff-lsp` server will continue to be maintained until further notice.
+
+  ]],
+    root_dir = [[root_pattern("pyproject.toml", "ruff.toml", ".ruff.toml", ".git")]],
+  },
+}


### PR DESCRIPTION
Hi 👋, we (Astral) have released the Alpha version of our new Rust-based language server for Ruff. It was added in `v0.3.3` and can be run via `ruff server` command with the `--preview` flag. Currently, the server is not in par with our existing `ruff-lsp` server and we plan to maintain `ruff-lsp` until any further notice. The following capabilities are supported as of today:

1. Diagnostics
2. Formatting
3. Range formatting
4. Code actions

This PR adds a configuration for the server under a new namespace `ruff`. I'm not exactly sure if this is the correct way to do so. Please inform me if not and I’ll update the PR accordingly.