### PR TITLE
feat: add ballerina support

### DIFF
--- a/lua/lspconfig/server_configurations/ballerina.lua
+++ b/lua/lspconfig/server_configurations/ballerina.lua
@@ -1,0 +1,17 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'bal', 'start-language-server' },
+    filetypes = { 'ballerina' },
+    root_dir = util.root_pattern 'Ballerina.toml',
+  },
+  docs = {
+    description = [[
+Ballerina language server
+
+The Ballerina language's CLI tool comes with its own language server implementation.
+The `bal` command line tool must be installed and available in your system's PATH.
+]],
+  },
+}


### PR DESCRIPTION
## Feature: Add config for `ballerina` language server

[Ballerina](https://ballerina.io/)'s CLI tool (`bal`) provides a language server.
This PR adds a minimal config for it to nvim-lspconfig.

- [x] `require'lspconfig'.ballerina.setup{}` run locally
- [x] `make lint` run / passed locally
- [x] docgen run locally and output checked (output changes reverted) 