### PR TITLE
fix: remove parenthesis from `find_git_ancestor` call

### DIFF
--- a/lua/lspconfig/server_configurations/drools_lsp.lua
+++ b/lua/lspconfig/server_configurations/drools_lsp.lua
@@ -37,7 +37,7 @@ end
 return {
   default_config = {
     filetypes = { 'drools' },
-    root_dir = util.find_git_ancestor(),
+    root_dir = util.find_git_ancestor,
     single_file_support = true,
     on_new_config = function(new_config)
       new_config.cmd = get_cmd(new_config)

--- a/lua/lspconfig/server_configurations/mutt_ls.lua
+++ b/lua/lspconfig/server_configurations/mutt_ls.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'mutt-language-server' },
     filetypes = { 'muttrc', 'neomuttrc' },
-    root_dir = util.find_git_ancestor(),
+    root_dir = util.find_git_ancestor,
     single_file_support = true,
     settings = {},
   },


### PR DESCRIPTION
The `drools_lsp` and `mutt_ls` are calling `util.find_git_ancestor()` when it should be `util.find_git_ancestor`.
This causes the following error when requiring one of those modules.
```
require'lspconfig.server_configurations.drools_lsp' E5108: Error executing lua [string ":lua"]:1: loop or previous error loading module 'lspconfig.server_configurations.drools_lsp'
```

This PR remove the parenthesis.