### PR TITLE
feat: add daedalus-language-server support

### DIFF
--- a/lua/lspconfig/server_configurations/daedalus_ls.lua
+++ b/lua/lspconfig/server_configurations/daedalus_ls.lua
@@ -1,0 +1,33 @@
+local util = require 'lspconfig.util'
+local bin_name = 'DaedalusLanguageServer'
+
+if vim.fn.has 'win32' == 1 then
+  bin_name = bin_name + '.exe'
+end
+
+local root_files = {
+  'Gothic.src',
+  'Camera.src',
+  'Menu.src',
+  'Music.src',
+  'ParticleFX.src',
+  'SFX.src',
+  'VisualFX.src',
+}
+
+return {
+  default_config = {
+    cmd = { bin_name },
+    filetypes = { 'd' },
+    root_dir = util.root_pattern(unpack(root_files)),
+    settings = {
+      DaedalusLanguageServer = {
+        loglevel = 'debug',
+        inlayHints = { constants = true },
+        numParserThreads = 16,
+        fileEncoding = 'Windows-1252',
+        srcFileEncoding = 'Windows-1252',
+      },
+    },
+  },
+}

--- a/lua/lspconfig/server_configurations/daedalus_ls.lua
+++ b/lua/lspconfig/server_configurations/daedalus_ls.lua
@@ -1,9 +1,4 @@
 local util = require 'lspconfig.util'
-local bin_name = 'DaedalusLanguageServer'
-
-if vim.fn.has 'win32' == 1 then
-  bin_name = bin_name + '.exe'
-end
 
 local root_files = {
   'Gothic.src',
@@ -17,7 +12,7 @@ local root_files = {
 
 return {
   default_config = {
-    cmd = { bin_name },
+    cmd = { 'DaedalusLanguageServer' },
     filetypes = { 'd' },
     root_dir = util.root_pattern(unpack(root_files)),
     settings = {


### PR DESCRIPTION
This PR adds support for https://github.com/kirides/DaedalusLanguageServer used by Gothic and Gothic II games. Please let me know if the `root_dir` was added correctly as I'm not sure if it's equivalent of steps described in README of mentioned repo.
