### PR TITLE
feat: ada_ls

### DIFF
--- a/lua/lspconfig/configs/ada_ls.lua
+++ b/lua/lspconfig/configs/ada_ls.lua
@@ -1,0 +1,32 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'ada_language_server' },
+    filetypes = { 'ada' },
+    root_dir = util.root_pattern('Makefile', '.git', '*.gpr', '*.adc'),
+  },
+  docs = {
+    description = [[
+https://github.com/AdaCore/ada_language_server
+
+Installation instructions can be found [here](https://github.com/AdaCore/ada_language_server#Install).
+
+Can be configured by passing a "settings" object to `ada_ls.setup{}`:
+
+```lua
+require('lspconfig').ada_ls.setup{
+    settings = {
+      ada = {
+        projectFile = "project.gpr";
+        scenarioVariables = { ... };
+      }
+    }
+}
+```
+]],
+    default_config = {
+      root_dir = [[util.root_pattern("Makefile", ".git", "*.gpr", "*.adc")]],
+    },
+  },
+}


### PR DESCRIPTION
The configuration for the Ada Language Server was first added in #171 and removed in #3310. The removal happened due to misunderstandings, it was thought at the time that the default language server configuration could not work on its own (#1683), it turns out that this was actually caused by a bug in the ALS that was fixed a long time ago. This means the default ALS configuration can be re-introduced.

However, in the meantime, a new neovim plugin for Ada was created by and the name "als" was borrowed, thus we have to use a new name, ada_ls, in order to avoid breaking this plugin.

This reverts commit 7b8b0b3ddd0ed6eddc93982753acaddc578defac.