### PR TITLE
feat: add django-template-lsp support

### DIFF
--- a/lua/lspconfig/server_configurations/djlsp.lua
+++ b/lua/lspconfig/server_configurations/djlsp.lua
@@ -1,0 +1,17 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'djlsp' },
+    filetypes = { 'html', 'htmldjango' },
+    root_dir = util.find_git_ancestor,
+    settings = {},
+  },
+  docs = {
+    description = [[
+      https://github.com/fourdigits/django-template-lsp
+
+      `djlsp`, a language server for Django templates.
+    ]],
+  },
+}


### PR DESCRIPTION
Add default server configuration for our `django-template-lsp` package.