### PR TITLE
refactor(docs): drop redundant default_config

### DIFF
--- a/lua/lspconfig/configs/gopls.lua
+++ b/lua/lspconfig/configs/gopls.lua
@@ -32,8 +32,5 @@ https://github.com/golang/tools/tree/master/gopls
 
 Google's lsp server for golang.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("go.work", "go.mod", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/gradle_ls.lua
+++ b/lua/lspconfig/configs/gradle_ls.lua
@@ -5,15 +5,13 @@ if vim.fn.has 'win32' == 1 then
   bin_name = bin_name .. '.bat'
 end
 
-local root_files = {
-  'settings.gradle', -- Gradle (multi-project)
-  'build.gradle', -- Gradle
-}
-
 return {
   default_config = {
     filetypes = { 'groovy' },
-    root_dir = util.root_pattern(unpack(root_files)),
+    root_dir = util.root_pattern(
+      'settings.gradle', -- Gradle (multi-project)
+      'build.gradle' -- Gradle
+    ),
     cmd = { bin_name },
     -- gradle-language-server expects init_options.settings to be defined
     init_options = {
@@ -30,14 +28,5 @@ Microsoft's lsp server for gradle files
 
 If you're setting this up manually, build vscode-gradle using `./gradlew installDist` and point `cmd` to the `gradle-language-server` generated in the build directory
 ]],
-    default_config = {
-      root_dir = [[root_pattern("settings.gradle", "build.gradle")]],
-      cmd = { 'gradle-language-server' },
-      init_options = {
-        settings = {
-          gradleWrapperEnabled = true,
-        },
-      },
-    },
   },
 }

--- a/lua/lspconfig/configs/grammarly.lua
+++ b/lua/lspconfig/configs/grammarly.lua
@@ -27,8 +27,5 @@ npm i -g grammarly-languageserver
 
 WARNING: Since this language server uses Grammarly's API, any document you open with it running is shared with them. Please evaluate their [privacy policy](https://www.grammarly.com/privacy-policy) before using this.
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/graphql.lua
+++ b/lua/lspconfig/configs/graphql.lua
@@ -19,8 +19,5 @@ npm install -g graphql-language-service-cli
 
 Note that you must also have [the graphql package](https://github.com/graphql/graphql-js) installed within your project and create a [GraphQL config file](https://the-guild.dev/graphql/config/docs).
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern('.git', '.graphqlrc*', '.graphql.config.*', 'graphql.config.*')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/guile_ls.lua
+++ b/lua/lspconfig/configs/guile_ls.lua
@@ -23,8 +23,5 @@ Checkout the repo for more info.
 
 Note: This LSP will start on `scheme.guile` filetype. You can set this file type using `:help modeline` or adding https://gitlab.com/HiPhish/guile.vim to your plugins to automatically set it.
     ]],
-    default_config = {
-      root_dir = [[root_pattern("guix.scm", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/harper_ls.lua
+++ b/lua/lspconfig/configs/harper_ls.lua
@@ -44,8 +44,5 @@ lspconfig.harper_ls.setup {
 }
 ```
     ]],
-    default_config = {
-      root_dir = [[bufdir]],
-    },
   },
 }

--- a/lua/lspconfig/configs/haxe_language_server.lua
+++ b/lua/lspconfig/configs/haxe_language_server.lua
@@ -16,6 +16,7 @@ return {
         executable = 'haxe',
       },
     },
+    -- Default value is set by on_new_config.
     init_options = {},
     on_new_config = function(new_config, new_root_dir)
       if new_config.init_options.displayArguments then
@@ -66,9 +67,5 @@ lspconfig.haxe_language_server.setup({
 ```
 
 ]],
-    default_config = {
-      root_dir = [[root_pattern("*.hxml", ".git")]],
-      init_options = 'default value is set by on_new_config',
-    },
   },
 }

--- a/lua/lspconfig/configs/hdl_checker.lua
+++ b/lua/lspconfig/configs/hdl_checker.lua
@@ -13,8 +13,5 @@ https://github.com/suoto/hdl_checker
 Language server for hdl-checker.
 Install using: `pip install hdl-checker --upgrade`
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/helm_ls.lua
+++ b/lua/lspconfig/configs/helm_ls.lua
@@ -1,20 +1,18 @@
 local util = require 'lspconfig.util'
 
-local default_capabilities = {
-  workspace = {
-    didChangeWatchedFiles = {
-      dynamicRegistration = true,
-    },
-  },
-}
-
 return {
   default_config = {
     cmd = { 'helm_ls', 'serve' },
     filetypes = { 'helm' },
     root_dir = util.root_pattern 'Chart.yaml',
     single_file_support = true,
-    capabilities = default_capabilities,
+    capabilities = {
+      workspace = {
+        didChangeWatchedFiles = {
+          dynamicRegistration = true,
+        },
+      },
+    },
   },
   docs = {
     description = [[
@@ -28,9 +26,5 @@ The default `cmd` assumes that the `helm_ls` binary can be found in `$PATH`.
 
 If need Helm file highlight use [vim-helm](https://github.com/towolf/vim-helm) plugin.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("Chart.yaml")]],
-      capabilities = [[default capabilities, with dynamicRegistration for didChangeWatchedFiles true]],
-    },
   },
 }

--- a/lua/lspconfig/configs/hhvm.lua
+++ b/lua/lspconfig/configs/hhvm.lua
@@ -14,8 +14,5 @@ https://github.com/facebook/hhvm
 See below for how to setup HHVM & typechecker:
 https://docs.hhvm.com/hhvm/getting-started/getting-started
     ]],
-    default_config = {
-      root_dir = [[root_pattern(".hhconfig")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/hie.lua
+++ b/lua/lspconfig/configs/hie.lua
@@ -26,9 +26,5 @@ init_options = {
 }
 ```
         ]],
-
-    default_config = {
-      root_dir = [[root_pattern("stack.yaml", "package.yaml", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/hlasm.lua
+++ b/lua/lspconfig/configs/hlasm.lua
@@ -13,8 +13,5 @@ return {
 
     To learn how to configure the HLASM language server, see the [HLASM Language Support documentation](https://github.com/eclipse-che4z/che-che4z-lsp-for-hlasm).
     ]],
-    default_config = {
-      root_dir = [[root_pattern(".hlasmplugin")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/hls.lua
+++ b/lua/lspconfig/configs/hls.lua
@@ -28,9 +28,5 @@ require('lspconfig')['hls'].setup{
 }
 ```
     ]],
-
-    default_config = {
-      root_dir = [[root_pattern("hie.yaml", "stack.yaml", "cabal.project", "*.cabal", "package.yaml")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/hydra_lsp.lua
+++ b/lua/lspconfig/configs/hydra_lsp.lua
@@ -13,8 +13,5 @@ https://github.com/Retsediv/hydra-lsp
 
 LSP for Hydra Python package config files.
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern '.git']],
-    },
   },
 }

