### PR TITLE
feat: add mail and text as ltex filetypes

### DIFF
--- a/lua/lspconfig/server_configurations/ltex.lua
+++ b/lua/lspconfig/server_configurations/ltex.lua
@@ -30,6 +30,8 @@ local filetypes = {
   'context',
   'html',
   'xhtml',
+  'mail',
+  'text',
 }
 
 local function get_language_id(_, filetype)


### PR DESCRIPTION
Plaintext email and standard plaintext do not feature any markup tokens, so ltex works out of the box with no parser (tested it out locally). I think it is very useful to have a grammar checker for these formats, too. Most people use them.