### PR TITLE
docs(shopify_theme_ls): remove unnecessary code snippet

### DIFF
--- a/lua/lspconfig/server_configurations/shopify_theme_ls.lua
+++ b/lua/lspconfig/server_configurations/shopify_theme_ls.lua
@@ -26,10 +26,6 @@ https://shopify.dev/docs/api/shopify-cli
 
 `shopify` can be installed via npm `npm install -g @shopify/cli`.
 
-```lua
-require lspconfig.shopify_theme_ls.setup {}
-```
-
 Note: This LSP already includes Theme Check so you don't need to use the `theme_check` server configuration as well.
 ]],
   },


### PR DESCRIPTION
I didn't notice last time that the code snippet is generated automatically. This removes an unnecessary snippet

<img width="1054" alt="Screenshot 2024-06-27 at 12 48 37 PM" src="https://github.com/neovim/nvim-lspconfig/assets/28267670/30e47f21-0392-4f05-8004-80eb63a1cc0f">
