### PR TITLE
fix(taplo): simplify root detection

### DIFF
--- a/lua/lspconfig/server_configurations/taplo.lua
+++ b/lua/lspconfig/server_configurations/taplo.lua
@@ -4,9 +4,7 @@ return {
   default_config = {
     cmd = { 'taplo', 'lsp', 'stdio' },
     filetypes = { 'toml' },
-    root_dir = function(fname)
-      return util.root_pattern '*.toml'(fname) or util.find_git_ancestor(fname)
-    end,
+    root_dir = util.find_git_ancestor,
     single_file_support = true,
   },
   docs = {


### PR DESCRIPTION
The taplo language server has a bit of a strict root directory detection. It seems like it was that way because it previously didn't have single file mode enabled. Now that single file mode is enabled we don't need to have it set a project root immediately in the folder. This aligns it more with how `jsonls` and `yamlls` root detection work.