--- a/lua/lspconfig/configs/hyprls.lua
+++ b/lua/lspconfig/configs/hyprls.lua
@@ -17,8 +17,5 @@ go install github.com/ewen-lbh/hyprls/cmd/hyprls@latest
 ```
 
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/intelephense.lua
+++ b/lua/lspconfig/configs/intelephense.lua
@@ -20,24 +20,24 @@ https://intelephense.com/
 ```sh
 npm install -g intelephense
 ```
+
+```lua
+-- See https://github.com/bmewburn/intelephense-docs/blob/master/installation.md#initialisation-options
+init_options = {
+  storagePath = …, -- Optional absolute path to storage dir. Defaults to os.tmpdir().
+  globalStoragePath = …, -- Optional absolute path to a global storage dir. Defaults to os.homedir().
+  licenceKey = …, -- Optional licence key or absolute path to a text file containing the licence key.
+  clearCache = …, -- Optional flag to clear server state. State can also be cleared by deleting {storagePath}/intelephense
+}
+-- See https://github.com/bmewburn/intelephense-docs
+settings = {
+  intelephense = {
+    files = {
+      maxSize = 1000000;
+    };
+  };
+}
+```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("composer.json", ".git")]],
-      init_options = [[{
-        storagePath = Optional absolute path to storage dir. Defaults to os.tmpdir().
-        globalStoragePath = Optional absolute path to a global storage dir. Defaults to os.homedir().
-        licenceKey = Optional licence key or absolute path to a text file containing the licence key.
-        clearCache = Optional flag to clear server state. State can also be cleared by deleting {storagePath}/intelephense
-        -- See https://github.com/bmewburn/intelephense-docs/blob/master/installation.md#initialisation-options
-      }]],
-      settings = [[{
-        intelephense = {
-          files = {
-            maxSize = 1000000;
-          };
-        };
-        -- See https://github.com/bmewburn/intelephense-docs
-      }]],
-    },
   },
 }

--- a/lua/lspconfig/configs/jdtls.lua
+++ b/lua/lspconfig/configs/jdtls.lua
@@ -76,18 +76,6 @@ local function on_language_status(_, result)
   command 'echohl None'
 end
 
-local root_files = {
-  -- Multi-module projects
-  { '.git', 'build.gradle', 'build.gradle.kts' },
-  -- Single-module projects
-  {
-    'build.xml', -- Ant
-    'pom.xml', -- Maven
-    'settings.gradle', -- Gradle
-    'settings.gradle.kts', -- Gradle
-  },
-}
-
 return {
   default_config = {
     cmd = {
@@ -100,6 +88,17 @@ return {
     },
     filetypes = { 'java' },
     root_dir = function(fname)
+      local root_files = {
+        -- Multi-module projects
+        { '.git', 'build.gradle', 'build.gradle.kts' },
+        -- Single-module projects
+        {
+          'build.xml', -- Ant
+          'pom.xml', -- Maven
+          'settings.gradle', -- Gradle
+          'settings.gradle.kts', -- Gradle
+        },
+      }
       for _, patterns in ipairs(root_files) do
         local root = util.root_pattern(unpack(patterns))(fname)
         if root then
@@ -156,18 +155,5 @@ For automatic installation you can use the following unofficial installers/launc
       require'lspconfig'.jdtls.setup{ cmd = { 'jdtls' } }
     ```
     ]],
-    default_config = {
-      root_dir = [[{
-        -- Single-module projects
-        {
-          'build.xml', -- Ant
-          'pom.xml', -- Maven
-          'settings.gradle', -- Gradle
-          'settings.gradle.kts', -- Gradle
-        },
-        -- Multi-module projects
-        { 'build.gradle', 'build.gradle.kts' },
-      } or vim.fn.getcwd()]],
-    },
   },
 }

--- a/lua/lspconfig/configs/jedi_language_server.lua
+++ b/lua/lspconfig/configs/jedi_language_server.lua
@@ -22,8 +22,5 @@ https://github.com/pappasam/jedi-language-server
 
 `jedi-language-server`, a language server for Python, built on top of jedi
     ]],
-    default_config = {
-      root_dir = "vim's starting directory",
-    },
   },
 }

