### PR TITLE
feat(biome): add `css` as filetype

### DIFF
--- a/lua/lspconfig/server_configurations/biome.lua
+++ b/lua/lspconfig/server_configurations/biome.lua
@@ -14,6 +14,7 @@ return {
       'astro',
       'svelte',
       'vue',
+      'css',
     },
     root_dir = util.root_pattern('biome.json', 'biome.jsonc'),
     single_file_support = false,


### PR DESCRIPTION
The latest biome release added support for css files: https://github.com/biomejs/biome/releases/tag/cli%2Fv1.8.0