### PR TITLE
fix(typo): correct typo in npm installation example

### DIFF
--- a/lua/lspconfig/configs/ast_grep.lua
+++ b/lua/lspconfig/configs/ast_grep.lua
@@ -27,7 +27,7 @@ https://ast-grep.github.io/
 ast-grep(sg) is a fast and polyglot tool for code structural search, lint, rewriting at large scale.
 ast-grep LSP only works in projects that have `sgconfig.y[a]ml` in their root directories.
 ```sh
-npm install [-g] @ast-grep/cli
+npm install -g @ast-grep/cli
 ```
 ]],
     default_config = {

--- a/lua/lspconfig/configs/biome.lua
+++ b/lua/lspconfig/configs/biome.lua
@@ -26,7 +26,7 @@ https://biomejs.dev
 Toolchain of the web. [Successor of Rome](https://biomejs.dev/blog/annoucing-biome).
 
 ```sh
-npm install [-g] @biomejs/biome
+npm install -g @biomejs/biome
 ```
 ]],
     default_config = {

--- a/lua/lspconfig/configs/rome.lua
+++ b/lua/lspconfig/configs/rome.lua
@@ -27,7 +27,7 @@ Language server for the Rome Frontend Toolchain.
 (Unmaintained, use [Biome](https://biomejs.dev/blog/annoucing-biome) instead.)
 
 ```sh
-npm install [-g] rome
+npm install -g rome
 ```
 ]],
     default_config = {


### PR DESCRIPTION
Corrected the typo in the npm installation example

- Changed the incorrect `npm install [-g]` command to `npm install -g` for the packages:

1. @biomejs/biome
2. @ast-grep/cli
3. rome