### PR TITLE
feat: cue language server

### DIFF
--- a/lua/lspconfig/configs/cue.lua
+++ b/lua/lspconfig/configs/cue.lua
@@ -1,16 +1,11 @@
 local util = require 'lspconfig.util'
 
-local root_files = {
-  'cue.mod',
-  '.git',
-}
-
 return {
   default_config = {
     cmd = { 'cue', 'lsp' },
     filetypes = { 'cue' },
     root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname)
+      return util.root_pattern(unpack({ 'cue.mod', '.git' }))(fname)
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/cue.lua
+++ b/lua/lspconfig/configs/cue.lua
@@ -1,0 +1,24 @@
+local util = require 'lspconfig.util'
+
+local root_files = {
+  'cue.mod',
+  '.git',
+}
+
+return {
+  default_config = {
+    cmd = { 'cue', 'lsp' },
+    filetypes = { 'cue' },
+    root_dir = function(fname)
+      return util.root_pattern(unpack(root_files))(fname)
+    end,
+    single_file_support = true,
+  },
+  docs = {
+    description = [[
+https://github.com/cue-lang/cue
+
+CUE makes it easy to validate data, write schemas, and ensure configurations align with policies.
+]],
+  },
+}


### PR DESCRIPTION
This PR adds support for the CUE language (https://github.com/cue-lang/cue) by integrating its official language server protocol implementation (`cue lsp`).

Background:
- Previously, CUE language support was provided through Dagger's LSP implementation, which has since been discontinued
- CUE is gaining significant adoption, with over 5.2k GitHub stars
- Notable projects like Timoni (https://github.com/stefanprodan/timoni) are embracing CUE for configuration management

This change ensures continued and improved CUE support through the official, maintained language server.