### PR TITLE
feat(vale_ls): add reStructuredText to filetypes

### DIFF
--- a/lua/lspconfig/configs/vale_ls.lua
+++ b/lua/lspconfig/configs/vale_ls.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'vale-ls' },
-    filetypes = { 'markdown', 'text', 'tex' },
+    filetypes = { 'markdown', 'text', 'tex', 'rst' },
     root_dir = util.root_pattern '.vale.ini',
     single_file_support = true,
   },


### PR DESCRIPTION
Vale supports parsing reStructuredText files, as documented here: https://vale.sh/docs/topics/scoping/#restructuredtext

It uses rst2html in the background.