### PR TITLE
Add missing close paren

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -13781,7 +13781,7 @@ require'lspconfig'.wgsl_analyzer.setup{}
   ```
   - `root_dir` : 
   ```lua
-  root_pattern(".git"
+  root_pattern(".git")
   ```
   - `settings` : 
   ```lua


### PR DESCRIPTION
This fixes a typo, where a close parenthesis is missing.