### PR TITLE
fix(typst_lsp): deprecate typst_lsp to tinymist

### DIFF
--- a/lua/lspconfig.lua
+++ b/lua/lspconfig.lua
@@ -39,6 +39,10 @@ local aliases = {
     to = 'buf_ls',
     version = '0.2.1',
   },
+  typst_lsp = {
+    to = 'tinymist',
+    version = '0.2.1',
+  },
 }
 
 ---@return Alias


### PR DESCRIPTION
Problem: typst_lsp has been archived.

Solution: use tinymist instead

Fix #3492