### PR TITLE
feat!: remove `--preview` flag from Ruff server

### DIFF
--- a/lua/lspconfig/server_configurations/ruff.lua
+++ b/lua/lspconfig/server_configurations/ruff.lua
@@ -8,7 +8,7 @@ local root_files = {
 
 return {
   default_config = {
-    cmd = { 'ruff', 'server', '--preview' },
+    cmd = { 'ruff', 'server' },
     filetypes = { 'python' },
     root_dir = util.root_pattern(unpack(root_files)) or util.find_git_ancestor(),
     single_file_support = true,
@@ -18,22 +18,29 @@ return {
     description = [[
 https://github.com/astral-sh/ruff
 
-A Language Server Protocol implementation for Ruff, an extremely fast Python linter and code formatter, written in Rust. It can be installed via pip.
+A Language Server Protocol implementation for Ruff, an extremely fast Python linter and code formatter, written in Rust. It can be installed via `pip`.
 
 ```sh
 pip install ruff
 ```
 
-_Requires Ruff v0.3.3 or later._
+**Available in Ruff `v0.4.5` in beta and stabilized in Ruff `v0.5.3`.**
 
-This is the new Rust-based version of the original `ruff-lsp` implementation. It's currently in alpha, meaning that some features are under development. Currently, the following capabilities are supported:
+This is the new built-in language server written in Rust. It supports the same feature set as `ruff-lsp`, but with superior performance and no installation required. Note that the `ruff-lsp` server will continue to be maintained until further notice.
 
-1. Diagnostics
-2. Code actions
-3. Formatting
-4. Range Formatting
+Server settings can be provided via:
 
-Please note that the `ruff-lsp` server will continue to be maintained until further notice.
+```lua
+require('lspconfig').ruff.setup({
+  init_options = {
+    settings = {
+      -- Server settings should go here
+    }
+  }
+})
+
+Refer to the [documentation](https://docs.astral.sh/ruff/editors/) for more details.
+```
 
   ]],
     root_dir = [[root_pattern("pyproject.toml", "ruff.toml", ".ruff.toml", ".git")]],


### PR DESCRIPTION
Now that the server is stabilized, the `--preview` flag isn't required to run it from [`v0.5.3`](https://github.com/astral-sh/ruff/releases/tag/0.5.3).

This PR removes the need of the `--preview` flag, update the documentation.

### Question

This is a breaking change because without the `--preview` flag, `ruff` will throw an error for previous versions. It's only from `0.5.3` that the flag isn't required.

Now, the reason the flag needs to be removed is because the flag itself would turn on preview features from both the linter and the formatter, as it should.

Can the maintainers guide me on how to go about making this kind of change? Is this ok to do so?

In our VS Code extension, we check the `ruff` version and only then use the `--preview` flag ([reference](https://github.com/astral-sh/ruff-vscode/blob/2dd2871fda974e4428bc34695dd711c3fb8a08cc/src/common/server.ts#L179-L185)).