### PR TITLE
fix: avoid overriding global default capabilities

### DIFF
--- a/lua/lspconfig/server_configurations/arduino_language_server.lua
+++ b/lua/lspconfig/server_configurations/arduino_language_server.lua
@@ -1,9 +1,5 @@
 local util = require 'lspconfig.util'
 
-local default_capabilities = vim.lsp.protocol.make_client_capabilities()
-default_capabilities.textDocument.semanticTokens = vim.NIL
-default_capabilities.workspace.semanticTokens = vim.NIL
-
 return {
   default_config = {
     filetypes = { 'arduino' },
@@ -11,7 +7,14 @@ return {
     cmd = {
       'arduino-language-server',
     },
-    capabilities = default_capabilities,
+    capabilities = {
+      textDocument = {
+        semanticTokens = vim.NIL,
+      },
+      workspace = {
+        semanticTokens = vim.NIL,
+      },
+    },
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/elmls.lua
+++ b/lua/lspconfig/server_configurations/elmls.lua
@@ -1,9 +1,6 @@
 local util = require 'lspconfig.util'
-local lsp = vim.lsp
 local api = vim.api
 
-local default_capabilities = lsp.protocol.make_client_capabilities()
-default_capabilities.offsetEncoding = { 'utf-8', 'utf-16' }
 local elm_root_pattern = util.root_pattern 'elm.json'
 
 return {
@@ -22,6 +19,9 @@ return {
       skipInstallPackageConfirmation = false,
       disableElmLSDiagnostics = false,
       onlyUpdateDiagnosticsOnSave = false,
+    },
+    capabilities = {
+      offsetEncoding = { 'utf-8', 'utf-16' },
     },
   },
   docs = {

--- a/lua/lspconfig/server_configurations/fennel_ls.lua
+++ b/lua/lspconfig/server_configurations/fennel_ls.lua
@@ -1,8 +1,5 @@
 local util = require 'lspconfig.util'
 
-local default_capabilities = vim.lsp.protocol.make_client_capabilities()
-default_capabilities.offsetEncoding = { 'utf-8', 'utf-16' }
-
 return {
   default_config = {
     cmd = { 'fennel-ls' },
@@ -11,7 +8,9 @@ return {
       return util.find_git_ancestor(dir)
     end,
     settings = {},
-    capabilities = default_capabilities,
+    capabilities = {
+      offsetEncoding = { 'utf-8', 'utf-16' },
+    },
   },
   docs = {
     description = [[

--- a/lua/lspconfig/server_configurations/rust_analyzer.lua
+++ b/lua/lspconfig/server_configurations/rust_analyzer.lua
@@ -32,14 +32,6 @@ local function is_library(fname)
   end
 end
 
-local function register_cap()
-  local capabilities = vim.lsp.protocol.make_client_capabilities()
-  capabilities.experimental = {
-    serverStatusNotification = true,
-  }
-  return capabilities
-end
-
 return {
   default_config = {
     cmd = { 'rust-analyzer' },
@@ -80,7 +72,11 @@ return {
         or util.root_pattern 'rust-project.json'(fname)
         or util.find_git_ancestor(fname)
     end,
-    capabilities = register_cap(),
+    capabilities = {
+      experimental = {
+        serverStatusNotification = true,
+      },
+    },
   },
   commands = {
     CargoReload = {


### PR DESCRIPTION
A config's `default_config` acts as an override to the global `default_config` because of `'keep'` here:

https://github.com/neovim/nvim-lspconfig/blob/38de86f82efd9ba0881203767d6a8e1815abca28/lua/lspconfig/configs.lua#L60

Some configs were providing the entire capabilities table in their `default_config`. This is not necessary because the global `default_config` already includes them, and it was causing any of the user's changes to be overridden.

https://github.com/neovim/nvim-lspconfig/blob/38de86f82efd9ba0881203767d6a8e1815abca28/lua/lspconfig/util.lua#L19


The specific issue I was facing was that globally setting `snippetSupport = true` was ignored for rust_analyzer.