### PR TITLE
fix: sourcekit lsp filetypes

### DIFF
--- a/lua/lspconfig/server_configurations/sourcekit.lua
+++ b/lua/lspconfig/server_configurations/sourcekit.lua
@@ -3,13 +3,22 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'sourcekit-lsp' },
-    filetypes = { 'swift', 'c', 'cpp', 'objective-c', 'objective-cpp' },
+    filetypes = { 'swift', 'objc', 'objcpp', 'c', 'cpp' },
     root_dir = function(filename, _)
       return util.root_pattern 'buildServer.json'(filename)
         or util.root_pattern('*.xcodeproj', '*.xcworkspace')(filename)
         -- better to keep it at the end, because some modularized apps contain multiple Package.swift files
         or util.root_pattern('compile_commands.json', 'Package.swift')(filename)
         or util.find_git_ancestor(filename)
+    end,
+    get_language_id = function(_, ftype)
+      if ftype == "objc" then
+        return "objective-c"
+      end
+      if ftype == "objcpp" then
+        return "objective-cpp"
+      end
+      return ftype
     end,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/sourcekit.lua
+++ b/lua/lspconfig/server_configurations/sourcekit.lua
@@ -12,11 +12,11 @@ return {
         or util.find_git_ancestor(filename)
     end,
     get_language_id = function(_, ftype)
-      if ftype == "objc" then
-        return "objective-c"
+      if ftype == 'objc' then
+        return 'objective-c'
       end
-      if ftype == "objcpp" then
-        return "objective-cpp"
+      if ftype == 'objcpp' then
+        return 'objective-cpp'
       end
       return ftype
     end,

--- a/lua/lspconfig/server_configurations/sourcekit.lua
+++ b/lua/lspconfig/server_configurations/sourcekit.lua
@@ -12,8 +12,8 @@ return {
         or util.find_git_ancestor(filename)
     end,
     get_language_id = function(_, ftype)
-    local t = { objc = 'objective-c', objcpp = 'objective-cpp' }
-    return t[ftype] or ftype
+      local t = { objc = 'objective-c', objcpp = 'objective-cpp' }
+      return t[ftype] or ftype
     end,
   },
   docs = {

--- a/lua/lspconfig/server_configurations/sourcekit.lua
+++ b/lua/lspconfig/server_configurations/sourcekit.lua
@@ -12,13 +12,8 @@ return {
         or util.find_git_ancestor(filename)
     end,
     get_language_id = function(_, ftype)
-      if ftype == 'objc' then
-        return 'objective-c'
-      end
-      if ftype == 'objcpp' then
-        return 'objective-cpp'
-      end
-      return ftype
+    local t = { objc = 'objective-c', objcpp = 'objective-cpp' }
+    return t[ftype] or ftype
     end,
   },
   docs = {


### PR DESCRIPTION
Sourcekit LSP was not being attached on objc and objc++ files