### PR TITLE
test(ci): change to luajit-openresty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: luajit
         uses: leafo/gh-actions-lua@v10
         with:
-          luaVersion: "luajit-2.1.0-beta3"
+          luaVersion: "luajit-openresty"
 
       - name: luarocks
         uses: leafo/gh-actions-luarocks@v4


### PR DESCRIPTION
Problem: LuaJIT.org has stopped publishing release tarballs on their website.

Solution: use luajit-openresty instead of.