### PR TITLE
fix(als): deprecate als in favour of a separate plugin

### DIFF
--- a/lua/lspconfig/server_configurations/als.lua
+++ b/lua/lspconfig/server_configurations/als.lua
@@ -10,6 +10,10 @@ return {
     cmd = { bin_name },
     filetypes = { 'ada' },
     root_dir = util.root_pattern('Makefile', '.git', '*.gpr', '*.adc'),
+    deprecate = {
+      to = 'github.com/TamaMcGlinn/nvim-lspconfig-ada',
+      version = '0.2.0',
+    },
   },
   docs = {
     description = [[


### PR DESCRIPTION
To move towards the goal of having lsp configs decentralised and lower the maintenance burden on current maintainers, as requested by @glepnir, @mjlbach and @justinmk

See https://github.com/neovim/nvim-lspconfig/pull/1693 and https://github.com/neovim/nvim-lspconfig/issues/1683 and https://github.com/neovim/nvim-lspconfig/pull/3275#issuecomment-2301318994