### PR TITLE
fix(health): "root directory" not reported

### DIFF
--- a/lua/lspconfig/health.lua
+++ b/lua/lspconfig/health.lua
@@ -88,9 +88,11 @@ local function fmtpath(p)
   if vim.startswith(p, 'Running') then
     return p
   end
+  local isdir = 0 ~= vim.fn.isdirectory(vim.fn.expand(p))
   local r = vim.fn.fnamemodify(p, ':~')
-  -- If the path ends with "~" add a space (:checkhealth currently uses ft=help).
-  return r .. (vim.endswith(r, '~') and ' ' or '')
+  -- Force directory path to end with "/".
+  -- Bonus: avoids wrong highlighting for "~" (because :checkhealth currently uses ft=help).
+  return r .. ((isdir and not r:find('[/\\\\]%s*$')) and '/' or '')
 end
 
 local cmd_type = {
@@ -205,17 +207,16 @@ local function make_client_info(client, fname)
       end
     end
   end
-
   if not client_info.root_dir then
     client_info.root_dir = 'Running in single file mode.'
   end
-  client_info.attached_buffers_list = table.concat(vim.lsp.get_buffers_by_client_id(client.id), ', ')
 
-  table.insert(
-    info_lines,
-    1,
-    ('Client: %s (id: %s, bufnr: [%s])'):format(client.name, client.id, client_info.attached_buffers_list)
-  )
+  client_info.attached_bufs = table.concat(vim.lsp.get_buffers_by_client_id(client.id), ', ')
+
+  info_lines = vim.list_extend({
+    ('Client: `%s` (id: %s, bufnr: [%s])'):format(client.name, client.id, client_info.attached_bufs),
+    'root directory:    ' .. fmtpath(client_info.root_dir),
+  }, info_lines)
 
   return table.concat(info_lines, '\n')
 end


### PR DESCRIPTION
Problem:
"root directory" not reported.

Solution:
report root_dir. regression from b55b9659de9ac17e05df4787bb023e4c7ef45329