### PR TITLE
fix(lsp_ai): docs.description string instead of table

### DIFF
--- a/lua/lspconfig/configs/lsp_ai.lua
+++ b/lua/lspconfig/configs/lsp_ai.lua
@@ -12,8 +12,7 @@ return {
     },
   },
   docs = {
-    description = {
-      [[
+    description = [[
 https://github.com/SilasMarvin/lsp-ai
 
 LSP-AI is an open source language server that serves as a backend for AI-powered functionality in your favorite code
@@ -24,6 +23,5 @@ You will need to provide configuration for the inference backends and models you
 completion/code actions. See the [wiki docs](https://github.com/SilasMarvin/lsp-ai/wiki/Configuration) and
 [examples](https://github.com/SilasMarvin/lsp-ai/blob/main/examples/nvim) for more information.
 ]],
-    },
   },
 }


### PR DESCRIPTION
Follow suit of other descriptions that are just strings. 

Follow up to https://github.com/neovim/nvim-lspconfig/pull/3206/files#r1801612126