### PR TITLE
fix(gopls): improve stability by fixing nil error when go env GOMODCACHE returns nothing

### DIFF
--- a/lua/lspconfig/server_configurations/gopls.lua
+++ b/lua/lspconfig/server_configurations/gopls.lua
@@ -12,9 +12,11 @@ return {
         local result = async.run_command { 'go', 'env', 'GOMODCACHE' }
         if result and result[1] then
           mod_cache = vim.trim(result[1])
+        else
+          mod_cache = vim.fn.system 'go env GOMODCACHE'
         end
       end
-      if fname:sub(1, #mod_cache) == mod_cache then
+      if mod_cache and fname:sub(1, #mod_cache) == mod_cache then
         local clients = util.get_lsp_clients { name = 'gopls' }
         if #clients > 0 then
           return clients[#clients].config.root_dir


### PR DESCRIPTION
Currently, if `go env GOMODCACHE` prints nothing, the config will error. This PR will 1. retry with sync version 2. skip the special configuration case if mod_cache is nil. Even though @glepnir says fallback to sync will cause performance issue, which I agree, I think this is much better than just throwing an error. `go env GOMODCACHE` takes 0.001 ms on my machine.

Alternatively, we can remove 1. (the else case) and just keep mod_cache nil so that there are no performance issue, but we should definitely keep 2. (the nil check on mod_cache).

Related (partially fixes): #2733 