### PR TITLE
feat: add bazelrc-lsp config

### DIFF
--- a/lua/lspconfig/server_configurations/bazelrc-lsp.lua
+++ b/lua/lspconfig/server_configurations/bazelrc-lsp.lua
@@ -1,0 +1,26 @@
+local util = require 'lspconfig/util'
+
+return {
+  default_config = {
+    cmd = { 'bazelrc-lsp' },
+    filetypes = { 'bazelrc' },
+    root_dir = util.root_pattern('WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel'),
+  },
+  docs = {
+    description = [[
+https://github.com/salesforce-misc/bazelrc-lsp
+
+`bazelrc-lsp` is a LSP for `.bazelrc` configuration files.
+
+The `.bazelrc` file type is not detected automatically, you can register it manually (see below) or override the filetypes:
+
+```lua
+vim.filetype.add {
+  pattern = {
+    ['.*.bazelrc'] = 'bazelrc',
+  },
+}
+```
+]],
+  },
+}


### PR DESCRIPTION
This is the configuration for https://github.com/salesforce-misc/bazelrc-lsp, which supports `.bazelrc` configuration files.