### PR TITLE
refactor: deprecate util.path.path_separator

### DIFF
--- a/lua/lspconfig/configs/glint.lua
+++ b/lua/lspconfig/configs/glint.lua
@@ -7,7 +7,7 @@ return {
       local project_root = vim.fs.find('node_modules', { path = new_root_dir, upward = true })[1]
       -- Glint should not be installed globally.
       local node_bin_path = project_root .. '/node_modules/.bin'
-      local path = node_bin_path .. util.path.path_separator .. vim.env.PATH
+      local path = node_bin_path .. (vim.fn.has('win32') == 1 and ';' or ':') .. vim.env.PATH
       if config.cmd_env then
         config.cmd_env.PATH = path
       else

--- a/lua/lspconfig/configs/relay_lsp.lua
+++ b/lua/lspconfig/configs/relay_lsp.lua
@@ -26,7 +26,7 @@ return {
       local project_root = vim.fs.find('node_modules', { path = root_dir, upward = true })[1]
       local node_bin_path = project_root .. '/node_modules/.bin'
       local compiler_cmd = { node_bin_path .. '/relay-compiler', '--watch' }
-      local path = node_bin_path .. util.path.path_separator .. vim.env.PATH
+      local path = node_bin_path .. (vim.fn.has('win32') == 1 and ';' or ':') .. vim.env.PATH
       if config.cmd_env then
         config.cmd_env.PATH = path
       else

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -158,13 +158,10 @@ M.path = (function()
     return dir == root
   end
 
-  local path_separator = iswin and ';' or ':'
-
   return {
     traverse_parents = traverse_parents,
     iterate_parents = iterate_parents,
     is_descendant = is_descendant,
-    path_separator = path_separator,
   }
 end)()
 
@@ -362,6 +359,9 @@ end
 function M.path.join(...)
   return table.concat({ ... }, '/')
 end
+
+--- @deprecated use `vim.fn.has('win32') == 1 and ';' or ':'` instead
+M.path.path_separator = vim.fn.has('win32') == 1 and ';' or ':'
 
 --- @deprecated use `vim.fs.dirname(vim.fs.find('.hg', { path = startpath, upward = true })[1])` instead
 function M.find_mercurial_ancestor(startpath)


### PR DESCRIPTION
Work on https://github.com/neovim/nvim-lspconfig/issues/2079.
