### PR TITLE
fix ruff and ruff_lsp returning a function from root pattern

### DIFF
--- a/lua/lspconfig/configs/crystalline.lua
+++ b/lua/lspconfig/configs/crystalline.lua
@@ -5,7 +5,8 @@ return {
     cmd = { 'crystalline' },
     filetypes = { 'crystal' },
     root_dir = function(fname)
-      return util.root_pattern 'shard.yml' or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return util.root_pattern('shard.yml')(fname)
+        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/janet_lsp.lua
+++ b/lua/lspconfig/configs/janet_lsp.lua
@@ -8,7 +8,7 @@ return {
     },
     filetypes = { 'janet' },
     root_dir = function(fname)
-      return util.root_pattern 'project.janet'
+      return util.root_pattern('project.janet')(fname)
         or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
     end,
     single_file_support = true,

--- a/lua/lspconfig/configs/ruff.lua
+++ b/lua/lspconfig/configs/ruff.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'ruff', 'server' },
     filetypes = { 'python' },
     root_dir = function(fname)
-      return util.root_pattern('pyproject.toml', 'ruff.toml', '.ruff.toml')
+      return util.root_pattern('pyproject.toml', 'ruff.toml', '.ruff.toml')(fname)
         or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
     end,
     single_file_support = true,

--- a/lua/lspconfig/configs/ruff_lsp.lua
+++ b/lua/lspconfig/configs/ruff_lsp.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'ruff-lsp' },
     filetypes = { 'python' },
     root_dir = function(fname)
-      return util.root_pattern('pyproject.toml', 'ruff.toml')
+      return util.root_pattern('pyproject.toml', 'ruff.toml')(fname)
         or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
     end,
     single_file_support = true,


### PR DESCRIPTION
fixes #3512 

the issue was that `util.root_pattern` returns a function, which i believe is intended to be called with fname as its argument.

this causes root_dir to return a funcref when called which causes the attached issue as well as causing an error on LspStart ruff.