### PR TITLE
feat: add shopify theme language-server

### DIFF
--- a/lua/lspconfig/server_configurations/shopify_theme_ls.lua
+++ b/lua/lspconfig/server_configurations/shopify_theme_ls.lua
@@ -1,0 +1,34 @@
+local util = require 'lspconfig.util'
+
+local root_files = {
+  '.shopifyignore',
+  '.theme-check.yml',
+  '.theme-check.yaml',
+  'shopify.theme.toml',
+}
+
+return {
+  default_config = {
+    cmd = {
+      'shopify',
+      'theme',
+      'language-server',
+    },
+    filetypes = { 'liquid' },
+    root_dir = util.root_pattern(unpack(root_files)),
+    settings = {},
+  },
+  docs = {
+    description = [[
+https://shopify.dev/docs/api/shopify-cli
+
+[Language Server](https://shopify.dev/docs/themes/tools/cli/language-server) and Theme Check (linter) for Shopify themes.
+
+`shopify` can be installed via npm `npm install -g @shopify/cli`.
+
+```lua
+require lspconfig.shopify_theme_ls.setup {}
+```
+]],
+  },
+}

--- a/lua/lspconfig/server_configurations/shopify_theme_ls.lua
+++ b/lua/lspconfig/server_configurations/shopify_theme_ls.lua
@@ -29,6 +29,8 @@ https://shopify.dev/docs/api/shopify-cli
 ```lua
 require lspconfig.shopify_theme_ls.setup {}
 ```
+
+Note: This LSP already includes Theme Check so you don't need to use the `theme_check` server configuration as well.
 ]],
   },
 }


### PR DESCRIPTION
Shopify theme [language-server](https://shopify.dev/docs/themes/tools/cli/language-server) is a LSP server for `liquid` files.  Currently we have the [theme_check](https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/theme_check.lua) server_configuration which is considered deprecated. Although I haven't found any information about it. But you can see that there is no activity in the [repository](https://github.com/Shopify/theme-check) for the last year, also this language-server already includes theme_check (linter). Thank you!