### PR TITLE
Update config for ember-language-server due to upstreaming

### DIFF
--- a/lua/lspconfig/server_configurations/ember.lua
+++ b/lua/lspconfig/server_configurations/ember.lua
@@ -8,12 +8,12 @@ return {
   },
   docs = {
     description = [[
-https://github.com/lifeart/ember-language-server
+https://github.com/ember-tooling/ember-language-server
 
 `ember-language-server` can be installed via `npm`:
 
 ```sh
-npm install -g @lifeart/ember-language-server
+npm install -g @ember-tooling/ember-language-server
 ```
 ]],
     default_config = {


### PR DESCRIPTION
Similar to: https://github.com/mason-org/mason-registry/pull/5740

ember-language-server has been upstreamed into its original repo, and released under a new / the original name.