### PR TITLE
Revert "feat: ruby_lsp works inside eruby files (#3266)"

### DIFF
--- a/lua/lspconfig/server_configurations/ruby_lsp.lua
+++ b/lua/lspconfig/server_configurations/ruby_lsp.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'ruby-lsp' },
-    filetypes = { 'ruby', 'eruby' },
+    filetypes = { 'ruby' },
     root_dir = util.root_pattern('Gemfile', '.git'),
     init_options = {
       formatter = 'auto',


### PR DESCRIPTION
This reverts commit 4cd29ab1b326f5b04f4b982fae05934ac64c779b.

It looks like missing support for DiagnosticRegistrationOptions  (https://github.com/neovim/neovim/issues/24412) is causing issues in some cases with eruby files. It seems best case to revert this change for now.

https://github.com/Shopify/ruby-lsp/pull/2432