### PR TITLE
refactor: deprecate util.find_node_modules_ancestor

### DIFF
--- a/.github/ci/run_sanitizer.sh
+++ b/.github/ci/run_sanitizer.sh
@@ -15,7 +15,7 @@ if git diff --pickaxe-all -U0 -G "${SEARCH_PATTERN}" "${REF_BRANCH}" "${PR_BRANC
   exit 1
 fi
 
-SEARCH_PATTERN='(util\.path\.dirname|util\.path\.sanitize|util\.path\.exists|util\.path\.is_file|util\.path\.is_dir|util\.find_mercurial_ancestor)'
+SEARCH_PATTERN='(util\.path\.dirname|util\.path\.sanitize|util\.path\.exists|util\.path\.is_file|util\.path\.is_dir|util\.find_mercurial_ancestor|util\.find_node_modules_ancestor)'
 
 if git diff --pickaxe-all -U0 -G "${SEARCH_PATTERN}" "${REF_BRANCH}" "${PR_BRANCH}" -- '*.lua' | grep -Ev '\.lua$' | grep -E "^\+.*${SEARCH_PATTERN}" ; then
   echo

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -297,9 +297,14 @@ below returns a function that takes as its argument the current buffer path.
 - `util.find_git_ancestor`: a function that locates the first parent directory
   containing a `.git` directory. >
    root_dir = util.find_git_ancestor
-- `util.find_node_modules_ancestor`: a function that locates the first parent
-  directory containing a `node_modules` directory. >
-   root_dir = util.find_node_modules_ancestor
+- Locate the first parent dir containing a "node_modules" dir: >lua
+  vim.fs.find('node_modules', { path = root_dir, upward = true })[1]
+<
+  If you have Nvim 0.10 or newer then >lua
+  vim.fs.root(root_dir, "node_modules")
+<
+  can be used instead.
+  - Note: The old `util.find_node_modules_ancestor` API is deprecated and will be removed.
 - `util.find_package_json_ancestor`: a function that locates the first parent
   directory containing a `package.json`. >
    root_dir = util.find_package_json_ancestor

--- a/lua/lspconfig/configs/angularls.lua
+++ b/lua/lspconfig/configs/angularls.lua
@@ -4,7 +4,7 @@ local util = require 'lspconfig.util'
 -- in order to use your projects configured versions.
 -- This defaults to the vim cwd, but will get overwritten by the resolved root of the file.
 local function get_probe_dir(root_dir)
-  local project_root = util.find_node_modules_ancestor(root_dir)
+  local project_root = vim.fs.find('node_modules', { path = root_dir, upward = true })[1]
 
   return project_root and (project_root .. '/node_modules') or ''
 end

--- a/lua/lspconfig/configs/astro.lua
+++ b/lua/lspconfig/configs/astro.lua
@@ -1,7 +1,7 @@
 local util = require 'lspconfig.util'
 
 local function get_typescript_server_path(root_dir)
-  local project_root = util.find_node_modules_ancestor(root_dir)
+  local project_root = vim.fs.find('node_modules', { path = root_dir, upward = true })[1]
   return project_root and (util.path.join(project_root, 'node_modules', 'typescript', 'lib')) or ''
 end
 

--- a/lua/lspconfig/configs/glint.lua
+++ b/lua/lspconfig/configs/glint.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'glint-language-server' },
     on_new_config = function(config, new_root_dir)
-      local project_root = util.find_node_modules_ancestor(new_root_dir)
+      local project_root = vim.fs.find('node_modules', { path = new_root_dir, upward = true })[1]
       -- Glint should not be installed globally.
       local node_bin_path = util.path.join(project_root, 'node_modules', '.bin')
       local path = node_bin_path .. util.path.path_separator .. vim.env.PATH

