### PR TITLE
docs: remove unnecessary backticks

### DIFF
--- a/lua/lspconfig/server_configurations/ruff.lua
+++ b/lua/lspconfig/server_configurations/ruff.lua
@@ -41,7 +41,6 @@ require('lspconfig').ruff.setup({
 ```
 
 Refer to the [documentation](https://docs.astral.sh/ruff/editors/) for more details.
-```
 
   ]],
     root_dir = [[root_pattern("pyproject.toml", "ruff.toml", ".ruff.toml", ".git")]],


### PR DESCRIPTION
fixup from https://github.com/neovim/nvim-lspconfig/commit/0c2aeaeef35436454689ea3b9596e1d4615ad8d0, sorry I keep messing it up!

This time I've generated the documentation locally and verified that it rendered correctly:

<img width="978" alt="Screenshot 2024-07-25 at 19 25 16" src="https://github.com/user-attachments/assets/19f6a5c1-cba5-436e-9533-cb0892554171">
