### PR TITLE
Add motoko language server

### DIFF
--- a/lua/lspconfig/server_configurations/motoko_lsp.lua
+++ b/lua/lspconfig/server_configurations/motoko_lsp.lua
@@ -1,0 +1,23 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'motoko-lsp', '--stdio' },
+    filetypes = { 'motoko' },
+    root_dir = util.root_pattern('dfx.json', '.git'),
+    init_options = {
+      formatter = 'auto',
+    },
+    single_file_support = true,
+  },
+  docs = {
+    description = [[
+https://github.com/dfinity/vscode-motoko
+
+Language server for the Motoko programming language.
+    ]],
+    default_config = {
+      root_dir = [[root_pattern("dfx.json", ".git")]],
+    },
+  },
+}


### PR DESCRIPTION
This adds configuration files for the [Motoko](https://github.com/dfinity/motoko) language server.

motoko-lsp is part of the [dfinity/vscode-motoko repository](https://github.com/dfinity/vscode-motoko) and can be installed via [Mason](https://github.com/mason-org/mason-registry/blob/main/packages/motoko-lsp/package.yaml).