### PR TITLE
fix: LspStop correctly closes lsp servers and notifies users

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -135,7 +135,7 @@ api.nvim_create_user_command('LspStop', function(info)
       filter = function(client)
         return server_name == client.config.name
       end
-      err_msg = ('nvim-lspconfig: server name "%s" not found'):format(server_name)
+      err_msg = ('nvim-lspconfig: config "%s" not found'):format(server_name)
       found = false
     end
   end

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -128,7 +128,7 @@ api.nvim_create_user_command('LspStop', function(info)
         return server_id == client.id
       end
       found = false
-      err_msg = ('nvim-lspconfig: server id "%s" not found'):format(server_id)
+      err_msg = ('nvim-lspconfig: client id "%s" not found'):format(server_id)
     elseif v ~= '' then
       server_name = v
       ---@param client vim.lsp.Client


### PR DESCRIPTION
## Problem

The current `LspStop` behavior is confusing and on some occasions wrong:

### Current Behavior:

**Server name:**
- If the server with the given `server_name` is **not attached**:
  - No notification is shown, and **all** LSP servers are stopped.
- If the server with the given `server_name` is **attached**:
  - **Incorrectly** closes all LSP servers.
- If no servers are attached:
  - `server_name` is notified as missing.

**Server ID:**
- If the server with the given `server_id` is **not attached**:
  - Uses `get_managed_clients()` function https://github.com/neovim/nvim-lspconfig/blob/541f3a2781de481bb84883889e4d9f0904250a56/plugin/lspconfig.lua#L45-L47 Which doesn't return all servers (e.g., `null-ls`), so it doesn't close all LSP clients.
- If the server with the given `server_id` is **attached**:
  - The correct LSP server is stopped (including `null-ls`).

**No arguments:**
- If servers are **attached**:
  - Stops all servers.
- If no servers are attached:
  - **Incorrectly** notifies the user with: `config "" not found`.

## Proposal

### With Changes:

**Server name:**
- If the server with the given `server_name` is **not attached**:
  - Notify the user, but **do not close** any servers.
- If the server with the given `server_name` is **attached**:
  - Close the specified server.

**Server ID:**
- If the server with the given `server_id` is **not attached**:
  - Notify the user, but **do not close** any servers.
- If the server with the given `server_id` is **attached**:
  - Close the specified server.

**No arguments:**
- If servers are **attached**:
  - Stops all servers.
- If no servers are attached:
  - No-op.

This behavior is more intuitive while still respecting the documentation:

> "Stops the server with the given client-id or config name. Defaults to stopping all servers active on the current buffer. To force stop a language server:"

When I read this, I expected that the "Defaults" only apply when `server_id` or `config_name` are **not** provided.

---

### Questions:

- Should I use `client.config.name` or simply `client.name`? They seem to have the same values.