### PR TITLE
docs(ruby_lsp): Remove instructions for adding ruby-lsp to Gemfile

### DIFF
--- a/lua/lspconfig/configs/ruby_lsp.lua
+++ b/lua/lspconfig/configs/ruby_lsp.lua
@@ -21,9 +21,7 @@ Install the gem. There's no need to require it, since the server is used as a
 standalone executable.
 
 ```sh
-group :development do
-  gem "ruby-lsp", require: false
-end
+gem install ruby-lsp
 ```
     ]],
   },


### PR DESCRIPTION
The best practice is to have the gem installed globally, and then ruby-lsp will set up it's own Gemfile and manage it's own version.