### PR TITLE
refactor: replace all instances of vim.uv with vim.loop

### DIFF
--- a/.github/ci/run_sanitizer.sh
+++ b/.github/ci/run_sanitizer.sh
@@ -22,3 +22,12 @@ if git diff --pickaxe-all -U0 -G "${SEARCH_PATTERN}" "${REF_BRANCH}" "${PR_BRANC
   echo 'Do not use deprecated util functions: '"${SEARCH_PATTERN}"
   exit 1
 fi
+
+SEARCH_PATTERN='(vim\.uv)'
+
+if git diff --pickaxe-all -U0 -G "${SEARCH_PATTERN}" "${REF_BRANCH}" "${PR_BRANCH}" -- '*.lua' | grep -Ev '\.lua$' | grep -E "^\+.*${SEARCH_PATTERN}" ; then
+  echo
+  echo 'Do not use modules that are too new: '"${SEARCH_PATTERN}"
+  echo 'Consult README to check the minimum supported neovim version.'
+  exit 1
+fi

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -1,6 +1,6 @@
 local util = require 'lspconfig.util'
 local async = require 'lspconfig.async'
-local api, validate, lsp, uv, fn = vim.api, vim.validate, vim.lsp, (vim.uv or vim.loop), vim.fn
+local api, validate, lsp, fn = vim.api, vim.validate, vim.lsp, vim.fn
 local tbl_deep_extend = vim.tbl_deep_extend
 
 local configs = {}
@@ -128,7 +128,7 @@ function configs.__newindex(t, config_name, config_def)
         return
       end
 
-      local pwd = uv.cwd()
+      local pwd = vim.loop.cwd()
 
       async.run(function()
         local root_dir

--- a/lua/lspconfig/configs/eslint.lua
+++ b/lua/lspconfig/configs/eslint.lua
@@ -134,7 +134,7 @@ return {
         if not result then
           return
         end
-        local sysname = vim.uv.os_uname().sysname
+        local sysname = vim.loop.os_uname().sysname
         if sysname:match 'Windows' then
           os.execute(string.format('start %q', result.url))
         elseif sysname:match 'Linux' then

--- a/lua/lspconfig/configs/gitlab_ci_ls.lua
+++ b/lua/lspconfig/configs/gitlab_ci_ls.lua
@@ -1,6 +1,6 @@
 local util = require 'lspconfig.util'
 
-local cache_dir = util.path.join(vim.uv.os_homedir(), '.cache/gitlab-ci-ls/')
+local cache_dir = util.path.join(vim.loop.os_homedir(), '.cache/gitlab-ci-ls/')
 return {
   default_config = {
     cmd = { 'gitlab-ci-ls' },

--- a/lua/lspconfig/configs/intelephense.lua
+++ b/lua/lspconfig/configs/intelephense.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'intelephense', '--stdio' },
     filetypes = { 'php' },
     root_dir = function(pattern)
-      local cwd = vim.uv.cwd()
+      local cwd = vim.loop.cwd()
       local root = util.root_pattern('composer.json', '.git')(pattern)
 
       -- prefer cwd if root is a descendant

--- a/lua/lspconfig/configs/jdtls.lua
+++ b/lua/lspconfig/configs/jdtls.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 local handlers = require 'vim.lsp.handlers'
 
 local env = {
-  HOME = vim.uv.os_homedir(),
+  HOME = vim.loop.os_homedir(),
   XDG_CACHE_HOME = os.getenv 'XDG_CACHE_HOME',
   JDTLS_JVM_ARGS = os.getenv 'JDTLS_JVM_ARGS',
 }

--- a/lua/lspconfig/configs/julials.lua
+++ b/lua/lspconfig/configs/julials.lua
@@ -22,7 +22,7 @@ local function activate_env(path)
     path = vim.fs.normalize(vim.fn.fnamemodify(vim.fn.expand(path), ':p'))
     local found_env = false
     for _, project_file in ipairs(root_files) do
-      local file = vim.uv.fs_stat(vim.fs.joinpath(path, project_file))
+      local file = vim.loop.fs_stat(vim.fs.joinpath(path, project_file))
       if file and file.type then
         found_env = true
         break

--- a/lua/lspconfig/configs/lua_ls.lua
+++ b/lua/lspconfig/configs/lua_ls.lua
@@ -48,7 +48,7 @@ require'lspconfig'.lua_ls.setup {
   on_init = function(client)
     if client.workspace_folders then
       local path = client.workspace_folders[1].name
-      if vim.uv.fs_stat(path..'/.luarc.json') or vim.uv.fs_stat(path..'/.luarc.jsonc') then
+      if vim.loop.fs_stat(path..'/.luarc.json') or vim.loop.fs_stat(path..'/.luarc.jsonc') then
         return
       end
     end

--- a/lua/lspconfig/configs/phan.lua
+++ b/lua/lspconfig/configs/phan.lua
@@ -19,7 +19,7 @@ return {
     filetypes = { 'php' },
     single_file_support = true,
     root_dir = function(pattern)
-      local cwd = vim.uv.cwd()
+      local cwd = vim.loop.cwd()
       local root = util.root_pattern('composer.json', '.git')(pattern)
 
       -- prefer cwd if root is a descendant

--- a/lua/lspconfig/configs/phpactor.lua
+++ b/lua/lspconfig/configs/phpactor.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'phpactor', 'language-server' },
     filetypes = { 'php' },
     root_dir = function(pattern)
-      local cwd = vim.uv.cwd()
+      local cwd = vim.loop.cwd()
       local root = util.root_pattern('composer.json', '.git', '.phpactor.json', '.phpactor.yml')(pattern)
 
       -- prefer cwd if root is a descendant

--- a/lua/lspconfig/configs/r_language_server.lua
+++ b/lua/lspconfig/configs/r_language_server.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'R', '--no-echo', '-e', 'languageserver::run()' },
     filetypes = { 'r', 'rmd' },
     root_dir = function(fname)
-      return util.find_git_ancestor(fname) or vim.uv.os_homedir()
+      return util.find_git_ancestor(fname) or vim.loop.os_homedir()
     end,
     log_level = vim.lsp.protocol.MessageType.Warning,
   },

--- a/lua/lspconfig/configs/rnix.lua
+++ b/lua/lspconfig/configs/rnix.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'rnix-lsp' },
     filetypes = { 'nix' },
     root_dir = function(fname)
-      return util.find_git_ancestor(fname) or vim.uv.os_homedir()
+      return util.find_git_ancestor(fname) or vim.loop.os_homedir()
     end,
     settings = {},
     init_options = {},

--- a/lua/lspconfig/configs/smarty_ls.lua
+++ b/lua/lspconfig/configs/smarty_ls.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'smarty-language-server', '--stdio' },
     filetypes = { 'smarty' },
     root_dir = function(pattern)
