### PR TITLE
refactor(docs): drop redundant default_config

### DIFF
--- a/lua/lspconfig/configs/angularls.lua
+++ b/lua/lspconfig/configs/angularls.lua
@@ -60,8 +60,5 @@ require'lspconfig'.angularls.setup{
 }
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("angular.json")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/apex_ls.lua
+++ b/lua/lspconfig/configs/apex_ls.lua
@@ -39,8 +39,5 @@ require'lspconfig'.apex_ls.setup {
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern('sfdx-project.json')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/ast_grep.lua
+++ b/lua/lspconfig/configs/ast_grep.lua
@@ -30,8 +30,5 @@ ast-grep LSP only works in projects that have `sgconfig.y[a]ml` in their root di
 npm install [-g] @ast-grep/cli
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern('sgconfig.yaml', 'sgconfig.yml')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/astro.lua
+++ b/lua/lspconfig/configs/astro.lua
@@ -28,8 +28,5 @@ https://github.com/withastro/language-tools/tree/main/packages/language-server
 npm install -g @astrojs/language-server
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/autotools_ls.lua
+++ b/lua/lspconfig/configs/autotools_ls.lua
@@ -22,8 +22,5 @@ pip install autotools-language-server
 
 Language server for autoconf, automake and make using tree sitter in python.
 ]],
-    default_config = {
-      root_dir = { 'configure.ac', 'Makefile', 'Makefile.am', '*.mk' },
-    },
   },
 }

--- a/lua/lspconfig/configs/bashls.lua
+++ b/lua/lspconfig/configs/bashls.lua
@@ -30,8 +30,5 @@ npm i -g bash-language-server
 
 Language server for bash, written using tree sitter in typescript.
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/beancount.lua
+++ b/lua/lspconfig/configs/beancount.lua
@@ -14,8 +14,5 @@ https://github.com/polarmutex/beancount-language-server#installation
 
 See https://github.com/polarmutex/beancount-language-server#configuration for configuration options
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/bicep.lua
+++ b/lua/lspconfig/configs/bicep.lua
@@ -40,8 +40,5 @@ To download the latest release and place in /usr/local/bin/bicep-langserver:
     && unzip -d /usr/local/bin/bicep-langserver bicep-langserver.zip)
 ```
 ]=],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/biome.lua
+++ b/lua/lspconfig/configs/biome.lua
@@ -30,8 +30,5 @@ Toolchain of the web. [Successor of Rome](https://biomejs.dev/blog/annoucing-bio
 npm install [-g] @biomejs/biome
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern('biome.json', 'biome.jsonc')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/bitbake_ls.lua
+++ b/lua/lspconfig/configs/bitbake_ls.lua
@@ -20,8 +20,5 @@ Can be installed from npm or github.
 npm install -g language-server-bitbake
 ```
     ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/blueprint_ls.lua
+++ b/lua/lspconfig/configs/blueprint_ls.lua
@@ -23,8 +23,5 @@ https://gitlab.gnome.org/jwestman/blueprint-compiler
 Language server for the blueprint markup language, written in python and part
 of the blueprint-compiler.
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/bqnlsp.lua
+++ b/lua/lspconfig/configs/bqnlsp.lua
@@ -38,8 +38,5 @@ If CBQN has been installed in a non-standard directory or can't be installed glo
 This will set the environment variables `LD_LIBRARY_PATH` (Linux) or `DYLD_LIBRARY_PATH` (macOS) to the provided path.
 
   ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/bright_script.lua
+++ b/lua/lspconfig/configs/bright_script.lua
@@ -16,8 +16,5 @@ https://github.com/RokuCommunity/brighterscript
 npm install -g brighterscript
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/bsl_ls.lua
+++ b/lua/lspconfig/configs/bsl_ls.lua
@@ -12,8 +12,5 @@ return {
     Language Server Protocol implementation for 1C (BSL) - 1C:Enterprise 8 and OneScript languages.
 
     ]],
