### PR TITLE
refactor: use simpler file existence check

### DIFF
--- a/lua/lspconfig/configs/fennel_ls.lua
+++ b/lua/lspconfig/configs/fennel_ls.lua
@@ -7,7 +7,7 @@ return {
     root_dir = function(dir)
       local has_fls_project_cfg = function(path)
         local fnlpath = vim.fs.joinpath(path, 'flsproject.fnl')
-        return (vim.loop.fs_stat(fnlpath) or {}).type == 'file'
+        return vim.fn.getftype(fnlpath) == 'file'
       end
       return util.search_ancestors(dir, has_fls_project_cfg) or vim.fs.root(0, '.git')
     end,

--- a/lua/lspconfig/configs/turtle_ls.lua
+++ b/lua/lspconfig/configs/turtle_ls.lua
@@ -17,7 +17,7 @@ if bin_path == nil then
   end
   for _, p in ipairs(paths) do
     local candidate = util.path.join(p, bin_name)
-    if (vim.loop.fs_stat(candidate) or {}).type == 'file' then
+    if vim.fn.getftype(candidate) == 'file' then
       full_path = candidate
       break
     end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -241,7 +241,7 @@ function M.find_git_ancestor(startpath)
   return M.search_ancestors(startpath, function(path)
     -- Support git directories and git files (worktrees)
     local gitpath = M.path.join(path, '.git')
-    if vim.fn.isdirectory(gitpath) == 1 or (uv.fs_stat(gitpath) or {}).type == 'file' then
+    if vim.fn.isdirectory(gitpath) == 1 or (vim.fn.getftype(gitpath) == 'file') then
       return path
     end
   end)
@@ -258,7 +258,7 @@ end
 function M.find_package_json_ancestor(startpath)
   return M.search_ancestors(startpath, function(path)
     local jsonpath = M.path.join(path, 'package.json')
-    if (uv.fs_stat(jsonpath) or {}).type == 'file' then
+    if vim.fn.getftype(jsonpath) == 'file' then
       return path
     end
   end)
@@ -375,11 +375,11 @@ function M.path.is_dir(filename)
   return vim.fn.isdirectory(filename) == 1
 end
 
---- @deprecated use `(vim.loop.fs_stat(path) or {}).type == 'file'` instead
+--- @deprecated use `vim.fn.getftype(path) == 'file'` instead
 --- @param path string
 --- @return boolean
 function M.path.is_file(path)
-  return (vim.loop.fs_stat(path) or {}).type == 'file'
+  return vim.fn.getftype(path) == 'file'
 end
 
 --- @deprecated use `vim.fs.dirname` instead

--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -63,7 +63,7 @@ local function make_section(indentlvl, sep, parts)
 end
 
 local function readfile(path)
-  assert((uv.fs_stat(path) or {}).type == 'file')
+  assert(vim.fn.getftype(path) == 'file')
   return io.open(path):read '*a'
 end
 
@@ -181,10 +181,10 @@ local function make_lsp_sections()
           function()
             local package_json_name = util.path.join(tempdir, config_name .. '.package.json')
             if docs.package_json then
-              if not ((uv.fs_stat(package_json_name) or {}).type == 'file') then
+              if vim.fn.getftype(package_json_name) ~= 'file' then
                 os.execute(string.format('curl -v -L -o %q %q', package_json_name, docs.package_json))
               end
-              if not ((uv.fs_stat(package_json_name) or {}).type == 'file') then
+              if vim.fn.getftype(package_json_name) ~= 'file' then
                 print(string.format('Failed to download package.json for %q at %q', config_name, docs.package_json))
                 os.exit(1)
                 return


### PR DESCRIPTION
The vimscript function `getftype` is an easier way to check for file
existence compared to vim.uv.