### PR TITLE
feat(htmx): add more filetypes

### DIFF
--- a/lua/lspconfig/server_configurations/htmx.lua
+++ b/lua/lspconfig/server_configurations/htmx.lua
@@ -3,7 +3,54 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'htmx-lsp' },
-    filetypes = { 'html', 'templ' },
+    filetypes = { -- filetypes copied and adjusted from tailwindcss-intellisense
+      -- html
+      'aspnetcorerazor',
+      'astro',
+      'astro-markdown',
+      'blade',
+      'clojure',
+      'django-html',
+      'htmldjango',
+      'edge',
+      'eelixir', -- vim ft
+      'elixir',
+      'ejs',
+      'erb',
+      'eruby', -- vim ft
+      'gohtml',
+      'gohtmltmpl',
+      'haml',
+      'handlebars',
+      'hbs',
+      'html',
+      'htmlangular',
+      'html-eex',
+      'heex',
+      'jade',
+      'leaf',
+      'liquid',
+      'markdown',
+      'mdx',
+      'mustache',
+      'njk',
+      'nunjucks',
+      'php',
+      'razor',
+      'slim',
+      'twig',
+      -- js
+      'javascript',
+      'javascriptreact',
+      'reason',
+      'rescript',
+      'typescript',
+      'typescriptreact',
+      -- mixed
+      'vue',
+      'svelte',
+      'templ',
+    },
     single_file_support = true,
     root_dir = function(fname)
       return util.find_git_ancestor(fname)


### PR DESCRIPTION
HTMX can be used pretty much anywhere where there are HTML tags, so I thought I'd copy the filetypes we have for tailwind CSS (minus the CSS only file types)

That should get good coverage for most templating languages that will use it.