### PR TITLE
feat(omnisharp)!: use standard `settings` table for configuration

### DIFF
--- a/lua/lspconfig/server_configurations/omnisharp.lua
+++ b/lua/lspconfig/server_configurations/omnisharp.lua
@@ -2,40 +2,44 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    -- Enables support for reading code style, naming convention and analyzer
-    -- settings from .editorconfig.
-    enable_editorconfig_support = true,
-
-    -- If true, MSBuild project system will only load projects for files that
-    -- were opened in the editor. This setting is useful for big C# codebases
-    -- and allows for faster initialization of code navigation features only
-    -- for projects that are relevant to code that is being edited. With this
-    -- setting enabled OmniSharp may load fewer projects and may thus display
-    -- incomplete reference lists for symbols.
-    enable_ms_build_load_projects_on_demand = false,
-
-    -- Enables support for roslyn analyzers, code fixes and rulesets.
-    enable_roslyn_analyzers = false,
-
-    -- Specifies whether 'using' directives should be grouped and sorted during
-    -- document formatting.
-    organize_imports_on_format = false,
-
-    -- Enables support for showing unimported types and unimported extension
-    -- methods in completion lists. When committed, the appropriate using
-    -- directive will be added at the top of the current file. This option can
-    -- have a negative impact on initial completion responsiveness,
-    -- particularly for the first few completion sessions after opening a
-    -- solution.
-    enable_import_completion = false,
-
-    -- Specifies whether to include preview versions of the .NET SDK when
-    -- determining which version to use for project loading.
-    sdk_include_prereleases = true,
-
-    -- Only run analyzers against open files when 'enableRoslynAnalyzers' is
-    -- true
-    analyze_open_documents_only = false,
+    settings = {
+      FormattingOptions = {
+        -- Enables support for reading code style, naming convention and analyzer
+        -- settings from .editorconfig.
+        EnableEditorConfigSupport = true,
+        -- Specifies whether 'using' directives should be grouped and sorted during
+        -- document formatting.
+        OrganizeImports = nil,
+      },
+      MsBuild = {
+        -- If true, MSBuild project system will only load projects for files that
+        -- were opened in the editor. This setting is useful for big C# codebases
+        -- and allows for faster initialization of code navigation features only
+        -- for projects that are relevant to code that is being edited. With this
+        -- setting enabled OmniSharp may load fewer projects and may thus display
+        -- incomplete reference lists for symbols.
+        LoadProjectsOnDemand = nil,
+      },
+      RoslynExtensionsOptions = {
+        -- Enables support for roslyn analyzers, code fixes and rulesets.
+        EnableAnalyzersSupport = nil,
+        -- Enables support for showing unimported types and unimported extension
+        -- methods in completion lists. When committed, the appropriate using
+        -- directive will be added at the top of the current file. This option can
+        -- have a negative impact on initial completion responsiveness,
+        -- particularly for the first few completion sessions after opening a
+        -- solution.
+        EnableImportCompletion = nil,
+        -- Only run analyzers against open files when 'enableRoslynAnalyzers' is
+        -- true
+        AnalyzeOpenDocumentsOnly = nil,
+      },
+      Sdk = {
+        -- Specifies whether to include preview versions of the .NET SDK when
+        -- determining which version to use for project loading.
+        IncludePrereleases = true,
+      },
+    },
 
     filetypes = { 'cs', 'vb' },
     root_dir = util.root_pattern('*.sln', '*.csproj', 'omnisharp.json', 'function.json'),
