### PR TITLE
docs(css_variables): `server_configuration` for `css_variables`

### DIFF
--- a/lua/lspconfig/server_configurations/css_variables.lua
+++ b/lua/lspconfig/server_configurations/css_variables.lua
@@ -38,8 +38,6 @@ CSS variables autocompletion and go-to-definition
 ```sh
 npm i -g css-variables-language-server
 ```
-
-```
 ]],
     default_config = {
       root_dir = [[root_pattern("package.json", ".git") or bufdir]],


### PR DESCRIPTION
I was scrolling through [server configurations](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md) searching for `css_variables` and I saw this problem:

<img width="1036" alt="lspconfig not showing properly" src="https://github.com/neovim/nvim-lspconfig/assets/71392160/59d00003-c0ff-40ab-a893-967ec9e3ee01">

> You can check it out [css_variables](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#css_variables)

So I made the change to look like this:

---

**Snippet to enable the language server:**

```lua
require'lspconfig'.css_variables.setup{}
```

---

> @glepnir sorry for the last PR about this issue 😥