### PR TITLE
fix(slangd): use .slang instead of .shaderslang for slang

### DIFF
--- a/lua/lspconfig/configs/slangd.lua
+++ b/lua/lspconfig/configs/slangd.lua
@@ -7,7 +7,7 @@ end
 return {
   default_config = {
     cmd = { bin_name },
-    filetypes = { 'hlsl', 'shaderslang' },
+    filetypes = { 'hlsl', 'slang' },
     root_dir = function(fname)
       return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
     end,


### PR DESCRIPTION
The extension used by slang is .slang.
[Examples] and [docs] for reference.

[Examples]: https://github.com/shader-slang/slang/tree/master/examples
[docs]: https://shader-slang.com/slang/user-guide/get-started.html