### PR TITLE
fix(svelte): prefer git over package.json

### DIFF
--- a/lua/lspconfig/configs/svelte.lua
+++ b/lua/lspconfig/configs/svelte.lua
@@ -4,7 +4,7 @@ return {
   default_config = {
     cmd = { 'svelteserver', '--stdio' },
     filetypes = { 'svelte' },
-    root_dir = util.root_pattern('package.json', '.git'),
+    root_dir = util.root_pattern('.git', 'package.json'),
   },
   docs = {
     description = [[


### PR DESCRIPTION
When using the Svelte LSP on a monorepo, the preference for a `package.json` may set an incorrect root dir.

To address that, prefer finding the git "root" instead.