### PR TITLE
Replace `cairo-language-server` with `scarb-cairo-language-server` and update installation docs

### DIFF
--- a/lua/lspconfig/server_configurations/cairo_ls.lua
+++ b/lua/lspconfig/server_configurations/cairo_ls.lua
@@ -1,6 +1,6 @@
 local util = require 'lspconfig.util'
 
-local bin_name = 'cairo-language-server'
+local bin_name = 'scarb-cairo-language-server'
 local cmd = { bin_name, '/C', '--node-ipc' }
 
 return {
@@ -14,9 +14,9 @@ return {
     description = [[
 [Cairo Language Server](https://github.com/starkware-libs/cairo/tree/main/crates/cairo-lang-language-server)
 
-First, install cairo following [this tutorial](https://medium.com/@elias.tazartes/ahead-of-the-curve-install-cairo-1-0-alpha-and-prepare-for-regenesis-85f4e3940e20)
+First, install Cairo following [this tutorial](https://book.cairo-lang.org/ch01-01-installation.html)
 
-Then enable cairo language server in your lua configuration.
+Then enable Cairo Language Server in your Lua configuration.
 ```lua
 require'lspconfig'.cairo_ls.setup{}
 ```

--- a/lua/lspconfig/server_configurations/cairo_ls.lua
+++ b/lua/lspconfig/server_configurations/cairo_ls.lua
@@ -1,12 +1,9 @@
 local util = require 'lspconfig.util'
 
-local bin_name = 'scarb-cairo-language-server'
-local cmd = { bin_name, '/C', '--node-ipc' }
-
 return {
   default_config = {
     init_options = { hostInfo = 'neovim' },
-    cmd = cmd,
+    cmd = { 'scarb-cairo-language-server', '/C', '--node-ipc' },
     filetypes = { 'cairo' },
     root_dir = util.root_pattern('Scarb.toml', 'cairo_project.toml', '.git'),
   },


### PR DESCRIPTION
This PR updates the Cairo Language Server (`cairo_ls`) configuration in `lspconfig` to use `scarb-cairo-language-server` instead of `cairo-language-server`. This change aligns with the new standard as Scarb is now the default package manager for Cairo, and the Scarb-distributed language server extension ensures compatibility with the version of the Cairo compiler used in Scarb.

* Replaced `cairo-language-server` with `scarb-cairo-language-server`, reflecting Scarb as the default package manager.
* Scarb's version of the language server is a launcher for the official Cairo Language Server, ensuring version compatibility with the compiler.
* Updated the documentation link for installing Cairo, following the latest official instructions.

This change simplifies user configuration and ensures they are working with the correct versions of the Cairo compiler and language server.