--- a/lua/lspconfig/configs/mdx_analyzer.lua
+++ b/lua/lspconfig/configs/mdx_analyzer.lua
@@ -1,7 +1,7 @@
 local util = require 'lspconfig.util'
 
 local function get_typescript_server_path(root_dir)
-  local project_root = util.find_node_modules_ancestor(root_dir)
+  local project_root = vim.fs.find('node_modules', { path = root_dir, upward = true })[1]
   return project_root and (util.path.join(project_root, 'node_modules', 'typescript', 'lib')) or ''
 end
 

--- a/lua/lspconfig/configs/relay_lsp.lua
+++ b/lua/lspconfig/configs/relay_lsp.lua
@@ -23,7 +23,7 @@ return {
     },
     root_dir = util.root_pattern('relay.config.*', 'package.json'),
     on_new_config = function(config, root_dir)
-      local project_root = util.find_node_modules_ancestor(root_dir)
+      local project_root = vim.fs.find('node_modules', { path = root_dir, upward = true })[1]
       local node_bin_path = util.path.join(project_root, 'node_modules', '.bin')
       local compiler_cmd = { util.path.join(node_bin_path, 'relay-compiler'), '--watch' }
       local path = node_bin_path .. util.path.path_separator .. vim.env.PATH

--- a/lua/lspconfig/configs/rome.lua
+++ b/lua/lspconfig/configs/rome.lua
@@ -13,7 +13,7 @@ return {
     },
     root_dir = function(fname)
       return util.find_package_json_ancestor(fname)
-        or util.find_node_modules_ancestor(fname)
+        or vim.fs.find('node_modules', { path = fname, upward = true })[1]
         or util.find_git_ancestor(fname)
     end,
     single_file_support = true,

--- a/lua/lspconfig/configs/tailwindcss.lua
+++ b/lua/lspconfig/configs/tailwindcss.lua
@@ -109,9 +109,10 @@ return {
         'postcss.config.cjs',
         'postcss.config.mjs',
         'postcss.config.ts'
-      )(fname) or util.find_package_json_ancestor(fname) or util.find_node_modules_ancestor(fname) or util.find_git_ancestor(
-        fname
-      )
+      )(fname) or util.find_package_json_ancestor(fname) or vim.fs.find(
+        'node_modules',
+        { path = fname, upward = true }
+      )[1] or util.find_git_ancestor(fname)
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/volar.lua
+++ b/lua/lspconfig/configs/volar.lua
@@ -1,7 +1,7 @@
 local util = require 'lspconfig.util'
 
 local function get_typescript_server_path(root_dir)
-  local project_root = util.find_node_modules_ancestor(root_dir)
+  local project_root = vim.fs.find('node_modules', { path = root_dir, upward = true })[1]
   return project_root and (util.path.join(project_root, 'node_modules', 'typescript', 'lib')) or ''
 end
 

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -247,14 +247,6 @@ function M.find_git_ancestor(startpath)
   end)
 end
 
-function M.find_node_modules_ancestor(startpath)
-  return M.search_ancestors(startpath, function(path)
-    if vim.fn.isdirectory(M.path.join(path, 'node_modules')) == 1 then
-      return path
-    end
-  end)
-end
-
 function M.find_package_json_ancestor(startpath)
   return M.search_ancestors(startpath, function(path)
     local jsonpath = M.path.join(path, 'package.json')
@@ -399,6 +391,11 @@ end
 --- @deprecated use `vim.fs.find('.hg', { path = startpath, upward = true })[1]` instead
 function M.find_mercurial_ancestor(startpath)
   return vim.fs.find('.hg', { path = startpath, upward = true })[1]
+end
+
+--- @deprecated use `vim.fs.find('node_modules', { path = startpath, upward = true })[1]` instead
+function M.find_node_modules_ancestor(startpath)
+  return vim.fs.find('node_modules', { path = startpath, upward = true })[1]
 end
 
 return M


### PR DESCRIPTION
Work on https://github.com/neovim/nvim-lspconfig/issues/2079.