### PR TITLE
feat(clangd): add symbolInfo support

### DIFF
--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -24,7 +24,7 @@ end
 local function symbol_info()
   local bufnr = vim.api.nvim_get_current_buf()
   local clangd_client = util.get_active_client_by_name(bufnr, 'clangd')
-  if not clangd_client then
+  if not clangd_client or not clangd_client.supports_method 'textDocument/symbolInfo' then
     return vim.notify('Clangd client not found', vim.log.levels.ERROR)
   end
   local params = vim.lsp.util.make_position_params()

--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -27,11 +27,8 @@ local function symbol_info(bufnr)
   if not clangd_client then
     return vim.notify('Clangd client not found', vim.log.levels.ERROR)
   end
-  local pos = vim.api.nvim_win_get_cursor(0)
-  vim.lsp.buf_request(0, 'textDocument/symbolInfo', {
-    textDocument = { uri = vim.uri_from_bufnr(0) },
-    position = { line = pos[1] - 1, character = pos[2] },
-  }, function(err, res)
+  local params = vim.lsp.util.make_position_params()
+  vim.lsp.buf_request(0, 'textDocument/symbolInfo', params, function(err, res)
     if err or #res == 0 then
       -- Clangd always returns an error, there is not reason to parse it
       return

--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -83,7 +83,7 @@ return {
     },
     ClangdShowSymbolInfo = {
       function()
-        symbol_info(0)
+        symbol_info()
       end,
       description = 'Show symbol info',
     },

--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -21,8 +21,8 @@ local function switch_source_header(bufnr)
   end
 end
 
-local function symbol_info(bufnr)
-  bufnr = util.validate_bufnr(bufnr)
+local function symbol_info()
+  local bufnr = vim.api.nvim_get_current_buf()
   local clangd_client = util.get_active_client_by_name(bufnr, 'clangd')
   if not clangd_client then
     return vim.notify('Clangd client not found', vim.log.levels.ERROR)

--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -28,7 +28,7 @@ local function symbol_info()
     return vim.notify('Clangd client not found', vim.log.levels.ERROR)
   end
   local params = vim.lsp.util.make_position_params()
-  vim.lsp.buf_request(0, 'textDocument/symbolInfo', params, function(err, res)
+  clangd_client.request('textDocument/symbolInfo', params, function(err, res)
     if err or #res == 0 then
       -- Clangd always returns an error, there is not reason to parse it
       return
@@ -43,7 +43,7 @@ local function symbol_info()
       border = require('lspconfig.ui.windows').default_options.border or 'single',
       title = 'Symbol Info',
     })
-  end)
+  end, bufnr)
 end
 
 local root_files = {

--- a/lua/lspconfig/server_configurations/clangd.lua
+++ b/lua/lspconfig/server_configurations/clangd.lua
@@ -21,6 +21,34 @@ local function switch_source_header(bufnr)
   end
 end
 
+local function symbol_info(bufnr)
+  bufnr = util.validate_bufnr(bufnr)
+  local clangd_client = util.get_active_client_by_name(bufnr, 'clangd')
+  if not clangd_client then
+    return vim.notify('Clangd client not found', vim.log.levels.ERROR)
+  end
+  local pos = vim.api.nvim_win_get_cursor(0)
+  vim.lsp.buf_request(0, 'textDocument/symbolInfo', {
+    textDocument = { uri = vim.uri_from_bufnr(0) },
+    position = { line = pos[1] - 1, character = pos[2] },
+  }, function(err, res)
+    if err or #res == 0 then
+      -- Clangd always returns an error, there is not reason to parse it
+      return
+    end
+    local container = string.format('container: %s', res[1].containerName) ---@type string
+    local name = string.format('name: %s', res[1].name) ---@type string
+    vim.lsp.util.open_floating_preview({ name, container }, '', {
+      height = 2,
+      width = math.max(string.len(name), string.len(container)),
+      focusable = false,
+      focus = false,
+      border = require('lspconfig.ui.windows').default_options.border or 'single',
+      title = 'Symbol Info',
+    })
+  end)
+end
+
 local root_files = {
   '.clangd',
   '.clang-tidy',
@@ -55,6 +83,12 @@ return {
         switch_source_header(0)
       end,
       description = 'Switch between source/header',
+    },
+    ClangdShowSymbolInfo = {
+      function()
+        symbol_info(0)
+      end,
+      description = 'Show symbol info',
     },
   },
   docs = {


### PR DESCRIPTION
This PR adds support for the symbolInfo capability of clangd, for more documentation [see](https://clangd.llvm.org/extensions.html#symbol-info-request). It follows the same principle as #3263, although simpler. I think this is a great and simple addition, which will not add a ton of maintenance burden. Here are some images that showcase, what it does:
 
![2024-08-20-22:03:49](https://github.com/user-attachments/assets/73503612-6679-4d30-8ba7-1885df400954)
![2024-08-20-22:03:35](https://github.com/user-attachments/assets/69cf35cf-776d-462a-b9e5-6d2fa5fb0ec7)

Thanks for your awesome work! :)