### PR TITLE
fix(hyprls): autostart with hyprland filetype

### DIFF
--- a/lua/lspconfig/server_configurations/hyprls.lua
+++ b/lua/lspconfig/server_configurations/hyprls.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'hyprls', '--stdio' },
-    filetypes = { '*.hl', 'hypr*.conf', '.config/hypr/*.conf' },
+    filetypes = { 'hyprlang', '*.hl', 'hypr*.conf', '.config/hypr/*.conf' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
   },


### PR DESCRIPTION
If the user sets up the `hyprlang` filetype which is also required for the treesitter parser to start should also start the language server