### PR TITLE
Added recommended default settings for fsautocomplete

### DIFF
--- a/lua/lspconfig/server_configurations/fsautocomplete.lua
+++ b/lua/lspconfig/server_configurations/fsautocomplete.lua
@@ -8,6 +8,27 @@ return {
     init_options = {
       AutomaticWorkspaceInit = true,
     },
+    -- this recommended settings values taken from  https://github.com/ionide/FsAutoComplete?tab=readme-ov-file#settings
+    settings = {
+      FSharp = {
+        keywordsAutocomplete = true,
+        ExternalAutocomplete = false,
+        Linter = true,
+        UnionCaseStubGeneration = true,
+        UnionCaseStubGenerationBody = 'failwith "Not Implemented"',
+        RecordStubGeneration = true,
+        RecordStubGenerationBody = 'failwith "Not Implemented"',
+        InterfaceStubGeneration = true,
+        InterfaceStubGenerationObjectIdentifier = 'this',
+        InterfaceStubGenerationMethodBody = 'failwith "Not Implemented"',
+        UnusedOpensAnalyzer = true,
+        UnusedDeclarationsAnalyzer = true,
+        UseSdkScripts = true,
+        SimplifyNameAnalyzer = true,
+        ResolveNamespaces = true,
+        EnableReferenceCodeLens = true,
+      }
+    },
   },
   docs = {
     description = [[


### PR DESCRIPTION
Hello.

I've added recommended default settings values for [fsautocomplete](https://github.com/ionide/FsAutoComplete?tab=readme-ov-file#settings). Without these settings some advanced capabilities of the language server doesn't work at all.