### PR TITLE
feat: improve default haxe_language_server init_options

### DIFF
--- a/lua/lspconfig/server_configurations/haxe_language_server.lua
+++ b/lua/lspconfig/server_configurations/haxe_language_server.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'haxe-language-server' },
     filetypes = { 'haxe' },
-    root_dir = util.root_pattern '*.hxml',
+    root_dir = util.root_pattern('*.hxml', '.git'),
     settings = {
       haxe = {
         executable = 'haxe',
@@ -41,7 +41,7 @@ your project's root directory. If your file is named something different,
 specify it using the `init_options.displayArguments` setting.
 ]],
     default_config = {
-      root_dir = [[root_pattern("*.hxml")]],
+      root_dir = [[root_pattern("*.hxml", ".git")]],
     },
   },
 }

--- a/lua/lspconfig/server_configurations/haxe_language_server.lua
+++ b/lua/lspconfig/server_configurations/haxe_language_server.lua
@@ -1,5 +1,11 @@
 local util = require 'lspconfig.util'
 
+local function find_hxml(path)
+  return vim.fs.find(function(name)
+    return name:match '.hxml$'
+  end, { path = path, type = 'file' })
+end
+
 return {
   default_config = {
     cmd = { 'haxe-language-server' },
@@ -10,9 +16,18 @@ return {
         executable = 'haxe',
       },
     },
-    init_options = {
-      displayArguments = { 'build.hxml' },
-    },
+    init_options = {},
+    on_new_config = function(new_config, new_root_dir)
+      if new_config.init_options.displayArguments then
+        return
+      end
+
+      local hxml = find_hxml(new_root_dir)[1]
+      if hxml then
+        vim.notify('Using HXML: ' .. hxml)
+        new_config.init_options.displayArguments = { hxml }
+      end
+    end,
   },
   docs = {
     description = [[
@@ -36,12 +51,24 @@ lspconfig.haxe_language_server.setup({
 })
 ```
 
-By default, an HXML compiler arguments file named `build.hxml` is expected in
-your project's root directory. If your file is named something different,
-specify it using the `init_options.displayArguments` setting.
+By default, the language server is configured with the HXML compiler arguments
+contained in the first `.hxml` file found in your project's root directory.
+If you want to specify which one to use, set the `init_options.displayArguments`
+setting:
+
+```lua
+lspconfig.haxe_language_server.setup({
+  -- ...
+  init_options = {
+    displayArguments = { "build.hxml" },
+  },
+})
+```
+
 ]],
     default_config = {
       root_dir = [[root_pattern("*.hxml", ".git")]],
+      init_options = 'default value is set by on_new_config',
     },
   },
 }


### PR DESCRIPTION
Adds `.git` as a root directory pattern.

Previously, it would detect the root dir by matching with "*.hxml", however, it
would use "build.hxml" as the default `displayArguments` even though it may not
exist. This could cause the error:

```
haxe_language_server: -32603: Error: Could not process argument build.hxml (file not found)
Invalid character:
```

Now it will use the first ".hxml" file that is found in the project. It will
only do this if no `displayArguments` value has been set in the `setup()` call,
so it will still respect user set values.

If no hxml file is found, then it uses empty `displayArguments`, which is still
better than a broken configuration.