### PR TITLE
Update util.rootpath to search all patterns per path => Fixes kotlin-ls root dir on multi-project builds

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -276,18 +276,18 @@ function M.root_pattern(...)
   local patterns = M.tbl_flatten { ... }
   return function(startpath)
     startpath = M.strip_archive_subpath(startpath)
-    for _, pattern in ipairs(patterns) do
-      local match = M.search_ancestors(startpath, function(path)
+    local match = M.search_ancestors(startpath, function(path)
+      for _, pattern in ipairs(patterns) do
         for _, p in ipairs(vim.fn.glob(M.path.join(M.path.escape_wildcards(path), pattern), true, true)) do
           if M.path.exists(p) then
             return path
           end
         end
-      end)
-
-      if match ~= nil then
-        return match
       end
+    end)
+
+    if match ~= nil then
+      return match
     end
   end
 end


### PR DESCRIPTION
The function `util.root_path` loops first from a list of patterns and then searches for matching files on parent folders.

See https://github.com/paulodiovani/nvim-lspconfig/blob/a9bc587e9ae0cbcb3e90a2e9342f86b3b78c4408/lua/lspconfig/util.lua#L279-L281

This makes the pattern list have precedence over paths, often matching patterns on parent folders before closest ones.

The issue happens with [Gradle Multi Project Builds](https://docs.gradle.org/current/userguide/multi_project_builds.html) using Kotlin LS as described at https://github.com/fwcd/kotlin-language-server/issues/559.

This PR swaps the loops, making sure all patterns are searched on each dir before moving up the ladder.

⚠️ Since the change is on the `util` package, this may affect other LSP Servers.
If it breaks any of them I can find a solution for Kotlin LS alone.