### PR TITLE
refactor: move all old get_clients to new compatible

### DIFF
--- a/lua/lspconfig/server_configurations/basedpyright.lua
+++ b/lua/lspconfig/server_configurations/basedpyright.lua
@@ -16,7 +16,7 @@ local function organize_imports()
     arguments = { vim.uri_from_bufnr(0) },
   }
 
-  local clients = vim.lsp.get_active_clients {
+  local clients = util.get_lsp_clients {
     bufnr = vim.api.nvim_get_current_buf(),
     name = 'basedpyright',
   }
@@ -26,7 +26,7 @@ local function organize_imports()
 end
 
 local function set_python_path(path)
-  local clients = vim.lsp.get_active_clients {
+  local clients = util.get_lsp_clients {
     bufnr = vim.api.nvim_get_current_buf(),
     name = 'basedpyright',
   }

--- a/lua/lspconfig/server_configurations/denols.lua
+++ b/lua/lspconfig/server_configurations/denols.lua
@@ -96,7 +96,7 @@ return {
   commands = {
     DenolsCache = {
       function()
-        local clients = vim.lsp.get_active_clients { bufnr = 0, name = 'denols' }
+        local clients = util.get_lsp_clients { bufnr = 0, name = 'denols' }
         if #clients > 0 then
           buf_cache(0, clients[#clients])
         end

--- a/lua/lspconfig/server_configurations/gopls.lua
+++ b/lua/lspconfig/server_configurations/gopls.lua
@@ -15,7 +15,7 @@ return {
         end
       end
       if fname:sub(1, #mod_cache) == mod_cache then
-        local clients = vim.lsp.get_active_clients { name = 'gopls' }
+        local clients = util.get_lsp_clients { name = 'gopls' }
         if #clients > 0 then
           return clients[#clients].config.root_dir
         end

--- a/lua/lspconfig/server_configurations/pyright.lua
+++ b/lua/lspconfig/server_configurations/pyright.lua
@@ -16,7 +16,7 @@ local function organize_imports()
     arguments = { vim.uri_from_bufnr(0) },
   }
 
-  local clients = vim.lsp.get_active_clients {
+  local clients = util.get_lsp_clients {
     bufnr = vim.api.nvim_get_current_buf(),
     name = 'pyright',
   }
@@ -26,7 +26,7 @@ local function organize_imports()
 end
 
 local function set_python_path(path)
-  local clients = vim.lsp.get_active_clients {
+  local clients = util.get_lsp_clients {
     bufnr = vim.api.nvim_get_current_buf(),
     name = 'pyright',
   }

--- a/lua/lspconfig/server_configurations/rust_analyzer.lua
+++ b/lua/lspconfig/server_configurations/rust_analyzer.lua
@@ -3,7 +3,7 @@ local async = require 'lspconfig.async'
 
 local function reload_workspace(bufnr)
   bufnr = util.validate_bufnr(bufnr)
-  local clients = vim.lsp.get_active_clients { name = 'rust_analyzer', bufnr = bufnr }
+  local clients = util.get_lsp_clients { bufnr = bufnr, name = 'rust_analyzer' }
   for _, client in ipairs(clients) do
     vim.notify 'Reloading Cargo Workspace'
     client.request('rust-analyzer/reloadWorkspace', nil, function(err)
@@ -26,7 +26,7 @@ local function is_library(fname)
 
   for _, item in ipairs { toolchains, registry, git_registry } do
     if util.path.is_descendant(item, fname) then
-      local clients = vim.lsp.get_active_clients { name = 'rust_analyzer' }
+      local clients = util.get_lsp_clients { name = 'rust_analyzer' }
       return #clients > 0 and clients[#clients].config.root_dir or nil
     end
   end

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -1,4 +1,4 @@
-local api, fn, lsp = vim.api, vim.fn, vim.lsp
+local api, fn = vim.api, vim.fn
 local windows = require 'lspconfig.ui.windows'
 local util = require 'lspconfig.util'
 
@@ -188,8 +188,8 @@ return function()
   -- These options need to be cached before switching to the floating
   -- buffer.
   local original_bufnr = api.nvim_get_current_buf()
-  local buf_clients = lsp.get_active_clients { bufnr = original_bufnr }
-  local clients = lsp.get_active_clients()
+  local buf_clients = util.get_lsp_clients { bufnr = original_bufnr }
+  local clients = util.get_lsp_clients()
   local buffer_filetype = vim.bo.filetype
   local fname = api.nvim_buf_get_name(original_bufnr)
 

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -266,7 +266,7 @@ function M.tbl_flatten(t)
   return nvim_ten and vim.iter(t):flatten(math.huge):totable() or vim.tbl_flatten(t)
 end
 
-local function get_lsp_clients(filter)
+function M.get_lsp_clients(filter)
   return nvim_ten and lsp.get_clients(filter) or lsp.get_active_clients(filter)
 end
 
@@ -342,7 +342,7 @@ function M.insert_package_json(config_files, field, fname)
 end
 
 function M.get_active_clients_list_by_ft(filetype)
-  local clients = get_lsp_clients()
+  local clients = M.get_lsp_clients()
   local clients_list = {}
   for _, client in pairs(clients) do
     local filetypes = client.config.filetypes or {}
@@ -388,7 +388,7 @@ end
 
 function M.get_active_client_by_name(bufnr, servername)
   --TODO(glepnir): remove this for loop when we want only support 0.10+
-  for _, client in pairs(get_lsp_clients { bufnr = bufnr }) do
+  for _, client in pairs(M.get_lsp_clients { bufnr = bufnr }) do
     if client.name == servername then
       return client
     end

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -135,7 +135,7 @@ api.nvim_create_user_command('LspStop', function(info)
   end
 
   if not server_id then
-    local servers_on_buffer = lsp.get_active_clients { bufnr = current_buf }
+    local servers_on_buffer = require('lspconfig.util').get_lsp_clients { bufnr = current_buf }
     for _, client in ipairs(servers_on_buffer) do
       if client.attached_buffers[current_buf] then
         client.stop(force)


### PR DESCRIPTION
still have some old `vim.lsp.get_active_clients` usage.