--- a/lua/lspconfig/configs/jqls.lua
+++ b/lua/lspconfig/configs/jqls.lua
@@ -23,8 +23,5 @@ You can add it via:
 vim.cmd([[au BufRead,BufNewFile *.jq setfiletype jq]])
 ```
 ]=],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/jsonls.lua
+++ b/lua/lspconfig/configs/jsonls.lua
@@ -34,8 +34,5 @@ require'lspconfig'.jsonls.setup {
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/jsonnet_ls.lua
+++ b/lua/lspconfig/configs/jsonnet_ls.lua
@@ -37,8 +37,5 @@ The language server can be installed with `go`:
 go install github.com/grafana/jsonnet-language-server@latest
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("jsonnetfile.json")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/kcl.lua
+++ b/lua/lspconfig/configs/kcl.lua
@@ -13,8 +13,5 @@ https://github.com/kcl-lang/kcl.nvim
 Language server for the KCL configuration and policy language.
 
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/koka.lua
+++ b/lua/lspconfig/configs/koka.lua
@@ -13,9 +13,5 @@ return {
     https://koka-lang.github.io/koka/doc/index.html
 Koka is a functional programming language with effect types and handlers.
     ]],
-    default_config = {
-      root_dir = [[git directory]],
-      capabilities = [[default capabilities]],
-    },
   },
 }

--- a/lua/lspconfig/configs/kotlin_language_server.lua
+++ b/lua/lspconfig/configs/kotlin_language_server.lua
@@ -23,8 +23,9 @@ return {
   default_config = {
     filetypes = { 'kotlin' },
     root_dir = util.root_pattern(unpack(root_files)),
-    cmd = { bin_name },
+    cmd = { bin_name }, -- kotlin-language-server
     init_options = {
+      -- Enables caching and use project root to store cache data.
       storagePath = util.root_pattern(unpack(root_files))(vim.fn.expand '%:p:h'),
     },
   },
@@ -46,12 +47,5 @@ return {
     For faster startup, you can setup caching by specifying a storagePath
     in the init_options. The default is your home directory.
     ]],
-    default_config = {
-      root_dir = [[See source]],
-      cmd = { 'kotlin-language-server' },
-      init_options = {
-        storagePath = [[Enables caching and use project root to store cache data. See source]],
-      },
-    },
   },
 }

--- a/lua/lspconfig/configs/kulala_ls.lua
+++ b/lua/lspconfig/configs/kulala_ls.lua
@@ -13,11 +13,5 @@ https://github.com/mistweaverco/kulala-ls
 
 A minimal language server for HTTP syntax.
 ]],
-    default_config = {
-      cmd = { 'kulala-ls', '--stdio' },
-      filetypes = { 'http' },
-      root_dir = [[root_pattern('.git')]],
-      single_file_support = true,
-    },
   },
 }

--- a/lua/lspconfig/configs/lean3ls.lua
+++ b/lua/lspconfig/configs/lean3ls.lua
@@ -39,8 +39,5 @@ Note: that if you're using [lean.nvim](https://github.com/Julian/lean.nvim),
 that plugin fully handles the setup of the Lean language server,
 and you shouldn't set up `lean3ls` both with it and `lspconfig`.
     ]],
-    default_config = {
-      root_dir = [[root_pattern("leanpkg.toml") or root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/leanls.lua
+++ b/lua/lspconfig/configs/leanls.lua
@@ -45,8 +45,5 @@ Note: that if you're using [lean.nvim](https://github.com/Julian/lean.nvim),
 that plugin fully handles the setup of the Lean language server,
 and you shouldn't set up `leanls` both with it and `lspconfig`.
     ]],
-    default_config = {
-      root_dir = [[root_pattern("lakefile.toml", "lakefile.lean", "lean-toolchain", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/lemminx.lua
+++ b/lua/lspconfig/configs/lemminx.lua
@@ -16,8 +16,5 @@ The easiest way to install the server is to get a binary from https://github.com
 NOTE to macOS users: Binaries from unidentified developers are blocked by default. If you trust the downloaded binary, run it once, cancel the prompt, then remove the binary from Gatekeeper quarantine with `xattr -d com.apple.quarantine lemminx`. It should now run without being blocked.
 
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/luau_lsp.lua
+++ b/lua/lspconfig/configs/luau_lsp.lua
@@ -21,8 +21,5 @@ You might also have to set up automatic filetype detection for Luau files, for e
 autocmd BufRead,BufNewFile *.luau setf luau
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/lwc_ls.lua
+++ b/lua/lspconfig/configs/lwc_ls.lua
@@ -30,8 +30,5 @@ require'lspconfig'.lwc_ls.setup {
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern('sfdx-project.json')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/marksman.lua
+++ b/lua/lspconfig/configs/marksman.lua
@@ -23,8 +23,5 @@ Marksman works on MacOS, Linux, and Windows and is distributed as a self-contain
 
 Pre-built binaries can be downloaded from https://github.com/artempyanykh/marksman/releases
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git", ".marksman.toml")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/mesonlsp.lua
+++ b/lua/lspconfig/configs/mesonlsp.lua
@@ -12,8 +12,5 @@ https://github.com/JCWasmx86/mesonlsp
 
 An unofficial, unendorsed language server for meson written in C++
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern("meson.build", "meson_options.txt", "meson.options", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/metals.lua
+++ b/lua/lspconfig/configs/metals.lua
@@ -33,8 +33,5 @@ Note: that if you're using [nvim-metals](https://github.com/scalameta/nvim-metal
 
 To install Metals, make sure to have [coursier](https://get-coursier.io/docs/cli-installation) installed, and once you do you can install the latest Metals with `cs install metals`.
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern("build.sbt", "build.sc", "build.gradle", "pom.xml")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/mojo.lua
+++ b/lua/lspconfig/configs/mojo.lua
@@ -15,8 +15,5 @@ https://github.com/modularml/mojo
 
 Mojo is a new programming language that bridges the gap between research and production by combining Python syntax and ecosystem with systems programming and metaprogramming features.
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/motoko_lsp.lua
+++ b/lua/lspconfig/configs/motoko_lsp.lua
@@ -16,8 +16,5 @@ https://github.com/dfinity/vscode-motoko
 
 Language server for the Motoko programming language.
     ]],
-    default_config = {
-      root_dir = [[root_pattern("dfx.json", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/move_analyzer.lua
+++ b/lua/lspconfig/configs/move_analyzer.lua
@@ -24,8 +24,5 @@ cargo install --git https://github.com/move-language/move move-analyzer
 
 See [`move-analyzer`'s doc](https://github.com/move-language/move/blob/1b258a06e3c7d2bc9174578aac92cca3ac19de71/language/move-analyzer/editors/code/README.md#how-to-install) for details.
     ]],
-    default_config = {
-      root_dir = [[root_pattern("Move.toml")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/msbuild_project_tools_server.lua
+++ b/lua/lspconfig/configs/msbuild_project_tools_server.lua
@@ -23,8 +23,5 @@ lspconfig.msbuild_project_tools_server.setup {
 ```
 
 ]],
