### PR TITLE
fix(nixd): update root_dir

### DIFF
--- a/lua/lspconfig/server_configurations/nixd.lua
+++ b/lua/lspconfig/server_configurations/nixd.lua
@@ -6,7 +6,7 @@ return {
     filetypes = { 'nix' },
     single_file_support = true,
     root_dir = function(fname)
-      return util.root_pattern(unpack { '.nixd.json', 'flake.nix' })(fname) or util.find_git_ancestor(fname)
+      return util.root_pattern(unpack { 'flake.nix' })(fname) or util.find_git_ancestor(fname)
     end,
   },
   docs = {
@@ -19,7 +19,7 @@ If you are using Nix with Flakes support, run `nix profile install github:nix-co
 Check the repository README for more information.
     ]],
     default_config = {
-      root_dir = [[root_pattern(".nixd.json", "flake.nix",".git")]],
+      root_dir = [[root_pattern("flake.nix",".git")]],
     },
   },
 }


### PR DESCRIPTION
Starting with nixd 2.0.2 the '.nixd.json' file will no longer be needed.