### PR TITLE
fix(v-analyzer): change repository location to vlang org

### DIFF
--- a/doc/server_configurations.md
+++ b/doc/server_configurations.md
@@ -13033,11 +13033,11 @@ require'lspconfig'.uvls.setup{}
 
 ## v_analyzer
 
-https://github.com/v-analyzer/v-analyzer
+https://github.com/vlang/v-analyzer
 
 V language server.
 
-`v-analyzer` can be installed by following the instructions [here](https://github.com/v-analyzer/v-analyzer#installation).
+`v-analyzer` can be installed by following the instructions [here](https://github.com/vlang/v-analyzer#installation).
 
 
 

--- a/doc/server_configurations.txt
+++ b/doc/server_configurations.txt
@@ -13033,11 +13033,11 @@ require'lspconfig'.uvls.setup{}
 
 ## v_analyzer
 
-https://github.com/v-analyzer/v-analyzer
+https://github.com/vlang/v-analyzer
 
 V language server.
 
-`v-analyzer` can be installed by following the instructions [here](https://github.com/v-analyzer/v-analyzer#installation).
+`v-analyzer` can be installed by following the instructions [here](https://github.com/vlang/v-analyzer#installation).
 
 
 

--- a/lua/lspconfig/server_configurations/v_analyzer.lua
+++ b/lua/lspconfig/server_configurations/v_analyzer.lua
@@ -8,11 +8,11 @@ return {
   },
   docs = {
     description = [[
-https://github.com/v-analyzer/v-analyzer
+https://github.com/vlang/v-analyzer
 
 V language server.
 
-`v-analyzer` can be installed by following the instructions [here](https://github.com/v-analyzer/v-analyzer#installation).
+`v-analyzer` can be installed by following the instructions [here](https://github.com/vlang/v-analyzer#installation).
 ]],
     default_config = {
       root_dir = [[root_pattern("v.mod", ".git")]],


### PR DESCRIPTION
v-analyzer repository is currently located in the vlang organization.