### PR TITLE
refactor: remove tbl_add_reverse_loopup

### DIFF
--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -1,17 +1,17 @@
 local util = require 'lspconfig.util'
 
-local texlab_build_status = vim.tbl_add_reverse_lookup {
-  Success = 0,
-  Error = 1,
-  Failure = 2,
-  Cancelled = 3,
+local texlab_build_status = {
+  [0] = 'Success',
+  [1] = 'Error',
+  [2] = 'Failure',
+  [3] = 'Cancelled',
 }
 
-local texlab_forward_status = vim.tbl_add_reverse_lookup {
-  Success = 0,
-  Error = 1,
-  Failure = 2,
-  Unconfigured = 3,
+local texlab_forward_status = {
+  [0] = 'Success',
+  [1] = 'Error',
+  [2] = 'Failure',
+  [3] = 'Unconfigured',
 }
 
 local function buf_build(bufnr)


### PR DESCRIPTION
`vim.lsp.get_active_clients` will be deprecated in the future, and the deprecation warning will be shown in 0.11.