### PR TITLE
fix(tinymist): fallback to single file in some case

### DIFF
--- a/lua/lspconfig/configs/tinymist.lua
+++ b/lua/lspconfig/configs/tinymist.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'tinymist' },
     filetypes = { 'typst' },
     root_dir = util.find_git_ancestor,
-    single_file_support = false,
+    single_file_support = true,
   },
   docs = {
     description = [[


### PR DESCRIPTION
When the `root_dir` is null, tinymist should still runs to give a baseline usage.

Ref: #3094 in this PR the modify of `root_dir` is rejected, but set single file support field to true looks just fine.