### PR TITLE
feat: expose config definition as `config_def`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 root = true
 
 [*]
+max_line_length = 100
 indent_style = space
 indent_size = 2
 tab_width = 8

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -28,20 +28,26 @@ QUICKSTART                                                *lspconfig-quickstart*
 5. Run `:checkhealth lsp` to see the status or to troubleshoot.
 
 ==============================================================================
-THE SETUP METHOD                                               *lspconfig-setup*
+USAGE                                                        *lspconfig-usage*
 
 `lspconfig` consists of a collection of language server configurations. Each
-configuration exposes a `setup {}` metamethod which makes it easy to directly
-use the default configuration or selectively override the defaults. 
-`setup {}` is the primary interface by which users interact with `lspconfig`.
+configuration exposes a `setup{}` metamethod which makes it easy to directly
+use the default configuration or selectively override the defaults. `setup{}`
+is the primary interface by which users interact with `lspconfig`.
 
-Using the default configuration for a server is simple:
->
+To activate a config, call its `setup{}` function. Each config name listed in
+|lspconfig-all| is available as `config.<name>`. For example to activate the
+"clangd" config: >lua
+
     require'lspconfig'.clangd.setup{}
 <
-The available server names listed in |lspconfig-all| match the
-`config.SERVER_NAME` defined in each configuration's source file.
+                                                        *lspconfig-config_def*
+You can use the `config_def` field to get the static config definition without
+activating it: >lua
 
+    local config = require'lspconfig'.clangd.config_def
+<
+                                                             *lspconfig-setup*
 `setup{}` wraps |vim.lsp.start_client()| or |vim.lsp.buf_attach_client()|
 functions (depending on whether the current file belongs to a project with
 a currently running client; see |lspconfig-root-detection|).
@@ -80,12 +86,12 @@ the following added keys:
   included in your new override. Some configurations use `on_new_config` to
   dynamically set or modify `cmd`.
 
-Note: all entries passed to `setup {}` override the entry in the default
-configuration. There is no composition.
+Note: all fields passed to `setup{}` override the respective field in the
+default configuration. There is no composition.
 
 All `config` elements described in `:help vim.lsp.start_client()` can
-additionally be overridden via the `setup {}` call. The most commonly
-passed overrides to `setup {}` are:
+additionally be overridden via the `setup{}` call. The most commonly passed
+overrides to `setup{}` are:
 
 - {settings} `table <string, string|table|bool>`
 
@@ -101,7 +107,7 @@ passed overrides to `setup {}` are:
   `pyright.disableOrganizeImports`: `boolean`
 
   Nested keys need to be translated into a nested table and passed to
