### PR TITLE
fix(mdx-analyzer): Duplicate node_modules folder causing errors, and filetypes option.

### DIFF
--- a/lua/lspconfig/configs/mdx_analyzer.lua
+++ b/lua/lspconfig/configs/mdx_analyzer.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 local function get_typescript_server_path(root_dir)
   local project_root = vim.fs.find('node_modules', { path = root_dir, upward = true })[1]
-  return project_root and (project_root .. '/node_modules/typescript/lib') or ''
+  return project_root and (project_root .. '/typescript/lib') or ''
 end
 
 return {

--- a/lua/lspconfig/configs/mdx_analyzer.lua
+++ b/lua/lspconfig/configs/mdx_analyzer.lua
@@ -8,7 +8,7 @@ end
 return {
   default_config = {
     cmd = { 'mdx-language-server', '--stdio' },
-    filetypes = { 'markdown.mdx' },
+    filetypes = { 'mdx' },
     root_dir = util.root_pattern 'package.json',
     single_file_support = true,
     settings = {},

--- a/lua/lspconfig/configs/mdx_analyzer.lua
+++ b/lua/lspconfig/configs/mdx_analyzer.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 local function get_typescript_server_path(root_dir)
   local project_root = vim.fs.dirname(vim.fs.find('node_modules', { path = root_dir, upward = true })[1])
-  return project_root and (project_root .. '/typescript/lib') or ''
+  return project_root and (project_root .. '/node_modules/typescript/lib') or ''
 end
 
 return {

--- a/lua/lspconfig/configs/mdx_analyzer.lua
+++ b/lua/lspconfig/configs/mdx_analyzer.lua
@@ -1,7 +1,7 @@
 local util = require 'lspconfig.util'
 
 local function get_typescript_server_path(root_dir)
-  local project_root = vim.fs.find('node_modules', { path = root_dir, upward = true })[1]
+  local project_root = vim.fs.dirname(vim.fs.find('node_modules', { path = root_dir, upward = true })[1])
   return project_root and (project_root .. '/typescript/lib') or ''
 end
 


### PR DESCRIPTION
In #3496, astro ls and volar lsp was fixed for having duplicate node_modules folder, but mdx-analyzer doesn't. This pr fixes that. Not only that, the `filetypes` option had `markdown.mdx`, but now vim.bo.filetype returns `mdx`, thats fixed also.