### PR TITLE
fix: offset_encoding is required now in `make_position_params`

### DIFF
--- a/lua/lspconfig/configs/clangd.lua
+++ b/lua/lspconfig/configs/clangd.lua
@@ -27,7 +27,8 @@ local function symbol_info()
   if not clangd_client or not clangd_client.supports_method 'textDocument/symbolInfo' then
     return vim.notify('Clangd client not found', vim.log.levels.ERROR)
   end
-  local params = vim.lsp.util.make_position_params()
+  local win = vim.api.nvim_get_current_win()
+  local params = vim.lsp.util.make_position_params(win, clangd_client.offset_encoding)
   clangd_client.request('textDocument/symbolInfo', params, function(err, res)
     if err or #res == 0 then
       -- Clangd always returns an error, there is not reason to parse it

--- a/lua/lspconfig/configs/texlab.lua
+++ b/lua/lspconfig/configs/texlab.lua
@@ -12,7 +12,9 @@ local function client_with_fn(fn)
 end
 
 local function buf_build(client, bufnr)
-  client.request('textDocument/build', vim.lsp.util.make_position_params(), function(err, result)
+  local win = vim.api.nvim_get_current_win()
+  local params = vim.lsp.util.make_position_params(win, client.offset_encoding)
+  client.request('textDocument/build', params, function(err, result)
     if err then
       error(tostring(err))
     end
@@ -27,7 +29,9 @@ local function buf_build(client, bufnr)
 end
 
 local function buf_search(client, bufnr)
-  client.request('textDocument/forwardSearch', vim.lsp.util.make_position_params(), function(err, result)
+  local win = vim.api.nvim_get_current_win()
+  local params = vim.lsp.util.make_position_params(win, client.offset_encoding)
+  client.request('textDocument/forwardSearch', params, function(err, result)
     if err then
       error(tostring(err))
     end
@@ -91,9 +95,10 @@ local function command_factory(cmd)
 end
 
 local function buf_find_envs(client, bufnr)
+  local win = vim.api.nvim_get_current_win()
   client.request('workspace/executeCommand', {
     command = 'texlab.findEnvironments',
-    arguments = { vim.lsp.util.make_position_params() },
+    arguments = { vim.lsp.util.make_position_params(win, client.offset_encoding) },
   }, function(err, result)
     if err then
       return vim.notify(err.code .. ': ' .. err.message, vim.log.levels.ERROR)


### PR DESCRIPTION
Adapt to the upstream change https://github.com/neovim/neovim/commit/629483e24eed3f2c07e55e0540c553361e0345a2 to get rid of the warning message "warning: offset_encoding is required, using the offset_encoding from the first client".