-  the settings field in `setup {}` as follows:
+  the settings field in `setup{}` as follows:
 >
   require('lspconfig').pyright.setup{
     settings = {
@@ -115,12 +121,9 @@ passed overrides to `setup {}` are:
 ==============================================================================
 OVERRIDING GLOBAL DEFAULTS                           *lspconfig-global-defaults*
 
-WARNING: This API is deprecated. Use |LspAttach| from Nvim core instead.
-
 The global defaults for all servers can be overridden by extending the
-`default_config` table.
+`default_config` table. `setup{}` can override these defaults. >lua
 
->
   local lspconfig = require'lspconfig'
   lspconfig.util.default_config = vim.tbl_extend(
     "force",
@@ -142,12 +145,9 @@ The global defaults for all servers can be overridden by extending the
     }
   )
 <
-`setup {}` can additionally override these defaults in subsequent calls.
 
 ==============================================================================
 SETUP HOOK                                                *lspconfig-setup-hook*
-
-WARNING: This API is deprecated. Use |LspAttach| from Nvim core instead.
 
 `lspconfig` will execute the `on_setup` hook for each setup call to a server after
 validating its configuration, and before attempting to launch the server
@@ -268,7 +268,7 @@ The steps for adding and enabling a new server configuration are:
 ROOT DETECTION                                        *lspconfig-root-detection*
                                                             *lspconfig-root-dir*
 
-WARNING: This API is deprecated. Use |vim.fs| from Nvim core instead.
+WARNING: This API is deprecated. Use |vim.fs.root()| from Nvim core instead.
 
 A project's `root_dir` is used by `lspconfig` to determine whether `lspconfig`
 should start a new server, or attach a previous one, to the current file.
@@ -280,7 +280,7 @@ each server, optionally overridable by the `filetypes` table passed to
 
 This autocommand triggers a search from the current file position in the
 filesystem hierarchy up to the top level directory of your filesystem. The
-`root_dir` entry of each configuration is a function that returns true if the
+`root_dir` field of each configuration is a function that returns true if the
 current directory in this traversal matches a given root pattern.
 
 The following utility functions are provided by `lspconfig`. Each function call
@@ -306,10 +306,10 @@ Note: On Windows, `lspconfig` always assumes forward slash normalized paths with
 capitalized drive letters.
 
 ==============================================================================
-ADVANCED ROOT DIRECTORY DETECTION                      *lspconfig-root-advanced* 
+ADVANCED ROOT DIRECTORY DETECTION                      *lspconfig-root-advanced*
                                                     *lspconfig-root-composition*
 
-WARNING: This API is deprecated. Use |vim.fs| from Nvim core instead.
+WARNING: This API is deprecated. Use |vim.fs.root()| from Nvim core instead.
 
 The `root_dir` key in `config` and `setup` can hold any function of the form
 >

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -26,6 +26,9 @@ local function sanitize_cmd(cmd)
   end
 end
 
+---@param t table
+---@param config_name string
+---@param config_def table Config definition read from `lspconfig.configs.<name>`.
 function configs.__newindex(t, config_name, config_def)
   validate {
     name = { config_name, 's' },
@@ -178,7 +181,7 @@ function configs.__newindex(t, config_name, config_def)
       end)
     end
 
-    -- Used by :LspInfo
+    -- Used by :LspInfo (evil, mutable aliases?)
     M.get_root_dir = get_root_dir
     M.filetypes = config.filetypes
     M.handlers = config.handlers
@@ -290,7 +293,9 @@ function configs.__newindex(t, config_name, config_def)
 
   M.commands = config_def.commands
   M.name = config_name
-  M.document_config = config_def
+  -- Expose the (original?) values of a config (non-active, or before `setup()`).
+  M.config_def = config_def
+  M.document_config = config_def -- For back-compat.
 
   rawset(t, config_name, M)
 end

--- a/lua/lspconfig/ui/lspinfo.lua
+++ b/lua/lspconfig/ui/lspinfo.lua
@@ -329,7 +329,7 @@ return function()
       if not config then
         return
       end
-      local desc = vim.tbl_get(config, 'document_config', 'docs', 'description')
+      local desc = vim.tbl_get(config, 'config_def', 'docs', 'description')
       if desc then
         lines[#lines + 1] = string.format('# %s', config.name)
         lines[#lines + 1] = ''

--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -103,7 +103,7 @@ local function make_lsp_sections()
     0,
     '\n',
     sorted_map_table(configs, function(template_name, template_object)
-      local template_def = template_object.document_config
+      local template_def = template_object.config_def
       local docs = template_def.docs
 
       local params = {


### PR DESCRIPTION
## Problem:
Users/plugins may want to use the config definition without actually activating the config via setup(). https://github.com/neovim/nvim-lspconfig/pull/3330#issuecomment-2387285872

## Solution:
- Expose `config_def` field and document it.
- Also undeprecate some stuff that doesn't yet have a documented alternative.

---

TODO: configs.lua sets `M.filetypes = config.filetypes` and other fields in ad-hoc fashion "for :LspInfo" but it's not clear when those fields are actually populated, and they don't source from `config_def`...