### PR TITLE
fix(fennel-ls): use cwd when git repo parent is not found

### DIFF
--- a/lua/lspconfig/configs/fennel_ls.lua
+++ b/lua/lspconfig/configs/fennel_ls.lua
@@ -8,7 +8,7 @@ return {
       local has_fls_project_cfg = function(path)
         return util.path.is_file(vim.fs.joinpath(path, 'flsproject.fnl'))
       end
-      return util.search_ancestors(dir, has_fls_project_cfg) or vim.fs.root(0, '.git')
+      return util.search_ancestors(dir, has_fls_project_cfg) or vim.fs.root(0, '.git') or vim.fn.getcwd()
     end,
     settings = {},
     capabilities = {


### PR DESCRIPTION
## Context
For the `fennel-ls` lspconfig, I recently changed how the  `fennel-ls` configuration file is found, i.e. nearest config -> git root. 

However, when there is no `fennel-ls` configuration available, and all parent directories of the current buffer do contain git repositories, then the LSP won't be loaded at all. This PR fixes that.

## Changes
* Use `cwd` for `fennel-ls`  when git repository parent is unavailable

## Questions
1. Can I write a test so this doesn't fail again? If so, where should that live?
2. If `root_dir` is `nil`, should the LSP fail to load? I'm not sure if there are legitimate cases to ever send `nil` to an LSP but I thought I'd ask if a wider, structural solution is appropriate.

Thanks for your help!