@@ -51,32 +55,21 @@ return {
       table.insert(new_config.cmd, '--languageserver')
 
       -- Append configuration-dependent command arguments
-      if new_config.enable_editorconfig_support then
-        table.insert(new_config.cmd, 'FormattingOptions:EnableEditorConfigSupport=true')
+      local function flatten(tbl)
+        local ret = {}
+        for k, v in pairs(tbl) do
+          if type(v) == 'table' then
+            for _, pair in ipairs(flatten(v)) do
+              ret[#ret + 1] = k .. ':' .. pair
+            end
+          else
+            ret[#ret + 1] = k .. '=' .. vim.inspect(v)
+          end
+        end
+        return ret
       end
-
-      if new_config.organize_imports_on_format then
-        table.insert(new_config.cmd, 'FormattingOptions:OrganizeImports=true')
-      end
-
-      if new_config.enable_ms_build_load_projects_on_demand then
-        table.insert(new_config.cmd, 'MsBuild:LoadProjectsOnDemand=true')
-      end
-
-      if new_config.enable_roslyn_analyzers then
-        table.insert(new_config.cmd, 'RoslynExtensionsOptions:EnableAnalyzersSupport=true')
-      end
-
-      if new_config.enable_import_completion then
-        table.insert(new_config.cmd, 'RoslynExtensionsOptions:EnableImportCompletion=true')
-      end
-
-      if new_config.sdk_include_prereleases then
-        table.insert(new_config.cmd, 'Sdk:IncludePrereleases=true')
-      end
-
-      if new_config.analyze_open_documents_only then
-        table.insert(new_config.cmd, 'RoslynExtensionsOptions:AnalyzeOpenDocumentsOnly=true')
+      if new_config.settings then
+        vim.list_extend(new_config.cmd, flatten(new_config.settings))
       end
 
       -- Disable the handling of multiple workspaces in a single instance
@@ -103,40 +96,44 @@ For `go_to_definition` to work fully, extended `textDocument/definition` handler
 require'lspconfig'.omnisharp.setup {
     cmd = { "dotnet", "/path/to/omnisharp/OmniSharp.dll" },
 
-    -- Enables support for reading code style, naming convention and analyzer
-    -- settings from .editorconfig.
-    enable_editorconfig_support = true,
-
-    -- If true, MSBuild project system will only load projects for files that
-    -- were opened in the editor. This setting is useful for big C# codebases
-    -- and allows for faster initialization of code navigation features only
-    -- for projects that are relevant to code that is being edited. With this
-    -- setting enabled OmniSharp may load fewer projects and may thus display
-    -- incomplete reference lists for symbols.
-    enable_ms_build_load_projects_on_demand = false,
-
-    -- Enables support for roslyn analyzers, code fixes and rulesets.
-    enable_roslyn_analyzers = false,
-
-    -- Specifies whether 'using' directives should be grouped and sorted during
-    -- document formatting.
-    organize_imports_on_format = false,
-
-    -- Enables support for showing unimported types and unimported extension
-    -- methods in completion lists. When committed, the appropriate using
-    -- directive will be added at the top of the current file. This option can
-    -- have a negative impact on initial completion responsiveness,
-    -- particularly for the first few completion sessions after opening a
-    -- solution.
-    enable_import_completion = false,
-
-    -- Specifies whether to include preview versions of the .NET SDK when
-    -- determining which version to use for project loading.
-    sdk_include_prereleases = true,
-
-    -- Only run analyzers against open files when 'enableRoslynAnalyzers' is
-    -- true
-    analyze_open_documents_only = false,
+    settings = {
+      FormattingOptions = {
+        -- Enables support for reading code style, naming convention and analyzer
+        -- settings from .editorconfig.
+        EnableEditorConfigSupport = true,
+        -- Specifies whether 'using' directives should be grouped and sorted during
+        -- document formatting.
+        OrganizeImports = nil,
+      },
+      MsBuild = {
+        -- If true, MSBuild project system will only load projects for files that
+        -- were opened in the editor. This setting is useful for big C# codebases
+        -- and allows for faster initialization of code navigation features only
+        -- for projects that are relevant to code that is being edited. With this
+        -- setting enabled OmniSharp may load fewer projects and may thus display
+        -- incomplete reference lists for symbols.
+        LoadProjectsOnDemand = nil,
+      },
+      RoslynExtensionsOptions = {
+        -- Enables support for roslyn analyzers, code fixes and rulesets.
+        EnableAnalyzersSupport = nil,
+        -- Enables support for showing unimported types and unimported extension
+        -- methods in completion lists. When committed, the appropriate using
+        -- directive will be added at the top of the current file. This option can
+        -- have a negative impact on initial completion responsiveness,
+        -- particularly for the first few completion sessions after opening a
+        -- solution.
+        EnableImportCompletion = nil,
+        -- Only run analyzers against open files when 'enableRoslynAnalyzers' is
+        -- true
+        AnalyzeOpenDocumentsOnly = nil,
+      },
+      Sdk = {
+        -- Specifies whether to include preview versions of the .NET SDK when
+        -- determining which version to use for project loading.
+        IncludePrereleases = true,
+      },
+    },
 }
 ```
 ]],


### PR DESCRIPTION
The standard way in lspconfig is configuring through the `settings` table. Omnisharp doesn't support being passed config at runtime, so previously some common options were toggled and added to the command args. That happened for only the preconfigured options.

This PR generalizes the behaviour in an attempt to allow users to set their options in the standard way, allowing for a more seamless syntax transition from JSON format that is used in `omnisharp` global config and `vscode`.

Although I haven't experienced any issues when leaving the `settings` table in the config, I assume `nvim` then tries to feed the settings to `omnisharp`, which may be avoidable by `settings=nil` (opinion needed).