### PR TITLE
fix(r-language-server): Use `--no-echo` instead of `--slave`

### DIFF
--- a/lua/lspconfig/server_configurations/r_language_server.lua
+++ b/lua/lspconfig/server_configurations/r_language_server.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 return {
   default_config = {
-    cmd = { 'R', '--slave', '-e', 'languageserver::run()' },
+    cmd = { 'R', '--no-echo', '-e', 'languageserver::run()' },
     filetypes = { 'r', 'rmd' },
     root_dir = function(fname)
       return util.find_git_ancestor(fname) or vim.loop.os_homedir()


### PR DESCRIPTION
Many thanks for your efforts maintaining neovim and the language server configurations.

Starting from R version 4.0.0, the command line option `--slave` were renamed to `--no-echo`.

See the relevant news for 4.0.0:
https://cran.r-project.org/bin/windows/base/old/4.0.0/NEWS.R-4.0.0.html and the corresponding commit:
https://github.com/wch/r-source/commit/f1ff49e74593341c74c20de9517f31a22c8bcb04#diff-4747789d759ae72b19c9791301bf52e8cfc5c23dbdda10bf1a6bd003509395dd