### PR TITLE
feat: adds ginko_ls support

### DIFF
--- a/lua/lspconfig/server_configurations/ginko_ls.lua
+++ b/lua/lspconfig/server_configurations/ginko_ls.lua
@@ -1,0 +1,21 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'ginko_ls' },
+    filetypes = { 'dts' },
+    root_dir = util.find_git_ancestor,
+    settings = {},
+  },
+  docs = {
+    description = [[
+`ginko_ls` is meant to be a feature-complete language server for device-trees.
+Language servers can be used in many editors, such as Visual Studio Code, Emacs
+or Vim
+
+Install `ginko_ls` from https://github.com/Schottkyc137/ginko and add it to path
+
+`ginko_ls` doesn't require any configuration.
+]],
+  },
+}


### PR DESCRIPTION
Adds configuration for [`ginko_ls`](https://github.com/Schottkyc137/ginko?tab=readme-ov-file#ginko_ls).

I tested this locally and it works well. I tested with the test file from `ginko`'s readme

```dts
/dts-v1/;

/ {
    pic@10000000 {
        phandle = <1>;
        interrupt-controller;
        reg = <0x10000000 0x100>;
    }
};
```