### PR TITLE
fix(texlab): remove deprecated texlab.auxDirectory

### DIFF
--- a/lua/lspconfig/configs/texlab.lua
+++ b/lua/lspconfig/configs/texlab.lua
@@ -167,7 +167,6 @@ return {
           onSave = false,
           forwardSearchAfter = false,
         },
-        auxDirectory = '.',
         forwardSearch = {
           executable = nil,
           args = {},


### PR DESCRIPTION
I noticed this while debugging some texlab problems.

The configuration key 'texlab.auxDirextory' has been deprecated, in favor of 'texlab.build.auxDir', mirroring the latexmkrc's auxDir variable.

see: https://github.com/latex-lsp/texlab/wiki/Configuration#deprecated-texlabauxdirectory