### PR TITLE
feat(regal): add regal/startDebugging handler

### DIFF
--- a/lua/lspconfig/configs/regal.lua
+++ b/lua/lspconfig/configs/regal.lua
@@ -8,6 +8,26 @@ return {
       return util.root_pattern '*.rego'(fname) or util.find_git_ancestor(fname)
     end,
     single_file_support = true,
+    handlers = {
+      ['regal/startDebugging'] = function(_, result)
+        if not result then
+          return nil, vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest)
+        end
+
+        local ok, dap = pcall(require, "dap")
+        if not ok then
+          return nil, vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, "nvim-dap is not installed")
+        end
+
+        if not dap.session() == nil then
+          return nil, vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, "active debug session exists")
+        end
+
+        dap.run(vim.tbl_deep_extend("force", result, { bundlePaths = {"${workspaceFolder}"}}))
+
+        return {ok = true}
+      end,
+    },
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/regal.lua
+++ b/lua/lspconfig/configs/regal.lua
@@ -7,8 +7,7 @@ vim.lsp.handlers['regal/startDebugging'] = function(_, result)
 
   local ok, dap = pcall(require, 'dap')
   if not ok then
-    return nil,
-      vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, 'nvim-dap is not installed')
+    return nil, vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, 'nvim-dap is not installed')
   end
 
   if dap.session() then

--- a/lua/lspconfig/configs/regal.lua
+++ b/lua/lspconfig/configs/regal.lua
@@ -1,5 +1,26 @@
 local util = require 'lspconfig.util'
 
+vim.lsp.handlers['regal/startDebugging'] = function(_, result)
+  if not result then
+    return nil, vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest)
+  end
+
+  local ok, dap = pcall(require, 'dap')
+  if not ok then
+    return nil,
+      vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, 'nvim-dap is not installed')
+  end
+
+  if dap.session() then
+    return nil,
+      vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, 'active debug session exists')
+  end
+
+  dap.run(vim.tbl_deep_extend('force', result, { bundlePaths = { '${workspaceFolder}' } }))
+
+  return { ok = true }
+end
+
 return {
   default_config = {
     cmd = { 'regal', 'language-server' },
@@ -8,28 +29,6 @@ return {
       return util.root_pattern '*.rego'(fname) or util.find_git_ancestor(fname)
     end,
     single_file_support = true,
-    handlers = {
-      ['regal/startDebugging'] = function(_, result)
-        if not result then
-          return nil, vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest)
-        end
-
-        local ok, dap = pcall(require, 'dap')
-        if not ok then
-          return nil,
-            vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, 'nvim-dap is not installed')
-        end
-
-        if dap.session() then
-          return nil,
-            vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, 'active debug session exists')
-        end
-
-        dap.run(vim.tbl_deep_extend('force', result, { bundlePaths = { '${workspaceFolder}' } }))
-
-        return { ok = true }
-      end,
-    },
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/regal.lua
+++ b/lua/lspconfig/configs/regal.lua
@@ -17,15 +17,15 @@ return {
         local ok, dap = pcall(require, 'dap')
         if not ok then
           return nil,
-            vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, "nvim-dap is not installed")
+            vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, 'nvim-dap is not installed')
         end
 
-        if not dap.session() == nil then
+        if dap.session() then
           return nil,
-            vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, "active debug session exists")
+            vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, 'active debug session exists')
         end
 
-        dap.run(vim.tbl_deep_extend("force", result, { bundlePaths = { '${workspaceFolder}' } }))
+        dap.run(vim.tbl_deep_extend('force', result, { bundlePaths = { '${workspaceFolder}' } }))
 
         return { ok = true }
       end,

--- a/lua/lspconfig/configs/regal.lua
+++ b/lua/lspconfig/configs/regal.lua
@@ -14,18 +14,20 @@ return {
           return nil, vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest)
         end
 
-        local ok, dap = pcall(require, "dap")
+        local ok, dap = pcall(require, 'dap')
         if not ok then
-          return nil, vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, "nvim-dap is not installed")
+          return nil,
+            vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, "nvim-dap is not installed")
         end
 
         if not dap.session() == nil then
-          return nil, vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, "active debug session exists")
+          return nil,
+            vim.lsp.rpc.rpc_response_error(vim.lsp.protocol.ErrorCodes.InvalidRequest, "active debug session exists")
         end
 
-        dap.run(vim.tbl_deep_extend("force", result, { bundlePaths = {"${workspaceFolder}"}}))
+        dap.run(vim.tbl_deep_extend("force", result, { bundlePaths = { '${workspaceFolder}' } }))
 
-        return {ok = true}
+        return { ok = true }
       end,
     },
   },


### PR DESCRIPTION
Regal has codelens feature to start a DAP debugging session.
https://github.com/StyraInc/regal/blob/f70b8928568a4286bef0bd531b8f06810d1e38f7/internal/lsp/server.go#L755

To handle this request, this pull request adds `regal/startDebugging` handler to default config to regal.lua.