### PR TITLE
fix: add C3 library support

### DIFF
--- a/lua/lspconfig/server_configurations/c3_lsp.lua
+++ b/lua/lspconfig/server_configurations/c3_lsp.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'c3lsp' },
     root_dir = function(fname)
       --look for a project directory
-      local path = util.root_pattern {"project.json"}(fname);
+      local path = util.root_pattern {'project.json', 'manifest.json'}(fname);
       if path ~= nil then
         return path;
       end

--- a/lua/lspconfig/server_configurations/c3_lsp.lua
+++ b/lua/lspconfig/server_configurations/c3_lsp.lua
@@ -4,7 +4,21 @@ return {
   default_config = {
     cmd = { 'c3lsp' },
     root_dir = function(fname)
-      return util.root_pattern { 'project.json', '.git' }(fname)
+      --look for a project directory
+      local path = util.root_pattern {"project.json"}(fname);
+      if path ~= nil then
+        return path;
+      end
+
+      --look for a library directory
+      path = util.root_pattern {"manifest.json"}(fname);
+      if path ~= nil then
+        return path;
+      end
+
+      --look for .git directory
+      return util.find_git_ancestors(fname);
+
     end,
     filetypes = { 'c3', 'c3i' },
   },
@@ -13,9 +27,6 @@ return {
 https://github.com/pherrymason/c3-lsp
 
 Language Server for c3.
-    ]],
-    default_config = {
-      root_dir = [[root_pattern("project.json", ".git")]],
-    },
+]],
   },
 }

--- a/lua/lspconfig/server_configurations/c3_lsp.lua
+++ b/lua/lspconfig/server_configurations/c3_lsp.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'c3lsp' },
     root_dir = function(fname)
       --look for a project directory
-      local path = util.root_pattern {'project.json', 'manifest.json'}(fname);
+      local path = util.root_pattern { 'project.json', 'manifest.json' }(fname);
       if path ~= nil then
         return path;
       end

--- a/lua/lspconfig/server_configurations/c3_lsp.lua
+++ b/lua/lspconfig/server_configurations/c3_lsp.lua
@@ -5,13 +5,13 @@ return {
     cmd = { 'c3lsp' },
     root_dir = function(fname)
       --look for a project directory
-      local path = util.root_pattern { 'project.json', 'manifest.json' }(fname);
+      local path = util.root_pattern { 'project.json', 'manifest.json' }(fname)
       if path ~= nil then
-        return path;
+        return path
       end
 
       --look for .git directory
-      return util.find_git_ancestors(fname);
+      return util.find_git_ancestors(fname)
 
     end,
     filetypes = { 'c3', 'c3i' },

--- a/lua/lspconfig/server_configurations/c3_lsp.lua
+++ b/lua/lspconfig/server_configurations/c3_lsp.lua
@@ -12,7 +12,6 @@ return {
 
       --look for .git directory
       return util.find_git_ancestors(fname)
-
     end,
     filetypes = { 'c3', 'c3i' },
   },

--- a/lua/lspconfig/server_configurations/c3_lsp.lua
+++ b/lua/lspconfig/server_configurations/c3_lsp.lua
@@ -9,7 +9,7 @@ return {
       if path ~= nil then
         return path;
       end
-      
+
       --look for .git directory
       return util.find_git_ancestors(fname);
 

--- a/lua/lspconfig/server_configurations/c3_lsp.lua
+++ b/lua/lspconfig/server_configurations/c3_lsp.lua
@@ -4,14 +4,7 @@ return {
   default_config = {
     cmd = { 'c3lsp' },
     root_dir = function(fname)
-      --look for a project directory
-      local path = util.root_pattern { 'project.json', 'manifest.json' }(fname)
-      if path ~= nil then
-        return path
-      end
-
-      --look for .git directory
-      return util.find_git_ancestors(fname)
+      return util.root_patttern { 'project.json', 'manifest.json', '.git' }(fname)
     end,
     filetypes = { 'c3', 'c3i' },
   },

--- a/lua/lspconfig/server_configurations/c3_lsp.lua
+++ b/lua/lspconfig/server_configurations/c3_lsp.lua
@@ -9,13 +9,7 @@ return {
       if path ~= nil then
         return path;
       end
-
-      --look for a library directory
-      path = util.root_pattern {"manifest.json"}(fname);
-      if path ~= nil then
-        return path;
-      end
-
+      
       --look for .git directory
       return util.find_git_ancestors(fname);
 


### PR DESCRIPTION
fix(c3_lsp): update root directory to be able to handle project in the following order - a C3 project 'project.json', a library '.c3l' dir, and ancestor 'git' repo.