-      local cwd = vim.uv.cwd()
+      local cwd = vim.loop.cwd()
       local root = util.root_pattern('composer.json', '.git')(pattern)
 
       -- prefer cwd if root is a descendant

--- a/lua/lspconfig/configs/vdmj.lua
+++ b/lua/lspconfig/configs/vdmj.lua
@@ -22,7 +22,7 @@ local function get_latest_installed_version(repo)
   local sort = vim.fn.sort
 
   local subdirs = function(file)
-    local stat = vim.uv.fs_stat(util.path.join(path, file))
+    local stat = vim.loop.fs_stat(util.path.join(path, file))
     return stat.type == 'directory' and 1 or 0
   end
 

--- a/lua/lspconfig/health.lua
+++ b/lua/lspconfig/health.lua
@@ -2,7 +2,6 @@ local M = {}
 local health = require('vim.health')
 
 local api, fn = vim.api, vim.fn
-local uv = vim.uv or vim.loop
 local util = require 'lspconfig.util'
 
 local error_messages = {
@@ -191,12 +190,12 @@ local function make_client_info(client, fname)
   local client_info, info_lines = make_info(client)
 
   local workspace_folders = fn.has 'nvim-0.9' == 1 and client.workspace_folders or client.workspaceFolders
-  fname = vim.fs.normalize(uv.fs_realpath(fname) or fn.fnamemodify(fn.resolve(fname), ':p'))
+  fname = vim.fs.normalize(vim.loop.fs_realpath(fname) or fn.fnamemodify(fn.resolve(fname), ':p'))
 
   if workspace_folders then
     for _, schema in ipairs(workspace_folders) do
       local matched = true
-      local root_dir = uv.fs_realpath(schema.name)
+      local root_dir = vim.loop.fs_realpath(schema.name)
       if root_dir == nil or fname:sub(1, root_dir:len()) ~= root_dir then
         matched = false
       end

--- a/lua/lspconfig/manager.lua
+++ b/lua/lspconfig/manager.lua
@@ -1,6 +1,5 @@
 local api = vim.api
 local lsp = vim.lsp
-local uv = vim.uv or vim.loop
 
 local async = require 'lspconfig.async'
 local util = require 'lspconfig.util'
@@ -116,7 +115,7 @@ function M:_start_client(bufnr, new_config, root_dir, single_file, silent)
 
   -- Launch the server in the root directory used internally by lspconfig, if otherwise unset
   -- also check that the path exist
-  if not new_config.cmd_cwd and uv.fs_realpath(root_dir) then
+  if not new_config.cmd_cwd and vim.loop.fs_realpath(root_dir) then
     new_config.cmd_cwd = root_dir
   end
 
@@ -203,7 +202,7 @@ function M:try_add(bufnr, project_root, silent)
 
   local get_root_dir = self.config.root_dir
 
-  local pwd = assert(uv.cwd())
+  local pwd = assert(vim.loop.cwd())
 
   async.run(function()
     local root_dir

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -1,10 +1,9 @@
 local validate = vim.validate
 local api = vim.api
 local lsp = vim.lsp
-local uv = vim.uv or vim.loop
 local nvim_eleven = vim.fn.has 'nvim-0.11' == 1
 
-local iswin = uv.os_uname().version:match 'Windows'
+local iswin = vim.loop.os_uname().version:match 'Windows'
 
 local M = {}
 
@@ -128,7 +127,7 @@ M.path = (function()
 
   -- Traverse the path calling cb along the way.
   local function traverse_parents(path, cb)
-    path = uv.fs_realpath(path)
+    path = vim.loop.fs_realpath(path)
     local dir = path
     -- Just in case our algo is buggy, don't infinite loop.
     for _ = 1, 100 do
@@ -154,7 +153,7 @@ M.path = (function()
       else
         return
       end
-      if v and uv.fs_realpath(v) then
+      if v and vim.loop.fs_realpath(v) then
         return v, path
       else
         return
@@ -224,7 +223,7 @@ function M.root_pattern(...)
     for _, pattern in ipairs(patterns) do
       local match = M.search_ancestors(startpath, function(path)
         for _, p in ipairs(vim.fn.glob(M.path.join(M.path.escape_wildcards(path), pattern), true, true)) do
-          if uv.fs_stat(p) then
+          if vim.loop.fs_stat(p) then
             return path
           end
         end
@@ -392,7 +391,7 @@ M.path.sanitize = vim.fs.normalize
 --- @param filename string
 --- @return string|false
 function M.path.exists(filename)
-  local stat = uv.fs_stat(filename)
+  local stat = vim.loop.fs_stat(filename)
   return stat and stat.type or false
 end
 

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -106,7 +106,7 @@ api.nvim_create_user_command('LspRestart', function(info)
       detach_clients[client.name] = { client, lsp.get_buffers_by_client_id(client.id) }
     end
   end
-  local timer = assert(vim.uv.new_timer())
+  local timer = assert(vim.loop.new_timer())
   timer:start(
     500,
     100,

--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -2,7 +2,6 @@ require 'lspconfig'
 local configs = require 'lspconfig.configs'
 local util = require 'lspconfig.util'
 local inspect = vim.inspect
-local uv = vim.uv
 local fn = vim.fn
 
 local function template(s, params)
@@ -171,7 +170,7 @@ local function make_lsp_sections()
       })
 
       if docs then
-        local tempdir = os.getenv 'DOCGEN_TEMPDIR' or uv.fs_mkdtemp '/tmp/nvim-lspconfig.XXXXXX'
+        local tempdir = os.getenv 'DOCGEN_TEMPDIR' or vim.loop.fs_mkdtemp '/tmp/nvim-lspconfig.XXXXXX'
         local preamble_parts = make_parts {
           function()
             if docs.description and #docs.description > 0 then
@@ -289,7 +288,7 @@ local function generate_readme(template_file, params)
   local writer = assert(io.open('doc/configs.md', 'w'))
   writer:write(readme_data)
   writer:close()
-  uv.fs_copyfile('doc/configs.md', 'doc/configs.txt')
+  vim.loop.fs_copyfile('doc/configs.md', 'doc/configs.txt')
 end
 
 require_all_configs()


### PR DESCRIPTION
We still support neovim 0.9 currently, so we can't use vim.uv. Also add
a check so we don't accidentally reintroduce it.
