### PR TITLE
fix(lua_ls): return longest root path

### DIFF
--- a/lua/lspconfig/configs/lua_ls.lua
+++ b/lua/lspconfig/configs/lua_ls.lua
@@ -15,16 +15,15 @@ return {
     cmd = { 'lua-language-server' },
     filetypes = { 'lua' },
     root_dir = function(fname)
-      local root = util.root_pattern(unpack(root_files))(fname)
-      if root and root ~= vim.env.HOME then
-        return root
-      end
+      local root_file = util.root_pattern(unpack(root_files))(fname) or ''
       local root_lua = util.root_pattern 'lua/'(fname) or ''
       local root_git = vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1]) or ''
-      if root_lua == '' and root_git == '' then
+      if root_file == '' and root_lua == '' and root_git == '' then
         return
       end
-      return #root_lua >= #root_git and root_lua or root_git
+      local root = #root_file >= #root_lua and root_file or root_lua
+      root = #root >= #root_git and root or root_git
+      return root
     end,
     single_file_support = true,
     log_level = vim.lsp.protocol.MessageType.Warning,


### PR DESCRIPTION
This commit doesn't address the case when root path == vim.env.HOME as the case lack return when it's true (#2110)

Fix #3508