### PR TITLE
feat: add the official Nextflow Language Server (`nextflow_ls`)

### DIFF
--- a/lua/lspconfig/configs/nextflow_ls.lua
+++ b/lua/lspconfig/configs/nextflow_ls.lua
@@ -22,7 +22,7 @@ https://github.com/nextflow-io/language-server
 Requirements:
  - Java 17+
 
-`nextflow_ls` can be installed by following the instructions [here](https://github.com/nextflow-io/language-server.git#development).
+`nextflow_ls` can be installed by following the instructions [here](https://github.com/nextflow-io/language-server#development).
 
 If you have installed nextflow language server, you can set the `cmd` custom path as follow:
 

--- a/lua/lspconfig/configs/nextflow_ls.lua
+++ b/lua/lspconfig/configs/nextflow_ls.lua
@@ -17,7 +17,7 @@ return {
   },
   docs = {
     description = [[
-https://github.com/nextflow-io/language-server.git
+https://github.com/nextflow-io/language-server
 
 Requirements:
  - Java 17+

--- a/lua/lspconfig/configs/nextflow_ls.lua
+++ b/lua/lspconfig/configs/nextflow_ls.lua
@@ -1,0 +1,37 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'java', '-jar', 'nextflow-language-server-all.jar' },
+    filetypes = { 'nextflow' },
+    root_dir = function(fname)
+      return util.root_pattern('nextflow.config')(fname) or util.find_git_ancestor(fname)
+    end,
+    settings = {
+      nextflow = {
+        files = {
+          exclude = { '.git', '.nf-test', 'work' },
+        },
+      },
+    },
+  },
+  docs = {
+    description = [[
+https://github.com/nextflow-io/language-server.git
+
+Requirements:
+ - Java 17+
+
+`nextflow_ls` can be installed by following the instructions [here](https://github.com/nextflow-io/language-server.git#development).
+
+If you have installed nextflow language server, you can set the `cmd` custom path as follow:
+
+```lua
+require'lspconfig'.nextflow_ls.setup{
+    cmd = { "java", "-jar", "path/to/nextflow_ls/language-server-all.jar" },
+    ...
+}
+```
+]],
+  },
+}

--- a/lua/lspconfig/configs/nextflow_ls.lua
+++ b/lua/lspconfig/configs/nextflow_ls.lua
@@ -26,8 +26,16 @@ If you have installed nextflow language server, you can set the `cmd` custom pat
 
 ```lua
 require'lspconfig'.nextflow_ls.setup{
-    cmd = { "java", "-jar", "path/to/nextflow_ls/language-server-all.jar" },
-    ...
+    cmd = { 'java', '-jar', 'nextflow-language-server-all.jar' },
+    filetypes = { 'nextflow' },
+    root_dir = util.root_pattern('nextflow.config', '.git'),
+    settings = {
+      nextflow = {
+        files = {
+          exclude = { '.git', '.nf-test', 'work' },
+        },
+      },
+    },
 }
 ```
 ]],

--- a/lua/lspconfig/configs/nextflow_ls.lua
+++ b/lua/lspconfig/configs/nextflow_ls.lua
@@ -4,9 +4,7 @@ return {
   default_config = {
     cmd = { 'java', '-jar', 'nextflow-language-server-all.jar' },
     filetypes = { 'nextflow' },
-    root_dir = function(fname)
-      return util.root_pattern('nextflow.config')(fname) or util.find_git_ancestor(fname)
-    end,
+    root_dir = util.root_pattern('nextflow.config', '.git'),
     settings = {
       nextflow = {
         files = {


### PR DESCRIPTION
This adds a configuration for the official language server for the Nextflow scientific pipeline language.

This language server is relatively new, but is part of an initiative to modernize their editor language support. It is an industry standard tool for developing scientific pipelines especially in the epidemiology/genomics community both academic and industry. It is an officially supported project by the language's organization so I'm hoping that is enough to vet it for getting added.