### PR TITLE
fix(r): change markdown injection in documentation to use lowercase r

### DIFF
--- a/lua/lspconfig/server_configurations/r_language_server.lua
+++ b/lua/lspconfig/server_configurations/r_language_server.lua
@@ -17,7 +17,7 @@ language.
 
 It is released on CRAN and can be easily installed by
 
-```R
+```r
 install.packages("languageserver")
 ```
 ]],


### PR DESCRIPTION
when using a recent build of neovim on macos (https://github.com/neovim/neovim/commit/26b5405d181e8c9e75c4b4ec9aae963cc25f285f), viewing `:h lspconfig-all` is entirely broken (error crash loop) because of a broken injection in the document. turns out that the `R` in the markdown description here should be lowercase, since the treesitter grammar uses lowercase `r`!