### PR TITLE
feat(gh_actions_ls): use `root_dir` to decide whether to attach

### DIFF
--- a/lua/lspconfig/configs/gh_actions_ls.lua
+++ b/lua/lspconfig/configs/gh_actions_ls.lua
@@ -5,10 +5,7 @@ return {
     cmd = { 'gh-actions-language-server', '--stdio' },
     filetypes = { 'yaml' },
     root_dir = function(filename)
-      if not filename:find('/%.github/workflows/.+%.ya?ml') then
-        return
-      end
-      return util.root_pattern('.github')
+      return filename:find('/%.github/workflows/.+%.ya?ml') and util.root_pattern('.github') or nil
     end,
     single_file_support = false,
     capabilities = {

--- a/lua/lspconfig/configs/gh_actions_ls.lua
+++ b/lua/lspconfig/configs/gh_actions_ls.lua
@@ -3,9 +3,14 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'gh-actions-language-server', '--stdio' },
-    filetypes = { 'yaml.github' },
-    root_dir = util.root_pattern('.github'),
-    single_file_support = true,
+    filetypes = { 'yaml' },
+    root_dir = function(filename)
+      if not filename:find('/%.github/workflows/.+%.ya?ml') then
+        return
+      end
+      return util.root_pattern('.github')
+    end,
+    single_file_support = false,
     capabilities = {
       workspace = {
         didChangeWorkspaceFolders = {
@@ -19,16 +24,6 @@ return {
 https://github.com/lttb/gh-actions-language-server
 
 Language server for GitHub Actions.
-
-The server is registered for the special `yaml.github` filetype. You need to configure this filetype pattern for GitHub workflow files.
-
-```lua
-vim.filetype.add({
-  pattern = {
-    ['.*/%.github[%w/]+workflows[%w/]+.*%.ya?ml'] = 'yaml.github',
-  },
-})
-```
 
 `gh-actions-language-server` can be installed via `npm`:
 

--- a/lua/lspconfig/configs/gh_actions_ls.lua
+++ b/lua/lspconfig/configs/gh_actions_ls.lua
@@ -4,10 +4,15 @@ return {
   default_config = {
     cmd = { 'gh-actions-language-server', '--stdio' },
     filetypes = { 'yaml' },
+
+    -- Only attach to yaml files that are GitHub workflows instead of all yaml
+    -- files. (A nil root_dir and no single_file_support results in the LSP not
+    -- attaching.) For details, see #3558
     root_dir = function(filename)
       return filename:find('/%.github/workflows/.+%.ya?ml') and util.root_pattern('.github') or nil
     end,
     single_file_support = false,
+
     capabilities = {
       workspace = {
         didChangeWorkspaceFolders = {

--- a/lua/lspconfig/configs/gh_actions_ls.lua
+++ b/lua/lspconfig/configs/gh_actions_ls.lua
@@ -11,6 +11,8 @@ return {
     root_dir = function(filename)
       return filename:find('/%.github/workflows/.+%.ya?ml') and util.root_pattern('.github') or nil
     end,
+    -- Disabling "single file support" is a hack to avoid enabling this LS for
+    -- every random yaml file, so `root_dir()` can control the enablement.
     single_file_support = false,
 
     capabilities = {


### PR DESCRIPTION
cc @disrupted 

This saves the user the extra setup work of copypasting the `vim.filetype.add` snippet, making this language server work out of the box.

Follow-up to #3551, on this suggestion: https://github.com/neovim/nvim-lspconfig/pull/3551/files#r1912833011