### PR TITLE
[wip] fix koka language server

### DIFF
--- a/lua/lspconfig/server_configurations/koka.lua
+++ b/lua/lspconfig/server_configurations/koka.lua
@@ -1,36 +1,21 @@
 local util = require 'lspconfig.util'
 
-local root_files = {}
-
-local default_capabilities = {
-  textDocument = {
-    completion = {
-      editsNearCursor = true,
-    },
-  },
-  offsetEncoding = { 'utf-8' },
-}
-
 return {
   default_config = {
-    cmd = { 'koka', '--language-server' },
-    filetypes = { 'kk' },
-    root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
-    end,
+    cmd = { 'koka', '--language-server', '--lsstdio' },
+    filetypes = { 'koka' },
     single_file_support = true,
-    capabilities = default_capabilities,
+    root_dir = util.find_git_ancestor,
   },
-  commands = {},
+
   docs = {
     description = [[
     https://koka-lang.github.io/koka/doc/index.html
 Koka is a functional programming language with effect types and handlers.
     ]],
     default_config = {
-      root_dir = [[
-      ]],
-      capabilities = [[default capabilities, with offsetEncoding utf-8]],
+      root_dir = [[git directory]],
+      capabilities = [[default capabilities]],
     },
   },
 }


### PR DESCRIPTION
This is still in draft because I couldn't make the language server attach. 

Currently I have 

```lua
vim.filetype.add({
  extension = {
    kk = "koka",
  },
})
```

in my `init.lua` but that doesn't seem to suffice. 

Help would be greatly appreciated. 