### PR TITLE
feat: poryscript-pls

### DIFF
--- a/lua/lspconfig/configs/poryscript_pls.lua
+++ b/lua/lspconfig/configs/poryscript_pls.lua
@@ -1,0 +1,20 @@
+local util = require('lspconfig.util')
+
+return {
+  default_config = {
+    cmd = { 'poryscript-pls' },
+    filetypes = { 'pory' },
+    root_dir = util.find_git_ancestor,
+    single_file_support = true,
+  },
+  docs = {
+    description = [[
+https://github.com/huderlem/poryscript-pls
+
+Language server for poryscript (a high level scripting language for GBA-era Pokémon decompilation projects)
+    ]],
+    default_config = {
+      root_dir = [[util.find_git_ancestor]],
+    },
+  },
+}


### PR DESCRIPTION
Adds minimal `poryscript-pls` configuration to the registry.

Function handlers expected by the LSP implementation are not included to keep this config minimal.