### PR TITLE
fix(kotlin_language_server): fix wrong cmd

### DIFF
--- a/lua/lspconfig/configs/kotlin_language_server.lua
+++ b/lua/lspconfig/configs/kotlin_language_server.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 local bin_name = 'kotlin-language-server'
 if vim.fn.has 'win32' == 1 then
-  bin_name = bin_name .. '.bat'
+  bin_name = bin_name .. '.cmd'
 end
 
 --- The presence of one of these files indicates a project root directory


### PR DESCRIPTION
Change .bat extension to .cmd because .bat is not available.

Ref: #3499 