### PR TITLE
draft: fix(slint-lsp): set root dir to git ancestor

### DIFF
--- a/lua/lspconfig/server_configurations/slint_lsp.lua
+++ b/lua/lspconfig/server_configurations/slint_lsp.lua
@@ -1,7 +1,10 @@
+local util = require 'lspconfig.util'
+
 return {
   default_config = {
     cmd = { 'slint-lsp' },
     filetypes = { 'slint' },
+    root_dir = util.find_git_ancestor,
     single_file_support = true,
   },
   docs = {


### PR DESCRIPTION
Without this, the LSP doesn't resolve imports properly, at least on recent versions.