### PR TITLE
[rust-analyzer] automatically populate `init_options` from `settings["rust-analyzer"]`

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -10180,6 +10180,9 @@ require'lspconfig'.rust_analyzer.setup{
   }
 }
 ```
+
+Note: do not set `init_options` for this LS config, it will be automatically populated by the contents of settings["rust-analyzer"] per
+https://github.com/rust-lang/rust-analyzer/blob/eb5da56d839ae0a9e9f50774fa3eb78eb0964550/docs/dev/lsp-extensions.md?plain=1#L26.
     
 
 
@@ -10191,6 +10194,10 @@ require'lspconfig'.rust_analyzer.setup{}
 - CargoReload: Reload current cargo workspace
 
 **Default values:**
+  - `before_init` : 
+  ```lua
+  see source file
+  ```
   - `capabilities` : 
   ```lua
   {

--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -10180,6 +10180,9 @@ require'lspconfig'.rust_analyzer.setup{
   }
 }
 ```
+
+Note: do not set `init_options` for this LS config, it will be automatically populated by the contents of settings["rust-analyzer"] per
+https://github.com/rust-lang/rust-analyzer/blob/eb5da56d839ae0a9e9f50774fa3eb78eb0964550/docs/dev/lsp-extensions.md?plain=1#L26.
     
 
 
@@ -10191,6 +10194,10 @@ require'lspconfig'.rust_analyzer.setup{}
 - CargoReload: Reload current cargo workspace
 
 **Default values:**
+  - `before_init` : 
+  ```lua
+  see source file
+  ```
   - `capabilities` : 
   ```lua
   {

--- a/lua/lspconfig/server_configurations/rust_analyzer.lua
+++ b/lua/lspconfig/server_configurations/rust_analyzer.lua
@@ -77,6 +77,12 @@ return {
         serverStatusNotification = true,
       },
     },
+    before_init = function(init_params, config)
+      -- See https://github.com/rust-lang/rust-analyzer/blob/eb5da56d839ae0a9e9f50774fa3eb78eb0964550/docs/dev/lsp-extensions.md?plain=1#L26
+      if config.settings and config.settings['rust-analyzer'] then
+        init_params.initializationOptions = config.settings['rust-analyzer']
+      end
+    end,
   },
   commands = {
     CargoReload = {
@@ -105,6 +111,9 @@ require'lspconfig'.rust_analyzer.setup{
   }
 }
 ```
+
+Note: do not set `init_options` for this LS config, it will be automatically populated by the contents of settings["rust-analyzer"] per
+https://github.com/rust-lang/rust-analyzer/blob/eb5da56d839ae0a9e9f50774fa3eb78eb0964550/docs/dev/lsp-extensions.md?plain=1#L26.
     ]],
     default_config = {
       root_dir = [[root_pattern("Cargo.toml", "rust-project.json")]],


### PR DESCRIPTION
rust-analyzer expects `init_options` to be set to the contents of `settings["rust-analyzer"]` per:
* https://github.com/rust-lang/rust-analyzer/blob/eb5da56d839ae0a9e9f50774fa3eb78eb0964550/docs/dev/lsp-extensions.md?plain=1#L26
* https://github.com/rust-lang/rust-analyzer/blob/eb5da56d839ae0a9e9f50774fa3eb78eb0964550/editors/code/src/ctx.ts#L213

This change ensures the Neovim config for RA complies with the docs, and eliminates a source of confusion around whether to define RA settings in `settings` or `init_options`.