### PR TITLE
fix(rust_analyzer): revert is_library regression

### DIFF
--- a/lua/lspconfig/server_configurations/rust_analyzer.lua
+++ b/lua/lspconfig/server_configurations/rust_analyzer.lua
@@ -25,7 +25,8 @@ local function is_library(fname)
   local toolchains = util.path.join(rustup_home, 'toolchains')
 
   for _, item in ipairs { toolchains, registry, git_registry } do
-    if util.path.is_descendant(item, fname) then
+    -- see if fname is a descendant of above roots
+    if fname:sub(1, #item) == item then
       local clients = util.get_lsp_clients { name = 'rust_analyzer' }
       return #clients > 0 and clients[#clients].config.root_dir or nil
     end


### PR DESCRIPTION
In #2995, root check is replaced with ``is_descendant``. Author of the PR then figured out issue was unrelated to the way root is checked, but kept the new implementation because it was descriptive on what it does. But on Windows, this causes the issue that #2645 is_library fixes.

So the issue is, ``is_descendant`` function calls ``traverse_parents``, which converts the path using:
```lua
path = uv.fs_realpath(path)
```
Which, in a Windows environment, this converts UNIX paths to Windows paths. So this requires items in line 27 to be also converted. BUT that doesn't work because ``dirname`` is not able to work with Windows paths. So I guess this is a bigger issue on Windows support, but I don't know the codebase enough to change how utils work and have that responsibility.

So, if that's it, **why isn't this an issue and a PR instead**. Because I think ``is_descendant`` is wrong tool here. For valid cases of items there, substring check is exact and does it in a way simpler way. I also added a comment above to make it descriptive on what it does. So this essentially reverts part of #2995 that changes how descendant is checked and adds a comment.