### PR TITLE
feat: add tsp-server support

### DIFF
--- a/lua/lspconfig/server_configurations/tsp_server.lua
+++ b/lua/lspconfig/server_configurations/tsp_server.lua
@@ -1,0 +1,24 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'tsp-server', '--stdio' },
+    filetypes = { 'typespec' },
+    root_dir = util.root_pattern('tspconfig.yaml', '.git'),
+  },
+  docs = {
+    description = [[
+https://github.com/microsoft/typespec
+
+The language server for TypeSpec, a language for defining cloud service APIs and shapes.
+
+`tsp-server` can be installed together with the typespec compiler via `npm`:
+```sh
+npm install -g @typespec/compiler
+```
+]],
+    default_config = {
+      root_dir = [[util.root_pattern("tspconfig.yaml", ".git")]],
+    },
+  },
+}


### PR DESCRIPTION
This adds support for `tsp-server`, the language server for the [TypeSpec language](https://github.com/microsoft/typespec).