### PR TITLE
fix(clangd): fix switchSourceHeader detection

### DIFF
--- a/lua/lspconfig/configs/clangd.lua
+++ b/lua/lspconfig/configs/clangd.lua
@@ -4,7 +4,7 @@ local util = require 'lspconfig.util'
 local function switch_source_header(bufnr)
   local method_name = 'textDocument/switchSourceHeader'
   bufnr = util.validate_bufnr(bufnr)
-  local client = util.get_active_client_by_name(bufnr, 'ccls')
+  local client = util.get_active_client_by_name(bufnr, 'clangd')
   if not client then
     return vim.notify(('method %s is not supported by any servers active on the current buffer'):format(method_name))
   end


### PR DESCRIPTION
The previous patch to this file (88c4c042e1e59f992e4c7aff3531033047b3aa9c) changed the string to 'ccls' (possibly by copy-paste error).