### PR TITLE
fix(doc): server_configuration for css_variables

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -2225,11 +2225,8 @@ CSS variables autocompletion and go-to-definition
 npm i -g css-variables-language-server
 ```
 
-```
-
-
-
 **Snippet to enable the language server:**
+
 ```lua
 require'lspconfig'.css_variables.setup{}
 ```

--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -2225,11 +2225,8 @@ CSS variables autocompletion and go-to-definition
 npm i -g css-variables-language-server
 ```
 
-```
-
-
-
 **Snippet to enable the language server:**
+
 ```lua
 require'lspconfig'.css_variables.setup{}
 ```


### PR DESCRIPTION
I was scrolling through [server configurations](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md) searching for `css_variables` and I saw this problem:

<img width="1036" alt="lspconfig not showing properly" src="https://github.com/neovim/nvim-lspconfig/assets/71392160/59d00003-c0ff-40ab-a893-967ec9e3ee01">

> You can check it out [css_variables](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#css_variables)

So I made the change to look like this:

---

**Snippet to enable the language server:**

```lua
require'lspconfig'.css_variables.setup{}
```

---