### PR TITLE
draft: feat(texlab): change all print() to vim.notify()

### DIFF
--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -30,7 +30,10 @@ local function buf_build(bufnr)
       vim.notify('Build ' .. texlab_build_status[result.status], vim.log.levels.INFO)
     end, bufnr)
   else
-    vim.notify('method textDocument/build is not supported by any servers active on the current buffer', vim.log.levels.WARN)
+    vim.notify(
+      'method textDocument/build is not supported by any servers active on the current buffer',
+      vim.log.levels.WARN
+    )
   end
 end
 
@@ -50,7 +53,10 @@ local function buf_search(bufnr)
       vim.notify('Search ' .. texlab_forward_status[result.status], vim.log.levels.INFO)
     end, bufnr)
   else
-    vim.notify('method textDocument/forwardSearch is not supported by any servers active on the current buffer', vim.log.levels.WARN)
+    vim.notify(
+      'method textDocument/forwardSearch is not supported by any servers active on the current buffer',
+      vim.log.levels.WARN
+    )
   end
 end
 

--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -27,10 +27,10 @@ local function buf_build(bufnr)
       if err then
         error(tostring(err))
       end
-      print('Build ' .. texlab_build_status[result.status])
+      vim.notify('Build ' .. texlab_build_status[result.status], vim.log.levels.INFO)
     end, bufnr)
   else
-    print 'method textDocument/build is not supported by any servers active on the current buffer'
+    vim.notify('method textDocument/build is not supported by any servers active on the current buffer', vim.log.levels.WARN)
   end
 end
 
@@ -47,10 +47,10 @@ local function buf_search(bufnr)
       if err then
         error(tostring(err))
       end
-      print('Search ' .. texlab_forward_status[result.status])
+      vim.notify('Search ' .. texlab_forward_status[result.status], vim.log.levels.INFO)
     end, bufnr)
   else
-    print 'method textDocument/forwardSearch is not supported by any servers active on the current buffer'
+    vim.notify('method textDocument/forwardSearch is not supported by any servers active on the current buffer', vim.log.levels.WARN)
   end
 end
 


### PR DESCRIPTION
Some texlab-specific functions were using `print`, some were using `vim.notify`. Changed all uses of `print` to `vim.notify` with levels:
- `vim.log.levels.INFO` for `build` and `forwardSeach` LSP methods,
- `vim.log.levels.WARN` when the `texlab` client cannot be found.

We could also switch all `error()` calls to `vim.notify`, but we'd lose the stacktrace printed by it hence I left those calls unmodified.

This PR should be compatible with #3255 but haven't rebased the changes against it :)