### PR TITLE
refactor: handle updated signature of lsp.start_client

### DIFF
--- a/lua/lspconfig/manager.lua
+++ b/lua/lspconfig/manager.lua
@@ -149,8 +149,13 @@ function M:_start_new_client(bufnr, new_config, root_dir, single_file)
     new_config.root_dir = nil
     new_config.workspace_folders = nil
   end
-  local client_id = lsp.start_client(new_config)
+
+  -- TODO: Replace lsp.start_client with lsp.start
+  local client_id, err = lsp.start_client(new_config)
   if not client_id then
+    if err then
+      vim.notify(err, vim.log.levels.WARN)
+    end
     return
   end
   self:_attach_and_cache(bufnr, root_dir, client_id)


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/28478 changes the signature of start_client to return two values: client_id or nil and error message or nil. start_client no longer calls vim.notify directly, so if there is an error we must call vim.notify ourselves.
