### PR TITLE
refactor: remove internal implementation of util.path.dirname

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -176,7 +176,7 @@ function configs.__newindex(t, config_name, config_def)
           if not api.nvim_buf_is_valid(bufnr) or (#bufname ~= 0 and not util.bufname_valid(bufname)) then
             return
           end
-          local pseudo_root = #bufname == 0 and pwd or util.path.dirname(util.path.sanitize(bufname))
+          local pseudo_root = #bufname == 0 and pwd or vim.fs.dirname(util.path.sanitize(bufname))
           M.manager:add(pseudo_root, true, bufnr, config.silent)
         end
       end)

--- a/lua/lspconfig/manager.lua
+++ b/lua/lspconfig/manager.lua
@@ -222,7 +222,7 @@ function M:try_add(bufnr, project_root, silent)
     if root_dir then
       self:add(root_dir, false, bufnr, silent)
     elseif self.config.single_file_support then
-      local pseudo_root = #bufname == 0 and pwd or util.path.dirname(buf_path)
+      local pseudo_root = #bufname == 0 and pwd or vim.fs.dirname(buf_path)
       self:add(pseudo_root, true, bufnr, silent)
     end
   end)

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -155,20 +155,7 @@ M.path = (function()
   --- @param path T
   --- @return T
   local function dirname(path)
-    local strip_dir_pat = '/([^/]+)$'
-    local strip_sep_pat = '/$'
-    if not path or #path == 0 then
-      return path
-    end
-    local result = path:gsub(strip_sep_pat, ''):gsub(strip_dir_pat, '')
-    if #result == 0 then
-      if iswin then
-        return path:sub(1, 2):upper()
-      else
-        return '/'
-      end
-    end
-    return result
+    return vim.fs.dirname(path)
   end
 
   local function path_join(...)
@@ -181,7 +168,7 @@ M.path = (function()
     local dir = path
     -- Just in case our algo is buggy, don't infinite loop.
     for _ = 1, 100 do
-      dir = dirname(dir)
+      dir = vim.fs.dirname(dir)
       if not dir then
         return
       end
@@ -199,7 +186,7 @@ M.path = (function()
   local function iterate_parents(path)
     local function it(_, v)
       if v and not is_fs_root(v) then
-        v = dirname(v)
+        v = vim.fs.dirname(v)
       else
         return
       end


### PR DESCRIPTION
Instead, just return the result of vim.fs.dirname.
