### PR TITLE
fix(types): lspconfig.Config commands

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -5,6 +5,8 @@ local tbl_deep_extend = vim.tbl_deep_extend
 
 local configs = {}
 
+--- @alias lspconfig.Config.command {[1]:string|fun(args: vim.api.keyset.create_user_command.command_args)}|vim.api.keyset.user_command
+
 --- @class lspconfig.Config : vim.lsp.ClientConfig
 --- @field enabled? boolean
 --- @field single_file_support? boolean
@@ -15,6 +17,7 @@ local configs = {}
 --- @field autostart? boolean
 --- @field package _on_attach? fun(client: vim.lsp.Client, bufnr: integer)
 --- @field root_dir? string|fun(filename: string, bufnr: number)
+--- @field commands? table<string, lspconfig.Config.command>
 
 --- @param cmd any
 local function sanitize_cmd(cmd)


### PR DESCRIPTION
This PR fixes the types of `vim.lsp.ClientConfig` `commands`

The current definition comes from [neovim](https://github.com/neovim/neovim/blob/ae93c7f369a174f3d738ab55030de2c9dfc10c57/runtime/lua/vim/lsp/client.lua?plain=1#L80-L84)

```lua
--- @field commands? table<string,fun(command: lsp.Command, ctx: table)>
```

fails validation when passed to `nvim-lspconfig` [here](https://github.com/neovim/nvim-lspconfig/blob/1aa9f36b6d542dafc0b4a38c48969d036003b00a/lua/lspconfig/configs.lua?plain=1#L87)
follow up to: [neovim/neovim #31351](https://github.com/neovim/neovim/pull/31351)
