### PR TITLE
refactor: add compatible tbl_flatten and lsp_get_clients for new version 0.10

### DIFF
--- a/lua/lspconfig/server_configurations/vdmj.lua
+++ b/lua/lspconfig/server_configurations/vdmj.lua
@@ -129,6 +129,6 @@ by neovim.
       dap,
     }
 
-    config.cmd = vim.tbl_flatten { java_cmd, vdmj_cmd }
+    config.cmd = util.tbl_flatten { java_cmd, vdmj_cmd }
   end,
 }

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -3,6 +3,7 @@ local validate = vim.validate
 local api = vim.api
 local lsp = vim.lsp
 local uv = vim.loop
+local nvim_nine = vim.fn.has 'nvim-0.9' == 1
 
 local is_windows = uv.os_uname().version:match 'Windows'
 
@@ -170,7 +171,7 @@ M.path = (function()
   end
 
   local function path_join(...)
-    return table.concat(vim.tbl_flatten { ... }, '/')
+    return table.concat(M.tbl_flatten { ... }, '/')
   end
 
   -- Traverse the path calling cb along the way.
@@ -261,8 +262,16 @@ function M.search_ancestors(startpath, func)
   end
 end
 
+function M.tbl_flatten(t)
+  return nvim_nine and vim.tbl_flatten(t) or vim.iter(t):flatten(math.huge):totable()
+end
+
+local function get_lsp_clients(filter)
+  return nvim_nine and lsp.get_active_clients(filter) or lsp.get_clients(filter)
+end
+
 function M.root_pattern(...)
-  local patterns = vim.tbl_flatten { ... }
+  local patterns = M.tbl_flatten { ... }
   return function(startpath)
     startpath = M.strip_archive_subpath(startpath)
     for _, pattern in ipairs(patterns) do
@@ -333,7 +342,7 @@ function M.insert_package_json(config_files, field, fname)
 end
 
 function M.get_active_clients_list_by_ft(filetype)
-  local clients = vim.lsp.get_active_clients()
+  local clients = get_lsp_clients()
   local clients_list = {}
   for _, client in pairs(clients) do
     local filetypes = client.config.filetypes or {}
@@ -378,7 +387,8 @@ function M.get_config_by_ft(filetype)
 end
 
 function M.get_active_client_by_name(bufnr, servername)
-  for _, client in pairs(vim.lsp.get_active_clients { bufnr = bufnr }) do
+  --TODO(glepnir): remove this for loop when we want only support 0.10+
+  for _, client in pairs(get_lsp_clients { bufnr = bufnr }) do
     if client.name == servername then
       return client
     end

--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -4,7 +4,6 @@ local util = require 'lspconfig.util'
 local inspect = vim.inspect
 local uv = vim.loop
 local fn = vim.fn
-local tbl_flatten = vim.tbl_flatten
 
 local function template(s, params)
   return (s:gsub('{{([^{}]+)}}', params))
@@ -40,12 +39,15 @@ local function indent(n, s)
 end
 
 local function make_parts(fns)
-  return tbl_flatten(map_list(fns, function(v)
-    if type(v) == 'function' then
-      v = v()
-    end
-    return { v }
-  end))
+  return vim
+    .iter(fns)
+    :map(function(v)
+      if type(v) == 'function' then
+        v = v()
+      end
+      return { v }
+    end)
+    :totable()
 end
 
 local function make_section(indentlvl, sep, parts)
@@ -215,7 +217,7 @@ local function make_lsp_sections()
                                 return tick('enum ' .. inspect(v.enum))
                               end
                               if v.type then
-                                return tick(table.concat(tbl_flatten { v.type }, '|'))
+                                return tick(table.concat(util.tbl_flatten { v.type }, '|'))
                               end
                             end,
                           }),


### PR DESCRIPTION
add compatible `util.tbl_flatten` and `lsp.get_active_clients` to avoid  deprecated error notify on 0.10 release.