### PR TITLE
fix(lsp_ai): fix docs not rendering properly

### DIFF
--- a/lua/lspconfig/configs/lsp_ai.lua
+++ b/lua/lspconfig/configs/lsp_ai.lua
@@ -12,7 +12,8 @@ return {
     },
   },
   docs = {
-    [[
+    description = {
+      [[
 https://github.com/SilasMarvin/lsp-ai
 
 LSP-AI is an open source language server that serves as a backend for AI-powered functionality in your favorite code
@@ -23,5 +24,6 @@ You will need to provide configuration for the inference backends and models you
 completion/code actions. See the [wiki docs](https://github.com/SilasMarvin/lsp-ai/wiki/Configuration) and
 [examples](https://github.com/SilasMarvin/lsp-ai/blob/main/examples/nvim) for more information.
 ]],
+    },
   },
 }


### PR DESCRIPTION
I made a mistake in #3206 causing the docs not to render, this PR puts the language server docstring under the `description` key as expected. The docs now show up when I render them locally.