### PR TITLE
feat: add lsp-ai support

### DIFF
--- a/lua/lspconfig/configs/lsp_ai.lua
+++ b/lua/lspconfig/configs/lsp_ai.lua
@@ -1,0 +1,27 @@
+return {
+  default_config = {
+    cmd = { 'lsp-ai' },
+    filetypes = {},
+    root_dir = nil,
+    single_file_support = true,
+    init_options = {
+      memory = {
+        file_store = vim.empty_dict(),
+      },
+      models = vim.empty_dict(),
+    },
+  },
+  docs = {
+    [[
+https://github.com/SilasMarvin/lsp-ai
+
+LSP-AI is an open source language server that serves as a backend for AI-powered functionality in your favorite code
+editors. It offers features like in-editor chatting with LLMs and code completions.
+
+
+You will need to provide configuration for the inference backends and models you want to use, as well as configure
+completion/code actions. See the [wiki docs](https://github.com/SilasMarvin/lsp-ai/wiki/Configuration) and
+[examples](https://github.com/SilasMarvin/lsp-ai/blob/main/examples/nvim) for more information.
+]],
+  },
+}


### PR DESCRIPTION
This PR adds support for the [lsp-ai](https://github.com/SilasMarvin/lsp-ai) language server. Since the server is language-agnostic, I've set the defaults to attach to all filetypes, and always run in single-file mode.

Do note that as is, this is not a full, functional configuration (it shouldn't error, just won't generate any completions), as there are parts for which I don't think there are good default values, so I just want to be sure you're good with this as long as I document it, since from a _quick_ look at the supported server list it looks like most (all ?) servers work out-of-the-box with the default config of an empty `setup{}` call. Then again this one is a bit unusual.  
In particular, a user would need to select an inference backend, which could either be some API requiring an API key or some other user-managed inference server (no sane defaults for us to provide here), or have `lsp-ai` do inference itself with `llama.cpp`, which requires a decent GPU as well as downloading a few GBs of model files from HuggingFace, which I don't think is a great default either.