### PR TITLE
fix(snyk_ls): update root_dir & supported filetypes

### DIFF
--- a/lua/lspconfig/server_configurations/snyk_ls.lua
+++ b/lua/lspconfig/server_configurations/snyk_ls.lua
@@ -3,7 +3,8 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'snyk-ls' },
-    root_dir = util.root_pattern '.git',
+    root_dir = util.root_pattern('.git', '.snyk'),
+    filetypes = { 'go', 'gomod', 'javascript', 'typescript', 'json', 'python', 'requirements', 'helm', 'yaml' },
     single_file_support = true,
     settings = {},
     init_options = {
@@ -17,7 +18,7 @@ https://github.com/snyk/snyk-ls
 LSP for Snyk Open Source, Snyk Infrastructure as Code, and Snyk Code.
 ]],
     default_config = {
-      root_dir = [[root_pattern(".git")]],
+      root_dir = [[root_pattern(".git", ".snyk")]],
       init_options = 'Configuration from https://github.com/snyk/snyk-ls#configuration-1',
     },
   },


### PR DESCRIPTION
To make snyk-ls work more seamlessly out-of-the-box, this PR adds support filetypes to launch the Snyk LS server and adds `.snyk` config file as a root dir