-    default_config = {
-      root_dir = [[root_pattern('.git')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/mutt_ls.lua
+++ b/lua/lspconfig/configs/mutt_ls.lua
@@ -18,8 +18,5 @@ A language server for (neo)mutt's muttrc. It can be installed via pip.
 pip install mutt-language-server
 ```
   ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/neocmake.lua
+++ b/lua/lspconfig/configs/neocmake.lua
@@ -1,12 +1,11 @@
 local util = require 'lspconfig.util'
 
-local root_files = { '.git', 'build', 'cmake' }
 return {
   default_config = {
     cmd = { 'neocmakelsp', '--stdio' },
     filetypes = { 'cmake' },
     root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname)
+      return util.root_pattern(unpack({ '.git', 'build', 'cmake' }))(fname)
     end,
     single_file_support = true,
   },
@@ -28,8 +27,5 @@ require'lspconfig'.neocmake.setup {
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern('.git', 'cmake')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/nil_ls.lua
+++ b/lua/lspconfig/configs/nil_ls.lua
@@ -18,8 +18,5 @@ Check the repository README for more information.
 
 _See an example config at https://github.com/oxalica/nil/blob/main/dev/nvim-lsp.nix._
     ]],
-    default_config = {
-      root_dir = [[root_pattern("flake.nix", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/nixd.lua
+++ b/lua/lspconfig/configs/nixd.lua
@@ -18,8 +18,5 @@ Nix language server, based on nix libraries.
 If you are using Nix with Flakes support, run `nix profile install github:nix-community/nixd` to install.
 Check the repository README for more information.
     ]],
-    default_config = {
-      root_dir = [[root_pattern("flake.nix",".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/nomad_lsp.lua
+++ b/lua/lspconfig/configs/nomad_lsp.lua
@@ -29,8 +29,5 @@ However, a `hcl.nomad` or `nomad` filetype should be defined.
 
 Description of your jobs should be written in `.nomad` files for the LSP client to configure the server's `root_dir` configuration option.
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern("hcl.nomad", "nomad")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/ntt.lua
+++ b/lua/lspconfig/configs/ntt.lua
@@ -21,8 +21,5 @@ require('lspconfig').ntt.setup{
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/nushell.lua
+++ b/lua/lspconfig/configs/nushell.lua
@@ -13,8 +13,5 @@ https://github.com/nushell/nushell
 
 Nushell built-in language server.
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/nxls.lua
+++ b/lua/lspconfig/configs/nxls.lua
@@ -17,8 +17,5 @@ nxls, a language server for Nx Workspaces
 npm i -g nxls
 ```
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern]],
-    },
   },
 }

--- a/lua/lspconfig/configs/ocamlls.lua
+++ b/lua/lspconfig/configs/ocamlls.lua
@@ -15,8 +15,5 @@ https://github.com/ocaml-lsp/ocaml-language-server
 npm install -g ocaml-language-server
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("*.opam", "esy.json", "package.json")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/ocamllsp.lua
+++ b/lua/lspconfig/configs/ocamllsp.lua
@@ -31,8 +31,5 @@ To install the lsp server in a particular opam switch:
 opam install ocaml-lsp-server
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("*.opam", "esy.json", "package.json", ".git", "dune-project", "dune-workspace")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/ols.lua
+++ b/lua/lspconfig/configs/ols.lua
@@ -12,8 +12,5 @@ return {
 
            `Odin Language Server`.
         ]],
-    default_config = {
-      root_dir = [[util.root_pattern("ols.json", ".git", "*.odin")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/omnisharp.lua
+++ b/lua/lspconfig/configs/omnisharp.lua
@@ -137,8 +137,5 @@ require'lspconfig'.omnisharp.setup {
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("*.sln", "*.csproj", "omnisharp.json", "function.json")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/opencl_ls.lua
+++ b/lua/lspconfig/configs/opencl_ls.lua
@@ -14,8 +14,5 @@ Build instructions can be found [here](https://github.com/Galarius/opencl-langua
 
 Prebuilt binaries are available for Linux, macOS and Windows [here](https://github.com/Galarius/opencl-language-server/releases).
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/openedge_ls.lua
+++ b/lua/lspconfig/configs/openedge_ls.lua
@@ -48,8 +48,5 @@ require('lspconfig').['openedge_ls'].setup {
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern('openedge-project.json')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/pbls.lua
+++ b/lua/lspconfig/configs/pbls.lua
@@ -19,8 +19,5 @@ cargo install --git https://git.sr.ht/~rrc/pbls
 
 pbls is a Language Server for protobuf
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".pbls.toml", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/perlls.lua
+++ b/lua/lspconfig/configs/perlls.lua
@@ -31,8 +31,5 @@ https://github.com/richterger/Perl-LanguageServer/tree/master/clients/vscode/per
 
 To use the language server, ensure that you have Perl::LanguageServer installed and perl command is on your path.
 ]],
-    default_config = {
-      root_dir = "vim's starting directory",
-    },
   },
 }

--- a/lua/lspconfig/configs/perlpls.lua
+++ b/lua/lspconfig/configs/perlpls.lua
@@ -22,8 +22,5 @@ https://metacpan.org/pod/PLS
 
 To use the language server, ensure that you have PLS installed and that it is in your path
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/phan.lua
+++ b/lua/lspconfig/configs/phan.lua
@@ -32,9 +32,5 @@ https://github.com/phan/phan
 
 Installation: https://github.com/phan/phan#getting-started
 ]],
-    default_config = {
-      cmd = cmd,
-      root_dir = [[root_pattern("composer.json", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/phpactor.lua
+++ b/lua/lspconfig/configs/phpactor.lua
@@ -18,9 +18,5 @@ https://github.com/phpactor/phpactor
 
 Installation: https://phpactor.readthedocs.io/en/master/usage/standalone.html#global-installation
 ]],
-    default_config = {
-      cmd = { 'phpactor', 'language-server' },
-      root_dir = [[root_pattern("composer.json", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/pkgbuild_language_server.lua
+++ b/lua/lspconfig/configs/pkgbuild_language_server.lua
@@ -12,8 +12,5 @@ https://github.com/Freed-Wu/pkgbuild-language-server
 
 Language server for ArchLinux/Windows Msys2's PKGBUILD.
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/poryscript_pls.lua
+++ b/lua/lspconfig/configs/poryscript_pls.lua
@@ -13,8 +13,5 @@ https://github.com/huderlem/poryscript-pls
 
 Language server for poryscript (a high level scripting language for GBA-era Pokémon decompilation projects)
     ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/postgres_lsp.lua
+++ b/lua/lspconfig/configs/postgres_lsp.lua
@@ -13,8 +13,5 @@ https://github.com/supabase/postgres_lsp
 
 A Language Server for Postgres
         ]],
-    default_config = {
-      root_dir = [[util.root_pattern 'root-file.txt']],
-    },
   },
 }

--- a/lua/lspconfig/configs/powershell_es.lua
+++ b/lua/lspconfig/configs/powershell_es.lua
@@ -65,8 +65,5 @@ require'lspconfig'.powershell_es.setup{
 }
 ```
 ]],
-    default_config = {
-      root_dir = 'git root or current directory',
-    },
   },
 }

--- a/lua/lspconfig/configs/prismals.lua
+++ b/lua/lspconfig/configs/prismals.lua
@@ -20,8 +20,5 @@ Language Server for the Prisma JavaScript and TypeScript ORM
 npm install -g @prisma/language-server
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git", "package.json")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/prosemd_lsp.lua
+++ b/lua/lspconfig/configs/prosemd_lsp.lua
@@ -15,8 +15,5 @@ An experimental LSP for Markdown.
 
 Please see the manual installation instructions: https://github.com/kitten/prosemd-lsp#manual-installation
 ]],
-    default_config = {
-      root_dir = util.find_git_ancestor,
-    },
   },
 }

--- a/lua/lspconfig/configs/psalm.lua
+++ b/lua/lspconfig/configs/psalm.lua
@@ -15,9 +15,5 @@ Can be installed with composer.
 composer global require vimeo/psalm
 ```
 ]],
-    default_config = {
-      cmd = { 'psalm', '--language-server' },
-      root_dir = [[root_pattern("psalm.xml", "psalm.xml.dist")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/puppet.lua
+++ b/lua/lspconfig/configs/puppet.lua
@@ -31,8 +31,5 @@ Installation:
 
 - Ensure you can run `puppet-languageserver` from outside the editor-services directory.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("manifests", ".puppet-lint.rc", "hiera.yaml", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/purescriptls.lua
+++ b/lua/lspconfig/configs/purescriptls.lua
@@ -22,8 +22,5 @@ The `purescript-language-server` can be added to your project and `$PATH` via
 * JavaScript package manager such as npm, pnpm, Yarn, et al.
 * Nix under the `nodePackages` and `nodePackages_latest` package sets
 ]],
-    default_config = {
-      root_dir = [[root_pattern('bower.json', 'flake.nix', 'psc-package.json', 'shell.nix', 'spago.dhall', 'spago.yaml'),]],
-    },
   },
 }

--- a/lua/lspconfig/configs/r_language_server.lua
+++ b/lua/lspconfig/configs/r_language_server.lua
@@ -21,8 +21,5 @@ It is released on CRAN and can be easily installed by
 install.packages("languageserver")
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git") or os_homedir]],
-    },
   },
 }

