### PR TITLE
fix(texlab): use exec_cmd method

### DIFF
--- a/lua/lspconfig/configs/texlab.lua
+++ b/lua/lspconfig/configs/texlab.lua
@@ -1,5 +1,4 @@
 local util = require 'lspconfig.util'
-local nvim_eleven = vim.fn.has 'nvim-0.11' == 1
 
 local texlab_build_status = {
   [0] = 'Success',

--- a/lua/lspconfig/configs/texlab.lua
+++ b/lua/lspconfig/configs/texlab.lua
@@ -1,4 +1,5 @@
 local util = require 'lspconfig.util'
+local nvim_eleven = vim.fn.has 'nvim-0.11' == 1
 
 local texlab_build_status = {
   [0] = 'Success',
@@ -52,8 +53,14 @@ end
 
 local function buf_cancel_build()
   local bufnr = vim.api.nvim_get_current_buf()
-  if not util.get_active_client_by_name(bufnr, 'texlab') then
+  local client = util.get_active_client_by_name(bufnr, 'texlab')
+  if not client then
     return vim.notify('Texlab client not found', vim.log.levels.ERROR)
+  end
+  if nvim_eleven == 1 then
+    return client:exec_cmd({
+      command = 'texlab.cancelBuild',
+    }, { bufnr = bufnr })
   end
   vim.lsp.buf.execute_command { command = 'texlab.cancelBuild' }
   vim.notify('Build cancelled', vim.log.levels.INFO)

--- a/lua/lspconfig/configs/texlab.lua
+++ b/lua/lspconfig/configs/texlab.lua
@@ -57,7 +57,7 @@ local function buf_cancel_build()
   if not client then
     return vim.notify('Texlab client not found', vim.log.levels.ERROR)
   end
-  if nvim_eleven == 1 then
+  if vim.fn.has 'nvim-0.11' == 1 then
     return client:exec_cmd({
       command = 'texlab.cancelBuild',
     }, { bufnr = bufnr })

--- a/lua/lspconfig/configs/texlab.lua
+++ b/lua/lspconfig/configs/texlab.lua
@@ -58,6 +58,7 @@ local function buf_cancel_build()
   end
   if vim.fn.has 'nvim-0.11' == 1 then
     return client:exec_cmd({
+      title = 'cancel',
       command = 'texlab.cancelBuild',
     }, { bufnr = bufnr })
   end


### PR DESCRIPTION
Problem: vim.lsp.buf.execute_command has been deprecated

For more info see #3426.