### PR TITLE
feat(texlab): give the find environments command a ui wrapper

### DIFF
--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -113,15 +113,9 @@ local function buf_find_envs(bufnr)
   if not texlab_client then
     return vim.notify('Texlab client not found', vim.log.levels.ERROR)
   end
-  local pos = vim.api.nvim_win_get_cursor(0)
   texlab_client.request('workspace/executeCommand', {
     command = 'texlab.findEnvironments',
-    arguments = {
-      {
-        textDocument = { uri = vim.uri_from_bufnr(bufnr) },
-        position = { line = pos[1] - 1, character = pos[2] },
-      },
-    },
+    arguments = { vim.lsp.util.make_position_params() },
   }, function(err, result)
     if err then
       return vim.notify(err.code .. ': ' .. err.message, vim.log.levels.ERROR)

--- a/lua/lspconfig/server_configurations/texlab.lua
+++ b/lua/lspconfig/server_configurations/texlab.lua
@@ -126,7 +126,23 @@ local function buf_find_envs(bufnr)
     if err then
       return vim.notify(err.code .. ': ' .. err.message, vim.log.levels.ERROR)
     end
-    return vim.notify('The environments are:\n' .. vim.inspect(result), vim.log.levels.INFO)
+    local env_names = {}
+    local max_length = 1
+    for _, env in ipairs(result) do
+      table.insert(env_names, env.name.text)
+      max_length = math.max(max_length, string.len(env.name.text))
+    end
+    for i, name in ipairs(env_names) do
+      env_names[i] = string.rep(' ', i - 1) .. name
+    end
+    vim.lsp.util.open_floating_preview(env_names, '', {
+      height = #env_names,
+      width = math.max((max_length + #env_names - 1), (string.len 'Environments')),
+      focusable = false,
+      focus = false,
+      border = require('lspconfig.ui.windows').default_options.border or 'single',
+      title = 'Environments',
+    })
   end, bufnr)
 end
 


### PR DESCRIPTION
This PR tries to improve #3225 by filtering the output and presenting it with `vim.lsp.util.open_floating_preview`. It is a pretty simple implementation that leverages builtin lua functions and basic API, therefore it should not be a burden to maintain. I have tested it locally without any major problems and i will keep testing, while making sure no issues pop up in this repo regarding this feature. I am really sure if the way the border style is setup is fitting. 
Here are some images:
![2024-08-08-16:46:06](https://github.com/user-attachments/assets/efc3e405-36f4-406d-8621-e812ad8895ec)
![2024-08-08-16:27:44](https://github.com/user-attachments/assets/cee627de-6aea-4e66-9f06-1fe3b428c45c)
I am totally open to any suggestions :)