### PR TITLE
fix(jqls): incorrect backslashes in docs

### DIFF
--- a/lua/lspconfig/configs/jqls.lua
+++ b/lua/lspconfig/configs/jqls.lua
@@ -7,7 +7,7 @@ return {
     single_file_support = true,
   },
   docs = {
-    description = [[
+    description = [=[
 https://github.com/wader/jq-lsp
 Language server for jq, written using Go.
 You can install the server easily using go install:
@@ -20,9 +20,9 @@ cp $(go env GOPATH)/bin/jq-lsp /usr/local/bin
 Note: To activate properly nvim needs to know the jq filetype.
 You can add it via:
 ```lua
-vim.cmd(\[\[au BufRead,BufNewFile *.jq setfiletype jq\]\])
+vim.cmd([[au BufRead,BufNewFile *.jq setfiletype jq]])
 ```
-]],
+]=],
     default_config = {
       root_dir = [[util.find_git_ancestor]],
     },

--- a/lua/lspconfig/configs/uvls.lua
+++ b/lua/lspconfig/configs/uvls.lua
@@ -7,7 +7,7 @@ return {
     single_file_support = true,
   },
   docs = {
-    description = [[
+    description = [=[
 https://codeberg.org/caradhras/uvls
 Language server for UVL, written using tree sitter and rust.
 You can install the server easily using cargo:
@@ -19,9 +19,9 @@ cargo install --path .
 Note: To activate properly nvim needs to know the uvl filetype.
 You can add it via:
 ```lua
-vim.cmd(\[\[au BufRead,BufNewFile *.uvl setfiletype uvl\]\])
+vim.cmd([[au BufRead,BufNewFile *.uvl setfiletype uvl]])
 ```
-]],
+]=],
     default_config = {
       root_dir = [[util.find_git_ancestor]],
     },


### PR DESCRIPTION
Basically from [this](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#jqls)

```lua
vim.cmd(\[\[au BufRead,BufNewFile *.jq setfiletype jq\]\])
```

to this

```lua
vim.cmd([[au BufRead,BufNewFile *.jq setfiletype jq]])
```