### PR TITLE
Add roc-language-server support

### DIFF
--- a/lua/lspconfig/server_configurations/roc_ls.lua
+++ b/lua/lspconfig/server_configurations/roc_ls.lua
@@ -1,0 +1,21 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'roc_language_server' },
+    filetypes = { 'roc' },
+    root_dir = util.find_git_ancestor,
+    single_file_support = true,
+  },
+  docs = {
+    description = [[
+https://github.com/roc-lang/roc/tree/main/crates/language_server#roc_language_server
+
+The built-in language server for the Roc programming language.
+[Installation](https://github.com/roc-lang/roc/tree/main/crates/language_server#installing)
+]],
+    default_config = {
+      root_dir = [[util.find_git_ancestor]],
+    },
+  },
+}


### PR DESCRIPTION
This adds a basic configuration for Roc's built-in language server.

So far only _go-to-definition_, _hover_, _inline diagnostics_ and _formatting_ is implemented.

For more information on the language server itself checkout [Roc](https://github.com/roc-lang/roc/tree/main/crates/language_server#roc_language_server).