### PR TITLE
fix(lua-language-server): update root directory pattern

### DIFF
--- a/lua/lspconfig/configs/lua_ls.lua
+++ b/lua/lspconfig/configs/lua_ls.lua
@@ -19,13 +19,9 @@ return {
       if root and root ~= vim.env.HOME then
         return root
       end
-      local root_lua = util.root_pattern 'lua/'(fname)
-      local root_git = util.find_git_ancestor(fname)
-      if string.len(root_lua or '') >= string.len(root_git or '') then
-        return root_lua
-      else
-        return root_git
-      end
+      local root_lua = util.root_pattern 'lua/'(fname) or ''
+      local root_git = util.find_git_ancestor(fname) or ''
+      return #root_lua >= #root_git and root_lua or root_git
     end,
     single_file_support = true,
     log_level = vim.lsp.protocol.MessageType.Warning,

--- a/lua/lspconfig/configs/lua_ls.lua
+++ b/lua/lspconfig/configs/lua_ls.lua
@@ -19,11 +19,13 @@ return {
       if root and root ~= vim.env.HOME then
         return root
       end
-      root = util.root_pattern 'lua/'(fname)
-      if root then
-        return root
+      local root_lua = util.root_pattern 'lua/'(fname)
+      local root_git = util.find_git_ancestor(fname)
+      if string.len(root_lua or '') >= string.len(root_git or '') then
+        return root_lua
+      else
+        return root_git
       end
-      return util.find_git_ancestor(fname)
     end,
     single_file_support = true,
     log_level = vim.lsp.protocol.MessageType.Warning,
@@ -83,8 +85,5 @@ See `lua-language-server`'s [documentation](https://luals.github.io/wiki/setting
 * [Lua.workspace.library](https://luals.github.io/wiki/settings/#workspacelibrary)
 
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".luarc.json", ".luarc.jsonc", ".luacheckrc", ".stylua.toml", "stylua.toml", "selene.toml", "selene.yml", ".git")]],
-    },
   },
 }


### PR DESCRIPTION
Fixes #3165 by returning the longer root path if both a `.git`- and a `lua`-ancestor are found (as [suggested by](https://github.com/neovim/nvim-lspconfig/issues/3165#issuecomment-2206937152) @powerman).

I also removed the documentation of the default `root_dir` pattern (assuming that now it will reference the source code, as in many other server configurations), since the root pattern calculation is more involved than the documentation indicated.