-    default_config = {
-      root_dir = [[root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/buck2.lua
+++ b/lua/lspconfig/configs/buck2.lua
@@ -20,8 +20,5 @@ To better detect Buck2 project files, the following can be added:
 vim.cmd [[ autocmd BufRead,BufNewFile *.bxl,BUCK,TARGETS set filetype=bzl ]]
 ```
 ]=],
-    default_config = {
-      root_dir = [[root_pattern(".buckconfig")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/bufls.lua
+++ b/lua/lspconfig/configs/bufls.lua
@@ -19,8 +19,5 @@ go install github.com/bufbuild/buf-language-server/cmd/bufls@latest
 
 bufls is a Protobuf language server compatible with Buf modules and workspaces
 ]],
-    default_config = {
-      root_dir = [[root_pattern("buf.work.yaml", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/bzl.lua
+++ b/lua/lspconfig/configs/bzl.lua
@@ -15,8 +15,5 @@ https://docs.stack.build/docs/cli/installation
 
 https://docs.stack.build/docs/vscode/starlark-language-server
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/cadence.lua
+++ b/lua/lspconfig/configs/cadence.lua
@@ -25,8 +25,5 @@ The `flow` command from flow-cli must be available. For install instructions see
 
 By default the configuration is taken from the closest `flow.json` or the `flow.json` in the users home directory.
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern('flow.json') or vim.env.HOME]],
-    },
   },
 }

--- a/lua/lspconfig/configs/cairo_ls.lua
+++ b/lua/lspconfig/configs/cairo_ls.lua
@@ -20,8 +20,5 @@ require'lspconfig'.cairo_ls.setup{}
 
 *cairo-language-server is still under active development, some features might not work yet !*
 ]],
-    default_config = {
-      root_dir = [[root_pattern("Scarb.toml", "cairo_project.toml", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/ccls.lua
+++ b/lua/lspconfig/configs/ccls.lua
@@ -1,16 +1,11 @@
 local util = require 'lspconfig.util'
 
-local root_files = {
-  'compile_commands.json',
-  '.ccls',
-}
-
 return {
   default_config = {
     cmd = { 'ccls' },
     filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda' },
     root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname) or util.find_git_ancestor(fname)
+      return util.root_pattern('compile_commands.json', '.ccls')(fname) or util.find_git_ancestor(fname)
     end,
     offset_encoding = 'utf-32',
     -- ccls does not support sending a null root directory
@@ -43,8 +38,5 @@ lspconfig.ccls.setup {
 ```
 
 ]],
-    default_config = {
-      root_dir = [[root_pattern('compile_commands.json', '.ccls', '.git')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/cds_lsp.lua
+++ b/lua/lspconfig/configs/cds_lsp.lua
@@ -1,17 +1,11 @@
 local util = require 'lspconfig.util'
 
-local root_files = {
-  'package.json',
-  'db',
-  'srv',
-}
-
 return {
   default_config = {
     cmd = { 'cds-lsp', '--stdio' },
     filetypes = { 'cds' },
     -- init_options = { provideFormatter = true }, -- needed to enable formatting capabilities
-    root_dir = util.root_pattern(unpack(root_files)),
+    root_dir = util.root_pattern('package.json', 'db', 'srv'),
     single_file_support = true,
     settings = {
       cds = { validate = true },

--- a/lua/lspconfig/configs/clarity_lsp.lua
+++ b/lua/lspconfig/configs/clarity_lsp.lua
@@ -12,8 +12,5 @@ return {
 
 To learn how to configure the clarity language server, see the [clarity-lsp documentation](https://github.com/hirosystems/clarity-lsp).
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/clojure_lsp.lua
+++ b/lua/lspconfig/configs/clojure_lsp.lua
@@ -12,8 +12,5 @@ https://github.com/clojure-lsp/clojure-lsp
 
 Clojure Language Server
 ]],
-    default_config = {
-      root_dir = [[root_pattern("project.clj", "deps.edn", "build.boot", "shadow-cljs.edn", ".git", "bb.edn")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/cmake.lua
+++ b/lua/lspconfig/configs/cmake.lua
@@ -1,12 +1,11 @@
 local util = require 'lspconfig.util'
 
-local root_files = { 'CMakePresets.json', 'CTestConfig.cmake', '.git', 'build', 'cmake' }
 return {
   default_config = {
     cmd = { 'cmake-language-server' },
     filetypes = { 'cmake' },
     root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname)
+      return util.root_pattern('CMakePresets.json', 'CTestConfig.cmake', '.git', 'build', 'cmake')(fname)
     end,
     single_file_support = true,
     init_options = {
@@ -19,8 +18,5 @@ https://github.com/regen100/cmake-language-server
 
 CMake LSP Implementation
 ]],
-    default_config = {
-      root_dir = [[root_pattern('CMakePresets.json', 'CTestConfig.cmake', '.git', 'build', 'cmake')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/cobol_ls.lua
+++ b/lua/lspconfig/configs/cobol_ls.lua
@@ -10,8 +10,5 @@ return {
     description = [[
 Cobol language support
     ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/codeqlls.lua
+++ b/lua/lspconfig/configs/codeqlls.lua
@@ -13,6 +13,7 @@ return {
       initialize_params['workspaceFolders'] = workspace_folders
     end,
     settings = {
+      -- List containing all search paths, eg: '~/codeql-home/codeql-repo'.
       search_path = vim.empty_dict(),
     },
   },
@@ -24,11 +25,6 @@ https://codeql.github.com/docs/codeql-cli/
 Binaries:
 https://github.com/github/codeql-cli-binaries
         ]],
-    default_config = {
-      settings = {
-        search_path = [[list containing all search paths, eg: '~/codeql-home/codeql-repo']],
-      },
-    },
   },
   on_new_config = function(config)
     if type(config.settings.search_path) == 'table' and not vim.tbl_isempty(config.settings.search_path) then

--- a/lua/lspconfig/configs/crystalline.lua
+++ b/lua/lspconfig/configs/crystalline.lua
@@ -13,8 +13,5 @@ https://github.com/elbywan/crystalline
 
 Crystal language server.
 ]],
-    default_config = {
-      root_dir = [[root_pattern('shard.yml', '.git')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/css_variables.lua
+++ b/lua/lspconfig/configs/css_variables.lua
@@ -39,27 +39,5 @@ CSS variables autocompletion and go-to-definition
 npm i -g css-variables-language-server
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("package.json", ".git") or bufdir]],
-      settings = [[
-cssVariables = {
-  lookupFiles = { '**/*.less', '**/*.scss', '**/*.sass', '**/*.css' },
-  blacklistFolders = {
-    '**/.cache',
-    '**/.DS_Store',
-    '**/.git',
-    '**/.hg',
-    '**/.next',
-    '**/.svn',
-    '**/bower_components',
-    '**/CVS',
-    '**/dist',
-    '**/node_modules',
-    '**/tests',
-    '**/tmp',
-  },
-},
-      ]],
-    },
   },
 }

--- a/lua/lspconfig/configs/cssls.lua
+++ b/lua/lspconfig/configs/cssls.lua
@@ -36,8 +36,5 @@ require'lspconfig'.cssls.setup {
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("package.json", ".git") or bufdir]],
-    },
   },
 }

--- a/lua/lspconfig/configs/cssmodules_ls.lua
+++ b/lua/lspconfig/configs/cssmodules_ls.lua
@@ -17,8 +17,5 @@ You can install cssmodules-language-server via npm:
 npm install -g cssmodules-language-server
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("package.json")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/cucumber_language_server.lua
+++ b/lua/lspconfig/configs/cucumber_language_server.lua
@@ -19,8 +19,5 @@ Language server for Cucumber.
 npm install -g @cucumber/language-server
 ```
     ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/custom_elements_ls.lua
+++ b/lua/lspconfig/configs/custom_elements_ls.lua
@@ -32,8 +32,5 @@ Here's an example that disables type checking in JavaScript files.
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("tsconfig.json", "package.json", "jsconfig.json", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/dagger.lua
+++ b/lua/lspconfig/configs/dagger.lua
@@ -15,8 +15,5 @@ https://github.com/dagger/cuelsp
 
 Dagger's lsp server for cuelang.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("cue.mod", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/dartls.lua
+++ b/lua/lspconfig/configs/dartls.lua
@@ -25,8 +25,5 @@ https://github.com/dart-lang/sdk/tree/master/pkg/analysis_server/tool/lsp_spec
 
 Language server for dart.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("pubspec.yaml")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/dcmls.lua
+++ b/lua/lspconfig/configs/dcmls.lua
@@ -12,8 +12,5 @@ https://dcm.dev/
 
 Language server for DCM analyzer.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("pubspec.yaml")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/denols.lua
+++ b/lua/lspconfig/configs/denols.lua
@@ -120,8 +120,5 @@ vim.g.markdown_fenced_languages = {
 ```
 
 ]],
-    default_config = {
-      root_dir = [[root_pattern("deno.json", "deno.jsonc", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/dhall_lsp_server.lua
+++ b/lua/lspconfig/configs/dhall_lsp_server.lua
@@ -19,8 +19,5 @@ cabal install dhall-lsp-server
 ```
 prebuilt binaries can be found [here](https://github.com/dhall-lang/dhall-haskell/releases).
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/diagnosticls.lua
+++ b/lua/lspconfig/configs/diagnosticls.lua
@@ -1,10 +1,12 @@
 local util = require 'lspconfig.util'
 
 return {
+  -- Configuration from https://github.com/iamcco/diagnostic-languageserver#config--document
   default_config = {
     cmd = { 'diagnostic-languageserver', '--stdio' },
     root_dir = util.find_git_ancestor,
     single_file_support = true,
+    -- Empty by default, override to add filetypes.
     filetypes = {},
   },
   docs = {
@@ -13,10 +15,5 @@ https://github.com/iamcco/diagnostic-languageserver
 
 Diagnostic language server integrate with linters.
 ]],
-    default_config = {
-      filetypes = 'Empty by default, override to add filetypes',
-      root_dir = "Vim's starting directory",
-      init_options = 'Configuration from https://github.com/iamcco/diagnostic-languageserver#config--document',
-    },
   },
 }

--- a/lua/lspconfig/configs/docker_compose_language_service.lua
+++ b/lua/lspconfig/configs/docker_compose_language_service.lua
@@ -20,8 +20,5 @@ npm install @microsoft/compose-language-service
 
 Note: If the docker-compose-langserver doesn't startup when entering a `docker-compose.yaml` file, make sure that the filetype is `yaml.docker-compose`. You can set with: `:set filetype=yaml.docker-compose`.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("docker-compose.yaml", "docker-compose.yml", "compose.yaml", "compose.yml")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/dockerls.lua
+++ b/lua/lspconfig/configs/dockerls.lua
@@ -31,8 +31,5 @@ require("lspconfig").dockerls.setup {
 }
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("Dockerfile")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/dprint.lua
+++ b/lua/lspconfig/configs/dprint.lua
@@ -26,8 +26,5 @@ https://github.com/dprint/dprint
 
 Pluggable and configurable code formatting platform written in Rust.
   ]],
-    default_config = {
-      root_dir = util.root_pattern('dprint.json', '.dprint.json', 'dprint.jsonc', '.dprint.jsonc'),
-    },
   },
 }

--- a/lua/lspconfig/configs/efm.lua
+++ b/lua/lspconfig/configs/efm.lua
@@ -36,8 +36,5 @@ require('lspconfig')['efm'].setup{
 ```
 
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/elixirls.lua
+++ b/lua/lspconfig/configs/elixirls.lua
@@ -37,8 +37,5 @@ require'lspconfig'.elixirls.setup{
 
 'root_dir' is chosen like this: if two or more directories containing `mix.exs` were found when searching directories upward, the second one (higher up) is chosen, with the assumption that it is the root of an umbrella app. Otherwise the directory containing the single mix.exs that was found is chosen.
 ]],
-    default_config = {
-      root_dir = '{{see description above}}',
-    },
   },
 }

--- a/lua/lspconfig/configs/elmls.lua
+++ b/lua/lspconfig/configs/elmls.lua
@@ -33,8 +33,5 @@ If you don't want to use Nvim to install it, then you can use:
 npm install -g elm elm-test elm-format @elm-tooling/elm-language-server
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("elm.json")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/elp.lua
+++ b/lua/lspconfig/configs/elp.lua
@@ -14,8 +14,5 @@ https://whatsapp.github.io/erlang-language-platform
 ELP integrates Erlang into modern IDEs via the language server protocol and was
 inspired by rust-analyzer.
 ]],
-    default_config = {
-      root_dir = [[root_pattern('rebar.config', 'erlang.mk', '.git')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/ember.lua
+++ b/lua/lspconfig/configs/ember.lua
@@ -16,8 +16,5 @@ https://github.com/ember-tooling/ember-language-server
 npm install -g @ember-tooling/ember-language-server
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("ember-cli-build.js", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/emmet_language_server.lua
+++ b/lua/lspconfig/configs/emmet_language_server.lua
@@ -28,9 +28,5 @@ Package can be installed via `npm`:
 npm install -g @olrtg/emmet-language-server
 ```
 ]],
-    default_config = {
-      root_dir = 'git root',
-      single_file_support = true,
-    },
   },
 }

--- a/lua/lspconfig/configs/emmet_ls.lua
+++ b/lua/lspconfig/configs/emmet_ls.lua
@@ -31,9 +31,5 @@ Package can be installed via `npm`:
 npm install -g emmet-ls
 ```
 ]],
-    default_config = {
-      root_dir = 'git root',
-      single_file_support = true,
-    },
   },
 }

--- a/lua/lspconfig/configs/erg_language_server.lua
+++ b/lua/lspconfig/configs/erg_language_server.lua
@@ -20,8 +20,5 @@ erg-language-server can be installed via `cargo` and used as follows:
  erg --language-server
  ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("package.er") or find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/erlangls.lua
+++ b/lua/lspconfig/configs/erlangls.lua
@@ -22,8 +22,5 @@ Installation requirements:
     - [Erlang OTP 21+](https://github.com/erlang/otp)
     - [rebar3 3.9.1+](https://github.com/erlang/rebar3)
 ]],
-    default_config = {
-      root_dir = [[root_pattern('rebar.config', 'erlang.mk', '.git')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/fish_lsp.lua
+++ b/lua/lspconfig/configs/fish_lsp.lua
@@ -19,8 +19,5 @@ scope aware symbol analysis, per-token hover generation, and many others.
 
 [homepage](https://www.fish-lsp.dev/)
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/flow.lua
+++ b/lua/lspconfig/configs/flow.lua
@@ -20,8 +20,5 @@ See below for lsp command options.
 npx flow lsp --help
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern(".flowconfig")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/flux_lsp.lua
+++ b/lua/lspconfig/configs/flux_lsp.lua
@@ -15,8 +15,5 @@ https://github.com/influxdata/flux-lsp
 cargo install --git https://github.com/influxdata/flux-lsp
 ```
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/fortls.lua
+++ b/lua/lspconfig/configs/fortls.lua
@@ -29,8 +29,5 @@ Settings to the server can be passed either through the `cmd` option or through
 a local configuration file e.g. `.fortls`. For more information
 see the `fortls` [documentation](https://fortls.fortran-lang.org/options.html).
     ]],
-    default_config = {
-      root_dir = [[root_pattern(".fortls")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/fstar.lua
+++ b/lua/lspconfig/configs/fstar.lua
@@ -12,8 +12,5 @@ https://github.com/FStarLang/FStar
 
 LSP support is included in FStar. Make sure `fstar.exe` is in your PATH.
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/gdscript.lua
+++ b/lua/lspconfig/configs/gdscript.lua
@@ -19,8 +19,5 @@ https://github.com/godotengine/godot
 
 Language server for GDScript, used by Godot Engine.
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern("project.godot", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/ghcide.lua
+++ b/lua/lspconfig/configs/ghcide.lua
@@ -14,8 +14,5 @@ https://github.com/digital-asset/ghcide
 A library for building Haskell IDE tooling.
 "ghcide" isn't for end users now. Use "haskell-language-server" instead of "ghcide".
 ]],
-    default_config = {
-      root_dir = [[root_pattern("stack.yaml", "hie-bios", "BUILD.bazel", "cabal.config", "package.yaml")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/gitlab_ci_ls.lua
+++ b/lua/lspconfig/configs/gitlab_ci_ls.lua
@@ -20,14 +20,5 @@ Language Server for Gitlab CI
 `gitlab-ci-ls` can be installed via cargo:
 cargo install gitlab-ci-ls
 ]],
-    default_config = {
-      cmd = { 'gitlab-ci-ls' },
-      filetypes = { 'yaml.gitlab' },
-      root_dir = [[util.root_pattern('.gitlab*', '.git')]],
-      init_options = {
-        cache_path = [[util.path.join(vim.uv.os_homedir(), '.cache/gitlab-ci-ls/')]],
-        log_path = [[util.path.join(util.path.join(vim.uv.os_homedir(), '.cache/gitlab-ci-ls/'), 'log/gitlab-ci-ls.log')]],
-      },
-    },
   },
 }

--- a/lua/lspconfig/configs/glasgow.lua
+++ b/lua/lspconfig/configs/glasgow.lua
@@ -31,8 +31,5 @@ Provides language features for WGSL (WebGPU Shading Language):
 cargo install glasgow
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/gleam.lua
+++ b/lua/lspconfig/configs/gleam.lua
@@ -17,9 +17,5 @@ A language server for Gleam Programming Language.
 
 It can be i
 ]],
-    default_config = {
-      cmd = { 'gleam', 'lsp' },
-      root_dir = [[root_pattern("gleam.toml", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/golangci_lint_ls.lua
+++ b/lua/lspconfig/configs/golangci_lint_ls.lua
@@ -35,8 +35,5 @@ go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 ```
 
 ]],
-    default_config = {
-      root_dir = [[root_pattern('.golangci.yml', '.golangci.yaml', '.golangci.toml', '.golangci.json', 'go.work', 'go.mod', '.git')]],
-    },
   },
 }


### PR DESCRIPTION
 🚀 🎸  use programming to do stuff 🚀 🎸 

Problem:
default_config duplicated in `docs` items.

Solution:
delete it. docgen autogenerates this now.