### PR TITLE
beancount: Avoid initialization of optional value

### DIFF
--- a/lua/lspconfig/server_configurations/beancount.lua
+++ b/lua/lspconfig/server_configurations/beancount.lua
@@ -6,10 +6,7 @@ return {
     filetypes = { 'beancount', 'bean' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
-    init_options = {
-      -- this is the path to the beancout journal file
-      journal_file = '',
-    },
+    init_options = {},
   },
   docs = {
     description = [[


### PR DESCRIPTION
parameter journal_file is optional and should net be set: https://github.com/polarmutex/beancount-language-server/commit/22a559501b41955dbbe3fb2404e29e8e3e66e2af

Further more, the current empty string raises an error in line: https://github.com/polarmutex/beancount-language-server/blob/main/crates/lsp/src/server.rs#L122