### PR TITLE
fix(lua_ls): don't set user config dir as root

### DIFF
--- a/lua/lspconfig/configs/lua_ls.lua
+++ b/lua/lspconfig/configs/lua_ls.lua
@@ -16,7 +16,7 @@ return {
     filetypes = { 'lua' },
     root_dir = function(fname)
       local root = util.root_pattern(unpack(root_files))(fname)
-      if root and root ~= vim.env.HOME then
+      if root and root ~= vim.env.HOME and root ~= (vim.env.CONFIG or vim.env.HOME .. '.config') then
         return root
       end
       local root_lua = util.root_pattern 'lua/'(fname) or ''


### PR DESCRIPTION
root_files may be in user's config dir which causes lua_ls to recursievly scan all config dirs, if you edit lua file like this: ~/.config/awesome/rc.lua