### PR TITLE
feat: show deprecate servers list in LspInfo

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -461,7 +461,8 @@ COMMANDS                                                    *lspconfig-commands*
 
 - `:LspInfo` shows the status of active and configured language servers. Note
   that client id refers to the Nvim RPC instance connected to a given
-  language server.
+  language server. Also shows a list of deprecated servers that have been
+  configured.
 
 The following commands support tab-completion for all arguments. All commands
 that require a client id can either leverage tab-completion or the info

--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -34,18 +34,18 @@ local aliases = {
 }
 
 ---@return Alias
----@param name Get this alias, or nil to get all aliases that were used in the current session.
+---@param name string|nil get this alias, or nil to get all aliases that were used in the current session.
 M.server_aliases = function(name)
   if name then
     return aliases[name]
   end
   local used_aliases = {}
-  for name, alias in pairs(aliases) do
-    if deprecated.inconfig then
-      result[server_name] = deprecated
+  for sname, alias in pairs(aliases) do
+    if alias.inconfig then
+      used_aliases[sname] = alias
     end
   end
-  return result
+  return used_aliases
 end
 
 local mt = {}

--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -39,8 +39,8 @@ M.server_aliases = function(name)
   if name then
     return aliases[name]
   end
-  local result = {}
-  for server_name, deprecated in pairs(aliases) do
+  local used_aliases = {}
+  for name, alias in pairs(aliases) do
     if deprecated.inconfig then
       result[server_name] = deprecated
     end

--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -7,41 +7,51 @@ local M = {
 ---@class Alias
 ---@field to string The new name of the server
 ---@field version string The version that the alias will be removed in
----@param name string
----@return Alias
-local function server_alias(name)
-  local aliases = {
-    ['fennel-ls'] = {
-      to = 'fennel_ls',
-      version = '0.2.0',
-    },
-    ruby_ls = {
-      to = 'ruby_lsp',
-      version = '0.2.0',
-    },
-    ['starlark-rust'] = {
-      to = 'starlark_rust',
-      version = '0.2.0',
-    },
-    sumneko_lua = {
-      to = 'lua_ls',
-      version = '0.2.0',
-    },
-    tsserver = {
-      to = 'ts_ls',
-      version = '0.2.0',
-    },
-  }
+---@field inconfig? boolean need shown in lspinfo
+local aliases = {
+  ['fennel-ls'] = {
+    to = 'fennel_ls',
+    version = '0.2.1',
+  },
+  ruby_ls = {
+    to = 'ruby_lsp',
+    version = '0.2.1',
+  },
+  ['starlark-rust'] = {
+    to = 'starlark_rust',
+    version = '0.2.1',
+  },
+  sumneko_lua = {
+    to = 'lua_ls',
+    version = '0.2.1',
+  },
+  tsserver = {
+    to = 'ts_ls',
+    version = '0.2.1',
+  },
+}
 
-  return aliases[name]
+---@return Alias
+M.server_aliases = function(name)
+  if name then
+    return aliases[name]
+  end
+  local result = {}
+  for server_name, deprecated in pairs(aliases) do
+    if deprecated.inconfig then
+      result[server_name] = deprecated
+    end
+  end
+  return result
 end
 
 local mt = {}
 function mt:__index(k)
   if configs[k] == nil then
-    local alias = server_alias(k)
+    local alias = M.server_aliases(k)
     if alias then
       vim.deprecate(k, alias.to, alias.version, 'lspconfig', false)
+      alias.inconfig = true
       k = alias.to
     end
 

--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -32,6 +32,7 @@ local aliases = {
 }
 
 ---@return Alias
+---@param name Get this alias, or nil to get all aliases that were used in the current session.
 M.server_aliases = function(name)
   if name then
     return aliases[name]

--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -4,6 +4,8 @@ local M = {
   util = require 'lspconfig.util',
 }
 
+--- Deprecated config names.
+---
 ---@class Alias
 ---@field to string The new name of the server
 ---@field version string The version that the alias will be removed in

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -268,8 +268,14 @@ return function()
     '',
     'Configured servers list: ' .. table.concat(util.available_servers(), ', '),
   }
-
+  local deprecated_servers = {}
   vim.list_extend(buf_lines, matching_config_header)
+  for server_name, deprecate in pairs(require('lspconfig').server_aliases()) do
+    table.insert(deprecated_servers, ('%s -> %s'):format(server_name, deprecate.to))
+  end
+  if #deprecated_servers > 0 then
+    vim.list_extend(buf_lines, { '', 'Deprecated servers: ' .. table.concat(deprecated_servers, ' ') })
+  end
 
   local fmt_buf_lines = indent_lines(buf_lines, ' ')
 


### PR DESCRIPTION
In order to smoothly transition to the vim.lsp.start interface in the future, adding checkhealth here is meaningless(because we already have checkhealth of lsp).  So shown deprecate servers list in LspInfo and update the server deprecate remove version to 0.2.1. 0.2.0 is tagged too quickly cause some servers not removed.


![QQ_1726571465599](https://github.com/user-attachments/assets/d2114e66-e049-4dd8-b79b-c06ecec96709)


cc @tskj 