### PR TITLE
fix: outdated references to 'lspconfig.ui.windows'

### DIFF
--- a/lua/lspconfig/configs/clangd.lua
+++ b/lua/lspconfig/configs/clangd.lua
@@ -41,7 +41,7 @@ local function symbol_info()
       width = math.max(string.len(name), string.len(container)),
       focusable = false,
       focus = false,
-      border = require('lspconfig.ui.windows').default_options.border or 'single',
+      border = 'single',
       title = 'Symbol Info',
     })
   end, bufnr)

--- a/lua/lspconfig/configs/texlab.lua
+++ b/lua/lspconfig/configs/texlab.lua
@@ -117,7 +117,7 @@ local function buf_find_envs(client, bufnr)
       width = math.max((max_length + #env_names - 1), (string.len 'Environments')),
       focusable = false,
       focus = false,
-      border = require('lspconfig.ui.windows').default_options.border or 'single',
+      border = 'single',
       title = 'Environments',
     })
   end, bufnr)


### PR DESCRIPTION
Problem:
Some configs still reference 'lspconfig.ui.windows', which was removed in e6569c18c21be5166e4b9cc7530e828b8285c84e.

Solution:
Remove the references.