### PR TITLE
fix(mesonlsp): update root directory pattern

### DIFF
--- a/lua/lspconfig/server_configurations/mesonlsp.lua
+++ b/lua/lspconfig/server_configurations/mesonlsp.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'mesonlsp', '--lsp' },
     filetypes = { 'meson' },
-    root_dir = util.root_pattern('meson_options.txt', 'meson.options', '.git'),
+    root_dir = util.root_pattern('meson.build', 'meson_options.txt', 'meson.options', '.git'),
   },
   docs = {
     description = [[
@@ -13,7 +13,7 @@ https://github.com/JCWasmx86/mesonlsp
 An unofficial, unendorsed language server for meson written in C++
 ]],
     default_config = {
-      root_dir = [[util.root_pattern("meson_options.txt", "meson.options", ".git")]],
+      root_dir = [[util.root_pattern("meson.build", "meson_options.txt", "meson.options", ".git")]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/swift_mesonls.lua
+++ b/lua/lspconfig/server_configurations/swift_mesonls.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'Swift-MesonLSP', '--lsp' },
     filetypes = { 'meson' },
-    root_dir = util.root_pattern('meson_options.txt', 'meson.options', '.git'),
+    root_dir = util.root_pattern('meson.build', 'meson_options.txt', 'meson.options', '.git'),
   },
   docs = {
     description = [[
@@ -13,7 +13,7 @@ https://github.com/JCWasmx86/Swift-MesonLSP
 Meson language server written in Swift
 ]],
     default_config = {
-      root_dir = [[util.root_pattern("meson_options.txt", "meson.options", ".git")]],
+      root_dir = [[util.root_pattern("meson.build", "meson_options.txt", "meson.options", ".git")]],
     },
   },
 }


### PR DESCRIPTION
This PR adds a pattern for the meson.build files in the `root_pattern` functions of the `default_config` and `doc` tables for the `mesonlsp` and `swift_mesonls` servers.

meson.build files are the primary configuration files for the Meson build system and lspconfig should look for these files to determine the root of a project that uses Meson.