### PR TITLE
fix(elmls): add missing init_options, remove deprecated

### DIFF
--- a/lua/lspconfig/server_configurations/elmls.lua
+++ b/lua/lspconfig/server_configurations/elmls.lua
@@ -18,7 +18,10 @@ return {
       end
     end,
     init_options = {
-      elmAnalyseTrigger = 'change',
+      elmReviewDiagnostics = 'off', -- 'off' | 'warning' | 'error'
+      skipInstallPackageConfirmation = false,
+      disableElmLSDiagnostics = false,
+      onlyUpdateDiagnosticsOnSave = false,
     },
   },
   docs = {


### PR DESCRIPTION
This PR fixes the `init_options` for the `elmls` server configuration.

Ref: https://github.com/elm-tooling/elm-language-server?tab=readme-ov-file#server-settings