### PR TITLE
fix: remove invalid filetypes containing wildcards from `typos_lsp` and `hyprls`

### DIFF
--- a/lua/lspconfig/server_configurations/hyprls.lua
+++ b/lua/lspconfig/server_configurations/hyprls.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'hyprls', '--stdio' },
-    filetypes = { 'hyprlang', '*.hl', 'hypr*.conf', '.config/hypr/*.conf' },
+    filetypes = { 'hyprlang' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
   },

--- a/lua/lspconfig/server_configurations/typos_lsp.lua
+++ b/lua/lspconfig/server_configurations/typos_lsp.lua
@@ -3,7 +3,6 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'typos-lsp' },
-    filetypes = { '*' },
     root_dir = util.root_pattern('typos.toml', '_typos.toml', '.typos.toml'),
     single_file_support = true,
     settings = {},


### PR DESCRIPTION
I happened to have created a mapping of filetypes and every server in lspconfig. While inspecting them, I noticed some anomalies and found out that they were invalid/unnecessary misconfigurations that were added by accident.

This PR removes those anomalies.

### typos_lsp

```lua
filetypes = { '*' },
```

`*` filetype pattern is unnecessary. If the `filetypes` field is omitted completely, lspconfig starts the server on `BufReadPost` instead of `FileType`.

### hyprls

```lua
filetypes = { 'hyprlang', '*.hl', 'hypr*.conf', '.config/hypr/*.conf' },
```

The author of hyprls and the original PR to lspconfig confirmed that the filetypes with wildcards were added by mistake.

https://github.com/hyprland-community/hyprls/issues/11#issuecomment-2189841216
> Hi! I actually did a PR for lspconfig to include hyprls (see [neovim/nvim-lspconfig#3137](https://github.com/neovim/nvim-lspconfig/pull/3137)) but it's misconfigured: **I mistook filetypes for file name patterns...**
> 
> However [someone fixed my mistake lmao, thx @mehalter](https://github.com/neovim/nvim-lspconfig/pull/3137)
> 
> So the lspconfig should work if the hyprlang filetype is defined

Technically, they can stay in the code, useless but doing no harm.
But I wrote this PR because why not and also it actually hinder the plugin I'm writing.