### PR TITLE
fix(dprint): add graphql to filetypes

### DIFF
--- a/lua/lspconfig/configs/dprint.lua
+++ b/lua/lspconfig/configs/dprint.lua
@@ -15,6 +15,7 @@ return {
       'toml',
       'rust',
       'roslyn',
+      'graphql',
     },
     root_dir = util.root_pattern('dprint.json', '.dprint.json', 'dprint.jsonc', '.dprint.jsonc'),
     single_file_support = true,


### PR DESCRIPTION
`dprint` is also a formatter for GraphQL files.