### PR TITLE
refactor: remove outdated code

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -471,9 +471,7 @@ When debugging language servers, it is helpful to enable additional logging in
 the built-in client, specifically considering the RPC logs. Example: >lua
 
   vim.lsp.set_log_level 'trace'
-  if vim.fn.has 'nvim-0.5.1' == 1 then
-    require('vim.lsp.log').set_format_func(vim.inspect)
-  end
+  require('vim.lsp.log').set_format_func(vim.inspect)
 <
 Attempt to run the language server, and open the log with:
 

--- a/lua/lspconfig/configs/gdscript.lua
+++ b/lua/lspconfig/configs/gdscript.lua
@@ -1,11 +1,7 @@
 local util = require 'lspconfig.util'
 
 local port = os.getenv 'GDScript_Port' or '6005'
-local cmd = { 'nc', 'localhost', port }
-
-if vim.fn.has 'nvim-0.8' == 1 then
-  cmd = vim.lsp.rpc.connect('127.0.0.1', port)
-end
+local cmd = vim.lsp.rpc.connect('127.0.0.1', tonumber(port))
 
 return {
   default_config = {

--- a/lua/lspconfig/health.lua
+++ b/lua/lspconfig/health.lua
@@ -189,7 +189,7 @@ end
 local function make_client_info(client, fname)
   local client_info, info_lines = make_info(client)
 
-  local workspace_folders = fn.has 'nvim-0.9' == 1 and client.workspace_folders or client.workspaceFolders
+  local workspace_folders = client.workspace_folders
   fname = vim.fs.normalize(vim.loop.fs_realpath(fname) or fn.fnamemodify(fn.resolve(fname), ':p'))
 
   if workspace_folders then

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -6,17 +6,6 @@ vim.g.lspconfig = 1
 local api, lsp = vim.api, vim.lsp
 local util = require('lspconfig.util')
 
-if vim.fn.has 'nvim-0.8' ~= 1 then
-  local version_info = vim.version()
-  local warning_str = string.format(
-    '[lspconfig] requires neovim 0.8 or later. Detected neovim version: 0.%s.%s',
-    version_info.minor,
-    version_info.patch
-  )
-  vim.notify_once(warning_str)
-  return
-end
-
 local completion_sort = function(items)
   table.sort(items)
   return items


### PR DESCRIPTION
Lspconfig requires neovim version 0.9 at the time of writing this, so
discard any version checks and code for older versions.