### PR TITLE
feat: do not process if commands[i] is func type

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -88,10 +88,12 @@ end
 
 function M.create_module_commands(module_name, commands)
   for command_name, def in pairs(commands) do
-    local opts = M._parse_user_command_options(def)
-    api.nvim_create_user_command(command_name, function(info)
-      require('lspconfig')[module_name].commands[command_name][1](unpack(info.fargs))
-    end, opts)
+    if type(def) ~= 'function' then
+      local opts = M._parse_user_command_options(def)
+      api.nvim_create_user_command(command_name, function(info)
+        require('lspconfig')[module_name].commands[command_name][1](unpack(info.fargs))
+      end, opts)
+    end
   end
 end
 


### PR DESCRIPTION
Context: https://github.com/neovim/nvim-lspconfig/issues/3087#issuecomment-2016041174

I want to set commands argument in [vim.lsp.ClientConfig](https://neovim.io/doc/user/lsp.html#vim.lsp.ClientConfig) which has `table<string, fun>` type, which is not conforming to lspconfig's own commands type. lspconfig has to skip them for user command registrations.