### PR TITLE
fix(nixd): remove unnecessary nid.json root pattern

### DIFF
--- a/lua/lspconfig/server_configurations/nixd.lua
+++ b/lua/lspconfig/server_configurations/nixd.lua
@@ -6,7 +6,7 @@ return {
     filetypes = { 'nix' },
     single_file_support = true,
     root_dir = function(fname)
-      return util.root_pattern(unpack { '.nixd.json', 'flake.nix' })(fname) or util.find_git_ancestor(fname)
+      return util.root_pattern 'flake.nix'(fname) or util.find_git_ancestor(fname)
     end,
   },
   docs = {


### PR DESCRIPTION
Problem: Starting with nixd 2.0.2 the '.nixd.json' file will no longer be needed.

Solution: remove .nidx.json

close #3119 