### PR TITLE
feat(msbuild): config instruction for filetypes

### DIFF
--- a/lua/lspconfig/configs/msbuild_project_tools_server.lua
+++ b/lua/lspconfig/configs/msbuild_project_tools_server.lua
@@ -2,7 +2,7 @@ local host_dll_name = 'MSBuildProjectTools.LanguageServer.Host.dll'
 
 return {
   default_config = {
-    filetypes = { 'xml.csproj', 'xml.fsproj', 'sln' },
+    filetypes = { 'msbuild' },
     root_dir = function(fname)
       return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
     end,
@@ -10,7 +10,7 @@ return {
     cmd = { 'dotnet', host_dll_name },
   },
   docs = {
-    description = [[
+    description = [=[
 https://github.com/tintoy/msbuild-project-tools-server/
 
 MSBuild Project Tools Server can be installed by following the README.MD on the above repository.
@@ -22,6 +22,26 @@ lspconfig.msbuild_project_tools_server.setup {
 }
 ```
 
-]],
+There's no builtin filetypes for msbuild files, would require some filetype aliases:
+
+```lua
+vim.filetype.add({
+  extension = {
+    props = 'msbuild',
+    tasks = 'msbuild',
+    targets = 'msbuild',
+  },
+  pattern = {
+    [ [[.*\..*proj]] ] = 'msbuild',
+  },
+})
+```
+
+Optionally tell treesitter to treat `msbuild` as `xml` so you can get syntax highlighting if you have the treesitter-xml-parser installed.
+
+```lua
+vim.treesitter.language.register('xml', { 'msbuild' })
+```
+]=],
   },
 }


### PR DESCRIPTION
Current default filetypes for `msbuild_project_tools_server` are not builtin from neovim, this PR adds instruction to register filetype for attaching to different types of msbuild file.