### PR TITLE
fix(clojure_lsp): adds current folder as fallback for root_dir

### DIFF
--- a/lua/lspconfig/configs/clojure_lsp.lua
+++ b/lua/lspconfig/configs/clojure_lsp.lua
@@ -4,7 +4,13 @@ return {
   default_config = {
     cmd = { 'clojure-lsp' },
     filetypes = { 'clojure', 'edn' },
-    root_dir = util.root_pattern('project.clj', 'deps.edn', 'build.boot', 'shadow-cljs.edn', '.git', 'bb.edn'),
+    root_dir = function(pattern)
+      local fallback = vim.loop.cwd()
+      local patterns = { 'project.clj', 'deps.edn', 'build.boot', 'shadow-cljs.edn', '.git', 'bb.edn' }
+      local root = util.root_pattern(patterns)(pattern)
+
+      return root or fallback
+    end,
   },
   docs = {
     description = [[


### PR DESCRIPTION
This is necessary to allow navigation within the dependencies.