### PR TITLE
fix(fennel-ls): enable single_file_support

### DIFF
--- a/lua/lspconfig/configs/fennel_ls.lua
+++ b/lua/lspconfig/configs/fennel_ls.lua
@@ -12,6 +12,7 @@ return {
       return util.search_ancestors(dir, has_fls_project_cfg) or vim.fs.root(0, '.git')
     end,
     settings = {},
+    single_file_support = true,
     capabilities = {
       offsetEncoding = { 'utf-8', 'utf-16' },
     },


### PR DESCRIPTION
## Context
`fennel-ls` will not load when a configuration file is not present, i.e. `flsproject.fnl`. This fixes that by adding `single_file_support`.

This PR addresses comments on from my [first attempted PR](https://github.com/neovim/nvim-lspconfig/pull/3389).

## Changes
* Add `single_file_support` to `fennel-ls`.