### PR TITLE
fix(eslint): useFlatConfig is not experimental anymore

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -71,9 +71,7 @@ return {
       validate = 'on',
       packageManager = nil,
       useESLintClass = false,
-      experimental = {
-        useFlatConfig = false,
-      },
+      useFlatConfig = false,
       codeActionOnSave = {
         enable = false,
         mode = 'all',
@@ -119,7 +117,7 @@ return {
         or vim.fn.filereadable(new_root_dir .. '/eslint.config.mts') == 1
         or vim.fn.filereadable(new_root_dir .. '/eslint.config.cts') == 1
       then
-        config.settings.experimental.useFlatConfig = true
+        config.settings.useFlatConfig = true
       end
 
       -- Support Yarn2 (PnP) projects


### PR DESCRIPTION
As [Support for the new ESLint flat config files has improved](https://github.com/microsoft/vscode-eslint?tab=readme-ov-file#version-305---pre-release)

```
eslint.experimental.useFlatConfig
```
should be 
```
eslint.useFlatConfig
```

I have tested with flat config. ```experimental``` not working anymore.