### PR TITLE
Add support using erb files to ruby-lsp

### DIFF
--- a/lua/lspconfig/configs/ruby_lsp.lua
+++ b/lua/lspconfig/configs/ruby_lsp.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'ruby-lsp' },
-    filetypes = { 'ruby' },
+    filetypes = { 'ruby', 'eruby' },
     root_dir = util.root_pattern('Gemfile', '.git'),
     init_options = {
       formatter = 'auto',


### PR DESCRIPTION
Ruby LSP has added support for ERB documents: https://shopify.github.io/ruby-lsp/#erb-support
I think it would be nice to add the filetype eruby to the ruby_lsp server config