### PR TITLE
chore(ruff_lsp): deprecate ruff_lsp in favour of ruff

### DIFF
--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -19,6 +19,10 @@ local aliases = {
     to = 'ruby_lsp',
     version = '0.2.1',
   },
+  ruff_lsp = {
+    to = 'ruff',
+    version = '0.2.1',
+  },
   ['starlark-rust'] = {
     to = 'starlark_rust',
     version = '0.2.1',


### PR DESCRIPTION
`ruff server` has been stable for some time now. Related to:

- #3241