### PR TITLE
feat: allow conditional attachment of LSP servers

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -122,6 +122,14 @@ listed in `:help vim.lsp.start_client()` with the following unique entries:
     should likely be included in your new override. Some configurations
     use `on_new_config` to dynamically set or modify `cmd`.
 
+- {should_attach}
+
+    `function(filename, bufnr)` (default: function that returns true)
+
+    Called before the language server is attached to a buffer. If it evaluates
+    to false, the language server will not be attached. Useful for
+    conditionally enabling an LSP based on the current project.
+
 Note: all entries passed to `setup {}` override the entry in the default
 configuration. There is no composition.
 

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -14,6 +14,7 @@ local configs = {}
 --- @field autostart? boolean
 --- @field package _on_attach? fun(client: vim.lsp.Client, bufnr: integer)
 --- @field root_dir? string|fun(filename: string, bufnr: number)
+--- @field should_attach? fun(filename: string, bufnr: integer)
 
 --- @param cmd any
 local function sanitize_cmd(cmd)

--- a/lua/lspconfig/manager.lua
+++ b/lua/lspconfig/manager.lua
@@ -249,6 +249,10 @@ function M:try_add(bufnr, project_root)
   end
 
   local bufname = api.nvim_buf_get_name(bufnr)
+  if not self.config.should_attach(bufname, bufnr) then
+    return
+  end
+
   if #bufname == 0 and not self.config.single_file_support then
     return
   end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -17,6 +17,9 @@ M.default_config = {
   handlers = {},
   autostart = true,
   capabilities = lsp.protocol.make_client_capabilities(),
+  should_attach = function(_, _)
+    return true
+  end,
 }
 
 -- global on_setup hook


### PR DESCRIPTION
This PR adds the ability for users to conditionally attach an LSP server to a buffer based on a user provided function that will be evaluated. This functionality is useful for disabling an LSP server for a particular project, or for files in a particular subdirectory. Currently there is no good way of doing this.

With this addition, disabling an LSP for a given project is easy:
```lua
server.should_attach = function()
  return not vim.g.disable_lsp
end
```

Then in the project's `.exrc` file the following can be added:
```vim
let g:disable_lsp = v:true
```

Related issues:
- https://github.com/neovim/nvim-lspconfig/issues/2477
- https://github.com/neovim/nvim-lspconfig/issues/2437
- https://github.com/neovim/nvim-lspconfig/issues/867