### PR TITLE
fix(lua_ls): when neither lua or git root found, return nil. See #3322

### DIFF
--- a/lua/lspconfig/configs/lua_ls.lua
+++ b/lua/lspconfig/configs/lua_ls.lua
@@ -21,6 +21,9 @@ return {
       end
       local root_lua = util.root_pattern 'lua/'(fname) or ''
       local root_git = util.find_git_ancestor(fname) or ''
+      if root_lua == '' and root_git == '' then
+        return
+      end
       return #root_lua >= #root_git and root_lua or root_git
     end,
     single_file_support = true,


### PR DESCRIPTION
Due to #3322, when neither a `/lua` directory or `.git` root dir exists, the empty (and invalid) `''` root dir was returned.

Instead it should return `nil` so that single-file mode can trigger instead.