--- a/lua/lspconfig/configs/regal.lua
+++ b/lua/lspconfig/configs/regal.lua
@@ -20,9 +20,5 @@ A linter for Rego, with support for running as an LSP server.
 go install github.com/StyraInc/regal@latest
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("*.rego", ".git")]],
-      single_file_support = true,
-    },
   },
 }

--- a/lua/lspconfig/configs/regols.lua
+++ b/lua/lspconfig/configs/regols.lua
@@ -20,9 +20,5 @@ OPA Rego language server.
 go install github.com/kitagry/regols@latest
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("*.rego", ".git")]],
-      single_file_support = true,
-    },
   },
 }

--- a/lua/lspconfig/configs/relay_lsp.lua
+++ b/lua/lspconfig/configs/relay_lsp.lua
@@ -101,10 +101,5 @@ return {
     }
     ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("relay.config.*", "package.json")]],
-      auto_start_compiler = false,
-      path_to_config = nil,
-    },
   },
 }

--- a/lua/lspconfig/configs/rls.lua
+++ b/lua/lspconfig/configs/rls.lua
@@ -35,8 +35,5 @@ If you want to use rls for a particular build, eg nightly, set cmd as follows:
 cmd = {"rustup", "run", "nightly", "rls"}
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("Cargo.toml")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/rnix.lua
+++ b/lua/lspconfig/configs/rnix.lua
@@ -21,8 +21,5 @@ To install manually, run `cargo install rnix-lsp`. If you are using nix, rnix-ls
 This server accepts configuration via the `settings` key.
 
     ]],
-    default_config = {
-      root_dir = "vim's starting directory",
-    },
   },
 }

--- a/lua/lspconfig/configs/robotframework_ls.lua
+++ b/lua/lspconfig/configs/robotframework_ls.lua
@@ -15,9 +15,5 @@ https://github.com/robocorp/robotframework-lsp
 
 Language Server Protocol implementation for Robot Framework.
 ]],
-    default_config = {
-      root_dir = "util.root_pattern('robotidy.toml', 'pyproject.toml', 'conda.yaml', 'robot.yaml')(fname)"
-        .. '\n  or util.find_git_ancestor(fname)',
-    },
   },
 }

