### PR TITLE
docs(taplo): update out of date docstring with new root_dir

### DIFF
--- a/lua/lspconfig/server_configurations/taplo.lua
+++ b/lua/lspconfig/server_configurations/taplo.lua
@@ -19,7 +19,7 @@ cargo install --features lsp --locked taplo-cli
 ```
     ]],
     default_config = {
-      root_dir = [[root_pattern("*.toml", ".git")]],
+      root_dir = [[root_pattern(".git")]],
     },
   },
 }


### PR DESCRIPTION
This updates the doc string with the updated `root_dir` for Taplo