### PR TITLE
build(editorconfig): set max_line_length to 120 only for lua files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,14 @@
 root = true
 
 [*]
-max_line_length = 120
 indent_style = space
 indent_size = 2
 tab_width = 8
 end_of_line = lf
 insert_final_newline = true
-charset = utf-8
+
+[*.lua]
+max_line_length = 120
 
 [{Makefile,**/Makefile,runtime/doc/*.txt}]
 indent_style = tab


### PR DESCRIPTION
Setting it for all filetypes is usually not correct. For example, git
commits are also affected by this option which makes 120 columns too
long.
