### PR TITLE
docs(lua_ls) Fix broken example setup when workspace_folders are not used

### DIFF
--- a/lua/lspconfig/server_configurations/lua_ls.lua
+++ b/lua/lspconfig/server_configurations/lua_ls.lua
@@ -45,9 +45,11 @@ settings.
 ```lua
 require'lspconfig'.lua_ls.setup {
   on_init = function(client)
-    local path = client.workspace_folders[1].name
-    if vim.loop.fs_stat(path..'/.luarc.json') or vim.loop.fs_stat(path..'/.luarc.jsonc') then
-      return
+    if client.workspace_folders then
+      local path = client.workspace_folders[1].name
+      if vim.loop.fs_stat(path..'/.luarc.json') or vim.loop.fs_stat(path..'/.luarc.jsonc') then
+        return
+      end
     end
 
     client.config.settings.Lua = vim.tbl_deep_extend('force', client.config.settings.Lua, {


### PR DESCRIPTION
Without this fix I get errors on startup and the config is not applied properly.

> LSP[lua_ls]: Error ON_INIT_CALLBACK_ERROR: "[string \":lua\"]:79: attempt to index field 'workspace_folders' (a nil value)"