### PR TITLE
docs: update ansiblels homepage url

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -516,7 +516,7 @@ require'lspconfig'.angularls.setup{}
 
 ## ansiblels
 
-https://github.com/ansible/ansible-language-server
+https://github.com/ansible/vscode-ansible
 
 Language server for the ansible configuration management tool.
 

--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -516,7 +516,7 @@ require'lspconfig'.angularls.setup{}
 
 ## ansiblels
 
-https://github.com/ansible/ansible-language-server
+https://github.com/ansible/vscode-ansible
 
 Language server for the ansible configuration management tool.
 

--- a/lua/lspconfig/server_configurations/ansiblels.lua
+++ b/lua/lspconfig/server_configurations/ansiblels.lua
@@ -29,7 +29,7 @@ return {
   },
   docs = {
     description = [[
-https://github.com/ansible/ansible-language-server
+https://github.com/ansible/vscode-ansible
 
 Language server for the ansible configuration management tool.
 


### PR DESCRIPTION
Updating the homepage for the `ansible-language-server` to the latest URL, as the currently stated URL points to an archived repository (whose repo description also now points to the latest URL as introduced by this change).

This can be further verified at the package's registry page here: https://www.npmjs.com/package/@ansible/ansible-language-server