### PR TITLE
fix(util) attempt to call `tbl_flatten` (a nil value)

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -263,7 +263,11 @@ function M.search_ancestors(startpath, func)
 end
 
 function M.tbl_flatten(t)
-  return nvim_ten and vim.iter(t):flatten(math.huge):totable() or vim.tbl_flatten(t)
+  if(nvim_ten)then
+    return vim.tbl_flatten(t)
+  else
+    return vim.iter(t):flatten(math.huge):totable()
+  end
 end
 
 function M.get_lsp_clients(filter)


### PR DESCRIPTION
Problem: On nvim v10.0, function `tbl_flatten` doesn't return anything.
Reason:  In neovimv10.0 iter.lua:234, function `Iter:flatten` calls the 'error' and does not return anything value.