### PR TITLE
fix(health): support gopls version command

### DIFF
--- a/lua/lspconfig/health.lua
+++ b/lua/lspconfig/health.lua
@@ -67,7 +67,7 @@ local function try_fmt_version(prog)
   local out = nil
   local cmd --[=[@type string[]]=]
   local tried = ''
-  for _, v_arg in ipairs { '--version', '-v', '--help', '-h' } do
+  for _, v_arg in ipairs { 'version', '--version', '-v', '--help', '-h' } do
     cmd = { prog, v_arg }
     out = try_get_cmd_output(cmd)
     if out then


### PR DESCRIPTION
Add support for the `gopls version` command. It only works if it is the first one that is tried. I am not sure if this breaks other tools. Maybe need to add a version command to each LSP config?

Before
```
- Client: gopls (id: 2, bufnr: [13])
  filetypes:         go, gomod, gowork, gotmpl
  cmd:               ~/.local/share/nvim/mason/bin/gopls
  version:           `flag provided but not defined: -version  gopls is a Go language server.  It is typically used with an editor to provide language features. When no command is specified, gopls will default to the 'serve' command. The language features can also be accessed via the gopls command-line interface.  Usage:   gopls help [<subject>]  Command:  Main                   serve             run a server for Go code using the Language Server Protocol   version           print the gopls version information   bug               report a bug in gopls   help              print usage information for subcommands   api-json          print JSON describing gopls API   licenses          print licenses of included software                      Features               call_hierarchy    display selected identifier's call hierarchy   check             show diagnostic results for the specified file   codelens          List or execute code lenses for a file   definition        show declaration of selected identifier   execute           Execute a gopls custom LSP command   folding_ranges    display selected file's folding ranges   format            format the code according to the go standard   highlight         display selected identifier's highlights   implementation    display selected identifier's implementation   imports           updates import statements   remote            interact with the gopls daemon   inspect           interact with the gopls daemon (deprecated: use 'remote')   links             list links in a file   prepare_rename    test validity of a rename operation at location   references        display selected identifier's references   rename            rename selected identifier   semtok            show semantic tokens for the specified file   signature         display selected identifier's signature   stats             print workspace statistics   fix               apply suggested fixes   symbols           display selected file's symbols   workspace_symbol  search symbols in workspace  flags:   -debug=string     	serve debug information on the supplied address   -listen=string     	address on which to listen for remote connections. If prefixed by 'unix;', the subsequent address is assumed to be a unix domain socket. Otherwise, TCP is used.   -listen.timeout=duration     	when used with -listen, shut down the server when there are no connected clients for this duration   -logfile=string     	filename to log to. if value is "auto", then logging to a default output file is enabled   -mode=string     	no effect   -ocagent=string     	the address of the ocagent (e.g. http://localhost:55678), or off (default "off")   -port=int     	port on which to run gopls for debugging purposes   -profile.alloc=string     	write alloc profile to this file   -profile.cpu=string     	write CPU profile to this file   -profile.mem=string     	write memory profile to this file   -profile.trace=string     	write trace log to this file   -remote=string     	forward all commands to a remote lsp specified by this flag. With no special prefix, this is assumed to be a TCP address. If prefixed by 'unix;', the subsequent address is assumed to be a unix domain socket. If 'auto', or prefixed by 'auto;', the remote address is automatically resolved based on the executing environment.   -remote.debug=string     	when used with -remote=auto, the -debug value used to start the daemon   -remote.listen.timeout=duration     	when used with -remote=auto, the -listen.timeout value used to start the daemon (default 1m0s)   -remote.logfile=string     	when used with -remote=auto, the -logfile value used to start the daemon   -rpc.trace     	print the full rpc trace in lsp inspector format   -v,-verbose     	verbose output   -vv,-veryverbose     	very verbose output` (output of `/Users/scott/.local/share/nvim/mason/bin/gopls --version`)
  executable:        true
  autostart:         true
```

```
- Client: gopls (id: 2, bufnr: [14])
  filetypes:         go, gomod, gowork, gotmpl
  cmd:               ~/.local/share/nvim/mason/bin/gopls
  version:           `golang.org/x/tools/gopls v0.16.2`
  executable:        true
  autostart:         true
```