### PR TITLE
docs(dockerls): document ignoreMultilineInstructions setting

### DIFF
--- a/lua/lspconfig/server_configurations/dockerls.lua
+++ b/lua/lspconfig/server_configurations/dockerls.lua
@@ -15,6 +15,21 @@ https://github.com/rcjsuen/dockerfile-language-server-nodejs
 ```sh
 npm install -g dockerfile-language-server-nodejs
 ```
+
+Additional configuration can be applied in the following way:
+```lua
+require("lspconfig").dockerls.setup {
+    settings = {
+        docker = {
+	    languageserver = {
+	        formatter = {
+		    ignoreMultilineInstructions = true,
+		},
+	    },
+	}
+    }
+}
+```
     ]],
     default_config = {
       root_dir = [[root_pattern("Dockerfile")]],


### PR DESCRIPTION
Document how the ignoreMultilineInstructions settings for dockerls can
be configured.

That the settings key must be "docker" instead of "dockerls" makes it
non-intuitive and harder to figure out.

Sources:
- https://github.com/rcjsuen/dockerfile-language-server?tab=readme-ov-file#language-server-settings
- https://github.com/rcjsuen/dockerfile-language-server/blob/9e3f8580f711e54a1de0351631baeac49665d6f3/src/server.ts#L330-L344