### PR TITLE
fix: `lspconfig.Config` class not modifying inherited `root_dir`

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -13,6 +13,7 @@ local configs = {}
 --- @field on_new_config? function
 --- @field autostart? boolean
 --- @field package _on_attach? fun(client: vim.lsp.Client, bufnr: integer)
+--- @field root_dir? string|fun(filename: string, bufnr: number)
 
 --- @param cmd any
 local function sanitize_cmd(cmd)


### PR DESCRIPTION
`lspconfig.Config` inherits from `vim.lsp.ClientConfig`, where the field `root_dir` is typed as string. However, for the `lspconfig.Config`, we are also able [to set a function that returns as string](https://github.com/neovim/nvim-lspconfig/blob/1ea7c6126a1aa0121098e4f16c04d5dde1a4ba22/doc/lspconfig.txt#L71-L80).

If you are trying to use `lspconfig.Config` to make your own config more type-safe, this therefore throws a spurious warning.