### PR TITLE
fix(tailwindcss): add includeLanguages to config in addition to init opts

### DIFF
--- a/lua/lspconfig/server_configurations/tailwindcss.lua
+++ b/lua/lspconfig/server_configurations/tailwindcss.lua
@@ -87,6 +87,11 @@ return {
           'classList',
           'ngClass',
         },
+        includeLanguages = {
+          eelixir = 'html-eex',
+          eruby = 'erb',
+          templ = 'html',
+        },
       },
     },
     on_new_config = function(new_config)


### PR DESCRIPTION
---
name: Pull Request
about: Submit a pull request
title: 'TailwindCSS: add includeLanguages to config in addition to init opts'
---

fix #3230

I keep the original `init_options.userLanguages`, but it should be safe to remove. If you would like me to remove it, please let me know.
