### PR TITLE
fix(fennel-ls): use closest cfg as root directory and fallback to git repo root

### DIFF
--- a/lua/lspconfig/configs/fennel_ls.lua
+++ b/lua/lspconfig/configs/fennel_ls.lua
@@ -5,7 +5,10 @@ return {
     cmd = { 'fennel-ls' },
     filetypes = { 'fennel' },
     root_dir = function(dir)
-      return util.find_git_ancestor(dir)
+      local has_fls_project_cfg = function(path)
+        return util.path.is_file(vim.fs.joinpath(path, 'flsproject.fnl'))
+      end
+      return util.search_ancestors(dir, has_fls_project_cfg) or vim.fs.root(0, '.git')
     end,
     settings = {},
     capabilities = {
@@ -17,6 +20,9 @@ return {
 https://sr.ht/~xerool/fennel-ls/
 
 A language server for fennel.
+
+fennel-ls is configured using the closest file to your working directory named `flsproject.fnl`.
+All fennel-ls configuration options [can be found here](https://git.sr.ht/~xerool/fennel-ls/tree/HEAD/docs/manual.md#configuration).
 ]],
   },
 }


### PR DESCRIPTION
## Changes
* `fennel-ls` root directory  looks for closest `flsproject.fnl` first, and if it cannot find one, the root of the nearest git repository is used.
* The `fennel-ls` description now references this file and links to the configuration.

Special thanks to @XeroOl for helping me get started here. 🙂 