### PR TITLE
feat(lspinfo): print "{cmd} --version", drop config.lspinfo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Do NOT file bugs in this repo. The configs in this repo are unsupported and provided only as a starting point. We depend on users (like you) to troubleshoot issues with their specific LSP setups and [send improvements](https://github.com/neovim/nvim-lspconfig/blob/master/CONTRIBUTING.md).
+        The configs in this repo are UNSUPPORTED and provided only as a starting point. We depend on users (like you) to troubleshoot issues with their specific LSP setups and [send improvements](https://github.com/neovim/nvim-lspconfig/blob/master/CONTRIBUTING.md).
         
         If you have a feature request or found a bug in the core Nvim `vim.lsp` module (not this repo), [report it to Nvim](https://github.com/neovim/neovim/issues/new?assignees=&labels=bug%2Clsp&projects=&template=lsp_bug_report.yml).
   - type: textarea

--- a/doc/configs.md
+++ b/doc/configs.md
@@ -5592,10 +5592,6 @@ require'lspconfig'.hls.setup{}
   ```lua
   { "haskell", "lhaskell" }
   ```
-  - `lspinfo` : 
-  ```lua
-  see source file
-  ```
   - `root_dir` : 
   ```lua
   root_pattern("hie.yaml", "stack.yaml", "cabal.project", "*.cabal", "package.yaml")

--- a/doc/configs.txt
+++ b/doc/configs.txt
@@ -5592,10 +5592,6 @@ require'lspconfig'.hls.setup{}
   ```lua
   { "haskell", "lhaskell" }
   ```
-  - `lspinfo` : 
-  ```lua
-  see source file
-  ```
   - `root_dir` : 
   ```lua
   root_pattern("hie.yaml", "stack.yaml", "cabal.project", "*.cabal", "package.yaml")

--- a/lua/lspconfig/configs/hls.lua
+++ b/lua/lspconfig/configs/hls.lua
@@ -12,22 +12,6 @@ return {
         cabalFormattingProvider = 'cabalfmt',
       },
     },
-    lspinfo = function(cfg)
-      local extra = {}
-      local function on_stdout(_, data, _)
-        local version = data[1]
-        table.insert(extra, 'version:   ' .. version)
-      end
-
-      local opts = {
-        cwd = cfg.cwd,
-        stdout_buffered = true,
-        on_stdout = on_stdout,
-      }
-      local chanid = vim.fn.jobstart({ cfg.cmd[1], '--version' }, opts)
-      vim.fn.jobwait { chanid }
-      return extra
-    end,
   },
 
   docs = {

--- a/lua/lspconfig/health.lua
+++ b/lua/lspconfig/health.lua
@@ -34,6 +34,21 @@ local function remove_newlines(cmd)
   return cmd
 end
 
+--- Finds a "x.y.z" version string from the output of `cmd`, and returns the whole line.
+---
+--- If a version string is not found, returns the concatenated output.
+---
+--- @param cmd string[]
+local function try_get_version(cmd)
+  local out = vim.fn.system(cmd)
+  if not out then
+    return nil
+  end
+  local version_line = out:match('[^\r\n]+%d+%.[0-9.]+[^\r\n]+')
+  local s = vim.trim(version_line and version_line or out:gsub('[\r\n]', ' '))
+  return s
+end
+
 --- Prettify a path for presentation.
 local function fmtpath(p)
   if vim.startswith(p, 'Running') then
@@ -104,10 +119,13 @@ local function make_config_info(config, bufnr)
     'Config: ' .. config_info.name,
   }
 
+  local cmd_version = { config_info.cmd, '--version' }
+
   local info_lines = {
     'filetypes:         ' .. config_info.filetypes,
     'root directory:    ' .. fmtpath(config_info.root_dir),
     'cmd:               ' .. fmtpath(config_info.cmd),
+    ('%-18s `%s`'):format('version:', try_get_version(cmd_version)),
     'cmd is executable: ' .. config_info.cmd_is_executable,
     'autostart:         ' .. config_info.autostart,
     'custom handlers:   ' .. config_info.handlers,

--- a/lua/lspconfig/health.lua
+++ b/lua/lspconfig/health.lua
@@ -174,11 +174,6 @@ local function make_client_info(client, fname)
     'autostart:       ' .. client_info.autostart,
   }
 
-  if client.config.lspinfo then
-    local server_specific_info = client.config.lspinfo(client.config)
-    info_lines = vim.list_extend(info_lines, server_specific_info)
-  end
-
   vim.list_extend(lines, info_lines)
 
   return table.concat(lines, '\n')


### PR DESCRIPTION
## Problem:
`config.lspinfo` is an undocumented feature that allows extending the info shown in `:LspInfo` (`:checkhealth lspconfig`). This feature is unwanted because:
- it's undocumented
- it adds a maintenance burden
- it provides info that should be derived from the LSP client or server, in a [generalized way](https://github.com/neovim/nvim-lspconfig/issues/3376).

## Solution:
- Remove support for `config.lspinfo`.
- Instead, `:LspInfo` (`:checkhealth lspconfig`) should be enhanced to automatically gather this kind of extra info from the server response. https://github.com/neovim/nvim-lspconfig/issues/3376