### PR TITLE
bug with opening projects embedded in other projects

### DIFF
--- a/lua/lspconfig/manager.lua
+++ b/lua/lspconfig/manager.lua
@@ -5,23 +5,6 @@ local uv = vim.uv or vim.loop
 local async = require 'lspconfig.async'
 local util = require 'lspconfig.util'
 
----@param client vim.lsp.Client
----@param root_dir string
----@return boolean
-local function check_in_workspace(client, root_dir)
-  if not client.workspace_folders then
-    return false
-  end
-
-  for _, dir in ipairs(client.workspace_folders) do
-    if (root_dir .. '/'):sub(1, #dir.name + 1) == dir.name .. '/' then
-      return true
-    end
-  end
-
-  return false
-end
-
 --- @class lspconfig.Manager
 --- @field _clients table<string,integer[]>
 --- @field config lspconfig.Config
@@ -168,10 +151,6 @@ end
 --- @param client vim.lsp.Client
 --- @param single_file boolean
 function M:_attach_or_spawn(bufnr, new_config, root_dir, client, single_file)
-  if check_in_workspace(client, root_dir) then
-    return self:_attach_and_cache(bufnr, root_dir, client.id)
-  end
-
   local supported = vim.tbl_get(client, 'server_capabilities', 'workspace', 'workspaceFolders', 'supported')
   if supported then
     return self:_register_workspace_folders(bufnr, root_dir, client)


### PR DESCRIPTION
In the following senario;

```
outter project/
├─ .git
├─ README.me
├─ src/
├─ inner project/
│  ├─ .git
│  ├─ README.me
│  ├─ src/
```

Assuming both the `outter project` and `inner project` are of the same langauge;
if you were to open the `outter project` first, then open the `inner project`, both projects would have the same `root directory`

This is causing issues with other plugins that rely on `root directory` to be accurate; 
https://github.com/ahmedkhalf/project.nvim/blob/8c6bad7d22eef1b71144b401c9f74ed01526a4fb/lua/project_nvim/project.lua#L25

This commit fixes the above described issue