--- a/lua/lspconfig/configs/roc_ls.lua
+++ b/lua/lspconfig/configs/roc_ls.lua
@@ -14,8 +14,5 @@ https://github.com/roc-lang/roc/tree/main/crates/language_server#roc_language_se
 The built-in language server for the Roc programming language.
 [Installation](https://github.com/roc-lang/roc/tree/main/crates/language_server#installing)
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/rome.lua
+++ b/lua/lspconfig/configs/rome.lua
@@ -30,8 +30,5 @@ Language server for the Rome Frontend Toolchain.
 npm install [-g] rome
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern('package.json', 'node_modules', '.git')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/rubocop.lua
+++ b/lua/lspconfig/configs/rubocop.lua
@@ -10,8 +10,5 @@ return {
     description = [[
 https://github.com/rubocop/rubocop
     ]],
-    default_config = {
-      root_dir = [[root_pattern("Gemfile", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/ruby_lsp.lua
+++ b/lua/lspconfig/configs/ruby_lsp.lua
@@ -26,8 +26,5 @@ group :development do
 end
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("Gemfile", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/ruff.lua
+++ b/lua/lspconfig/configs/ruff.lua
@@ -1,16 +1,10 @@
 local util = require 'lspconfig.util'
 
-local root_files = {
-  'pyproject.toml',
-  'ruff.toml',
-  '.ruff.toml',
-}
-
 return {
   default_config = {
     cmd = { 'ruff', 'server' },
     filetypes = { 'python' },
-    root_dir = util.root_pattern(unpack(root_files)) or util.find_git_ancestor(),
+    root_dir = util.root_pattern('pyproject.toml', 'ruff.toml', '.ruff.toml') or util.find_git_ancestor(),
     single_file_support = true,
     settings = {},
   },
@@ -43,6 +37,5 @@ require('lspconfig').ruff.setup({
 Refer to the [documentation](https://docs.astral.sh/ruff/editors/) for more details.
 
   ]],
-    root_dir = [[root_pattern("pyproject.toml", "ruff.toml", ".ruff.toml", ".git")]],
   },
 }

--- a/lua/lspconfig/configs/ruff_lsp.lua
+++ b/lua/lspconfig/configs/ruff_lsp.lua
@@ -1,15 +1,10 @@
 local util = require 'lspconfig.util'
 
-local root_files = {
-  'pyproject.toml',
-  'ruff.toml',
-}
-
 return {
   default_config = {
     cmd = { 'ruff-lsp' },
     filetypes = { 'python' },
-    root_dir = util.root_pattern(unpack(root_files)) or util.find_git_ancestor(),
+    root_dir = util.root_pattern('pyproject.toml', 'ruff.toml') or util.find_git_ancestor(),
     single_file_support = true,
     settings = {},
   },
@@ -37,6 +32,5 @@ require'lspconfig'.ruff_lsp.setup{
 ```
 
   ]],
-    root_dir = [[root_pattern("pyproject.toml", "ruff.toml", ".git")]],
   },
 }

--- a/lua/lspconfig/configs/rune_languageserver.lua
+++ b/lua/lspconfig/configs/rune_languageserver.lua
@@ -14,8 +14,5 @@ https://crates.io/crates/rune-languageserver
 A language server for the [Rune](https://rune-rs.github.io/) Language,
 an embeddable dynamic programming language for Rust
         ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/rust_analyzer.lua
+++ b/lua/lspconfig/configs/rust_analyzer.lua
@@ -115,8 +115,5 @@ require'lspconfig'.rust_analyzer.setup{
 Note: do not set `init_options` for this LS config, it will be automatically populated by the contents of settings["rust-analyzer"] per
 https://github.com/rust-lang/rust-analyzer/blob/eb5da56d839ae0a9e9f50774fa3eb78eb0964550/docs/dev/lsp-extensions.md?plain=1#L26.
     ]],
-    default_config = {
-      root_dir = [[root_pattern("Cargo.toml", "rust-project.json")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/salt_ls.lua
+++ b/lua/lspconfig/configs/salt_ls.lua
@@ -17,8 +17,5 @@ The language server can be installed with `pip`:
 pip install salt-lsp
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern('.git')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/scry.lua
+++ b/lua/lspconfig/configs/scry.lua
@@ -15,8 +15,5 @@ https://github.com/crystal-lang-tools/scry
 
 Crystal language server.
 ]],
-    default_config = {
-      root_dir = [[root_pattern('shard.yml', '.git')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/serve_d.lua
+++ b/lua/lspconfig/configs/serve_d.lua
@@ -13,8 +13,5 @@ return {
            `Microsoft language server protocol implementation for D using workspace-d.`
            Download a binary from https://github.com/Pure-D/serve-d/releases and put it in your $PATH.
         ]],
-    default_config = {
-      root_dir = [[util.root_pattern("dub.json", "dub.sdl", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/slangd.lua
+++ b/lua/lspconfig/configs/slangd.lua
@@ -37,8 +37,5 @@ require('lspconfig').slangd.setup{
 Available options are documented [here](https://github.com/shader-slang/slang-vscode-extension/tree/main?tab=readme-ov-file#configurations)
 or in more detail [here](https://github.com/shader-slang/slang-vscode-extension/blob/main/package.json#L70).
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/smithy_ls.lua
+++ b/lua/lspconfig/configs/smithy_ls.lua
@@ -3,19 +3,12 @@ local util = require 'lspconfig.util'
 -- pass 0 as the first argument to use STDIN/STDOUT for communication
 local cmd = { 'smithy-language-server', '0' }
 
-local root_files = {
-  'smithy-build.json',
-  'build.gradle',
-  'build.gradle.kts',
-  '.git',
-}
-
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'smithy' },
     single_file_support = true,
-    root_dir = util.root_pattern(unpack(root_files)),
+    root_dir = util.root_pattern('smithy-build.json', 'build.gradle', 'build.gradle.kts', '.git'),
   },
   docs = {
     description = [[
@@ -23,8 +16,5 @@ https://github.com/awslabs/smithy-language-server
 
 `Smithy Language Server`, A Language Server Protocol implementation for the Smithy IDL
 ]],
-    default_config = {
-      root_dir = [[root_pattern("smithy-build.json", "build.gradle", "build.gradle.kts", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/snyk_ls.lua
+++ b/lua/lspconfig/configs/snyk_ls.lua
@@ -19,6 +19,7 @@ return {
     },
     single_file_support = true,
     settings = {},
+    -- Configuration from https://github.com/snyk/snyk-ls#configuration-1
     init_options = {
       activateSnykCode = 'true',
     },
@@ -29,9 +30,5 @@ https://github.com/snyk/snyk-ls
 
 LSP for Snyk Open Source, Snyk Infrastructure as Code, and Snyk Code.
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git", ".snyk")]],
-      init_options = 'Configuration from https://github.com/snyk/snyk-ls#configuration-1',
-    },
   },
 }

--- a/lua/lspconfig/configs/solang.lua
+++ b/lua/lspconfig/configs/solang.lua
@@ -20,8 +20,5 @@ The language server only provides the following capabilities:
 There is currently no support for completion, goto definition, references, or other functionality.
 
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/solargraph.lua
+++ b/lua/lspconfig/configs/solargraph.lua
@@ -24,8 +24,5 @@ You can install solargraph via gem install.
 gem install --user-install solargraph
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("Gemfile", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/solc.lua
+++ b/lua/lspconfig/configs/solc.lua
@@ -12,8 +12,5 @@ https://docs.soliditylang.org/en/latest/installing-solidity.html
 
 solc is the native language server for the Solidity language.
 ]],
-    default_config = {
-      root_dir = [[root_pattern('hardhat.config.*', '.git')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/solidity.lua
+++ b/lua/lspconfig/configs/solidity.lua
@@ -42,8 +42,5 @@ After installing with package.json, just create a `remappings.txt` with:
 
 You can omit the node_modules as well.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("package.json", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/solidity_ls.lua
+++ b/lua/lspconfig/configs/solidity_ls.lua
@@ -29,8 +29,5 @@ npm install -g vscode-solidity-server
 
 `vscode-solidity-server` is a language server for the Solidity language ported from the VSCode "solidity" extension.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("]] .. table.concat(root_files, '", "') .. [[", ".git", "package.json")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/solidity_ls_nomicfoundation.lua
+++ b/lua/lspconfig/configs/solidity_ls_nomicfoundation.lua
@@ -29,8 +29,5 @@ npm install -g @nomicfoundation/solidity-language-server
 
 A language server for the Solidity programming language, built by the Nomic Foundation for the Ethereum community.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("]] .. table.concat(root_files, '", "') .. [[", ".git", "package.json")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/somesass_ls.lua
+++ b/lua/lspconfig/configs/somesass_ls.lua
@@ -33,8 +33,5 @@ The language server provides:
 - Suggestions and hover info for built-in Sass modules, when used with @use.
 
 ]],
-    default_config = {
-      root_dir = [[root_pattern("package.json", ".git") or bufdir]],
-    },
   },
 }

--- a/lua/lspconfig/configs/sorbet.lua
+++ b/lua/lspconfig/configs/sorbet.lua
@@ -19,8 +19,5 @@ Sorbet up for new projects: https://sorbet.org/docs/adopting.
 gem install sorbet
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern("Gemfile", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/sourcekit.lua
+++ b/lua/lspconfig/configs/sourcekit.lua
@@ -22,8 +22,5 @@ https://github.com/apple/sourcekit-lsp
 
 Language server for Swift and C/C++/Objective-C.
     ]],
-    default_config = {
-      root_dir = [[root_pattern("buildServer.json", "*.xcodeproj", "*.xcworkspace", "compile_commands.json", "Package.swift", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/standardrb.lua
+++ b/lua/lspconfig/configs/standardrb.lua
@@ -12,8 +12,5 @@ https://github.com/testdouble/standard
 
 Ruby Style Guide, with linter & automatic code fixer.
     ]],
-    default_config = {
-      root_dir = [[root_pattern("Gemfile", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/statix.lua
+++ b/lua/lspconfig/configs/statix.lua
@@ -13,8 +13,5 @@ https://github.com/nerdypepper/statix
 
 lints and suggestions for the nix programming language
     ]],
-    default_config = {
-      root_dir = [[root_pattern("flake.nix", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/steep.lua
+++ b/lua/lspconfig/configs/steep.lua
@@ -14,8 +14,5 @@ https://github.com/soutaro/steep
 
 You need `Steepfile` to make it work. Generate it with `steep init`.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("Steepfile", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/superhtml.lua
+++ b/lua/lspconfig/configs/superhtml.lua
@@ -25,8 +25,5 @@ require'lspconfig'.superhtml.setup {
 }
 ```
         ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/svelte.lua
+++ b/lua/lspconfig/configs/svelte.lua
@@ -17,8 +17,5 @@ Note: assuming that [ts_ls](#ts_ls) is setup, full JavaScript/TypeScript support
 npm install -g svelte-language-server
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("package.json", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/svlangserver.lua
+++ b/lua/lspconfig/configs/svlangserver.lua
@@ -51,8 +51,5 @@ Language server for SystemVerilog.
 $ npm install -g @imc-trading/svlangserver
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".svlangserver", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/svls.lua
+++ b/lua/lspconfig/configs/svls.lua
@@ -17,8 +17,5 @@ Language server for verilog and SystemVerilog
  cargo install svls
  ```
     ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/swift_mesonls.lua
+++ b/lua/lspconfig/configs/swift_mesonls.lua
@@ -12,8 +12,5 @@ https://github.com/JCWasmx86/Swift-MesonLSP
 
 Meson language server written in Swift
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern("meson.build", "meson_options.txt", "meson.options", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/syntax_tree.lua
+++ b/lua/lspconfig/configs/syntax_tree.lua
@@ -21,8 +21,5 @@ build formatters, linters, language servers, and more.
 gem install syntax_tree
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern(".streerc", "Gemfile", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/tailwindcss.lua
+++ b/lua/lspconfig/configs/tailwindcss.lua
@@ -123,8 +123,5 @@ Tailwind CSS Language Server can be installed via npm:
 npm install -g @tailwindcss/language-server
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern('tailwind.config.js', 'tailwind.config.cjs', 'tailwind.config.mjs', 'tailwind.config.ts', 'postcss.config.js', 'postcss.config.cjs', 'postcss.config.mjs', 'postcss.config.ts', 'package.json', 'node_modules', '.git')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/taplo.lua
+++ b/lua/lspconfig/configs/taplo.lua
@@ -18,8 +18,5 @@ Language server for Taplo, a TOML toolkit.
 cargo install --features lsp --locked taplo-cli
 ```
     ]],
-    default_config = {
-      root_dir = [[root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/teal_ls.lua
+++ b/lua/lspconfig/configs/teal_ls.lua
@@ -24,8 +24,5 @@ Optional Command Args:
 * "--log-mode=by_proj_path" - Enable logging in $HOME/.cache/teal-language-server. Log name will be project path + pid of process
 * "--verbose=true" - Increases log level.  Does nothing unless log-mode is set
 ]],
-    default_config = {
-      root_dir = [[root_pattern("tlconfig.lua")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/templ.lua
+++ b/lua/lspconfig/configs/templ.lua
@@ -14,8 +14,5 @@ https://templ.guide
 
 The official language server for the templ HTML templating language.
 ]],
-    default_config = {
-      root_dir = [[root_pattern('go.work', 'go.mod', '.git')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/terraform_lsp.lua
+++ b/lua/lspconfig/configs/terraform_lsp.lua
@@ -36,8 +36,5 @@ choice:
     - configs designed for other 0.12 versions may work, but interpretation may be inaccurate
   - less stability (due to reliance on Terraform's own internal packages)
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".terraform", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/terraformls.lua
+++ b/lua/lspconfig/configs/terraformls.lua
@@ -40,8 +40,5 @@ Note, that the `settings` configuration option uses the `workspace/didChangeConf
 Instead you should use `init_options` which passes the settings as part of the LSP initialize call
 [as is required by terraform-ls](https://github.com/hashicorp/terraform-ls/blob/main/docs/SETTINGS.md#how-to-pass-settings).
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".terraform", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/tflint.lua
+++ b/lua/lspconfig/configs/tflint.lua
@@ -13,8 +13,5 @@ https://github.com/terraform-linters/tflint
 A pluggable Terraform linter that can act as lsp server.
 Installation instructions can be found in https://github.com/terraform-linters/tflint#installation.
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".terraform", ".git", ".tflint.hcl")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/thriftls.lua
+++ b/lua/lspconfig/configs/thriftls.lua
@@ -13,8 +13,5 @@ https://github.com/joyme123/thrift-ls
 
 you can install thriftls by mason or download binary here: https://github.com/joyme123/thrift-ls/releases
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".thrift")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/tilt_ls.lua
+++ b/lua/lspconfig/configs/tilt_ls.lua
@@ -19,8 +19,5 @@ You might need to add filetype detection manually:
 autocmd BufRead Tiltfile setf=tiltfile
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern(".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/tsp_server.lua
+++ b/lua/lspconfig/configs/tsp_server.lua
@@ -17,8 +17,5 @@ The language server for TypeSpec, a language for defining cloud service APIs and
 npm install -g @typespec/compiler
 ```
 ]],
-    default_config = {
-      root_dir = [[util.root_pattern("tspconfig.yaml", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/twiggy_language_server.lua
+++ b/lua/lspconfig/configs/twiggy_language_server.lua
@@ -16,8 +16,5 @@ https://github.com/moetelo/twiggy
 npm install -g twiggy-language-server
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("composer.json", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/ungrammar_languageserver.lua
+++ b/lua/lspconfig/configs/ungrammar_languageserver.lua
@@ -27,8 +27,5 @@ Ungrammar Language Server can be installed via npm:
 npm i ungrammar-languageserver -g
 ```
     ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/unocss.lua
+++ b/lua/lspconfig/configs/unocss.lua
@@ -42,8 +42,5 @@ UnoCSS Language Server can be installed via npm:
 npm i unocss-language-server -g
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern('unocss.config.js', 'unocss.config.ts', 'uno.config.js', 'uno.config.ts')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/uvls.lua
+++ b/lua/lspconfig/configs/uvls.lua
@@ -22,8 +22,5 @@ You can add it via:
 vim.cmd([[au BufRead,BufNewFile *.uvl setfiletype uvl]])
 ```
 ]=],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/v_analyzer.lua
+++ b/lua/lspconfig/configs/v_analyzer.lua
@@ -14,8 +14,5 @@ V language server.
 
 `v-analyzer` can be installed by following the instructions [here](https://github.com/vlang/v-analyzer#installation).
 ]],
-    default_config = {
-      root_dir = [[root_pattern("v.mod", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/vala_ls.lua
+++ b/lua/lspconfig/configs/vala_ls.lua
@@ -33,8 +33,5 @@ return {
   },
   docs = {
     description = 'https://github.com/Prince781/vala-language-server',
-    default_config = {
-      root_dir = [[root_pattern("meson.build", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/vdmj.lua
+++ b/lua/lspconfig/configs/vdmj.lua
@@ -79,20 +79,6 @@ More settings for VDMJ can be changed in a file called `vdmj.properties` under
 Note: proof obligations and combinatorial testing are not currently supported
 by neovim.
 ]],
-    default_config = {
-      cmd = 'Generated from the options given',
-      root_dir = 'util.find_git_ancestor(fname) or find_vscode_ancestor(fname)',
-      options = {
-        java = '$JAVA_HOME/bin/java',
-        java_opts = { '-Xmx3000m', '-Xss1m' },
-        annotation_paths = {},
-        mavenrepo = '$HOME/.m2/repository/dk/au/ece/vdmj',
-        version = 'The latest version installed in `mavenrepo`',
-        logfile = "path.join(vim.fn.stdpath 'cache', 'vdm-lsp.log')",
-        debugger_port = -1,
-        high_precision = false,
-      },
-    },
   },
   on_new_config = function(config, root_dir)
     local version = with_precision(

--- a/lua/lspconfig/configs/veryl_ls.lua
+++ b/lua/lspconfig/configs/veryl_ls.lua
@@ -17,8 +17,5 @@ Language server for Veryl
  cargo install veryl-ls
  ```
     ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/visualforce_ls.lua
+++ b/lua/lspconfig/configs/visualforce_ls.lua
@@ -31,8 +31,5 @@ require'lspconfig'.visualforce_ls.setup {
 }
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern('sfdx-project.json')]],
-    },
   },
 }

--- a/lua/lspconfig/configs/vls.lua
+++ b/lua/lspconfig/configs/vls.lua
@@ -14,8 +14,5 @@ V language server.
 
 `v-language-server` can be installed by following the instructions [here](https://github.com/vlang/vls#installation).
 ]],
-    default_config = {
-      root_dir = [[root_pattern("v.mod", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/vtsls.lua
+++ b/lua/lspconfig/configs/vtsls.lua
@@ -28,8 +28,5 @@ To configure a TypeScript project, add a
 or [`jsconfig.json`](https://code.visualstudio.com/docs/languages/jsconfig) to
 the root of your project.
 ]],
-    default_config = {
-      root_dir = [[root_pattern("tsconfig.json", "package.json", "jsconfig.json", ".git")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/vuels.lua
+++ b/lua/lspconfig/configs/vuels.lua
@@ -54,8 +54,5 @@ Vue language server(vls)
 npm install -g vls
 ```
 ]],
-    default_config = {
-      root_dir = [[root_pattern("package.json", "vue.config.js")]],
-    },
   },
 }

--- a/lua/lspconfig/configs/yamlls.lua
+++ b/lua/lspconfig/configs/yamlls.lua
@@ -73,8 +73,5 @@ require('lspconfig').yamlls.setup {
 ```
 
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }

--- a/lua/lspconfig/configs/ziggy.lua
+++ b/lua/lspconfig/configs/ziggy.lua
@@ -14,8 +14,5 @@ https://ziggy-lang.io/documentation/ziggy-lsp/
 Language server for the Ziggy data serialization format
 
 ]],
-    default_config = {
-      root_dir = [[util.find_git_ancestor]],
-    },
   },
 }


### PR DESCRIPTION
Problem:
default_config duplicated in `docs` items.

Solution:
delete it. docgen autogenerates this now.

followup to:
- https://github.com/neovim/nvim-lspconfig/pull/3396
- https://github.com/neovim/nvim-lspconfig/pull/3397