### PR TITLE
refactor(util): change traversal strategy in root_pattern

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -175,18 +175,19 @@ function M.root_pattern(...)
   local patterns = M.tbl_flatten { ... }
   return function(startpath)
     startpath = M.strip_archive_subpath(startpath)
-    for _, pattern in ipairs(patterns) do
-      local match = M.search_ancestors(startpath, function(path)
+
+    local match = M.search_ancestors(startpath, function(path)
+      for _, pattern in ipairs(patterns) do
         for _, p in ipairs(vim.fn.glob(table.concat({ escape_wildcards(path), pattern }, '/'), true, true)) do
           if vim.loop.fs_stat(p) then
             return path
           end
         end
-      end)
-
-      if match ~= nil then
-        return match
       end
+    end)
+
+    if match ~= nil then
+      return match
     end
   end
 end


### PR DESCRIPTION
In the previous implementation, there was a priority order in defining the root_file.
I have modified it to give priority to the configuration file that is closer to the current directory.

### For example
```lua
local root_file = {
  '.eslintrc',
  '.eslintrc.js',
  '.eslintrc.cjs',
  '.eslintrc.yaml',
  '.eslintrc.yml',
  '.eslintrc.json',
  'eslint.config.js',
  'eslint.config.mjs',
  'eslint.config.cjs',
  'eslint.config.ts',
  'eslint.config.mts',
  'eslint.config.cts',
}
```
In the case where it runs from monorepo/packages/something,
if both `monorepo/packages/something/eslint.config.js` and `monorepo/.eslintrc` exist, the execution root is currently set to `monorepo`.

 However, I believe that the closer file `monorepo/packages/something/eslint.config.js` should be prioritized, and the execution root should be `monorepo/packages/something` instead of `monorepo`.