### PR TITLE
fix(gh_actions_ls): correctly call util.root_pattern

### DIFF
--- a/lua/lspconfig/configs/gh_actions_ls.lua
+++ b/lua/lspconfig/configs/gh_actions_ls.lua
@@ -9,7 +9,7 @@ return {
     -- files. (A nil root_dir and no single_file_support results in the LSP not
     -- attaching.) For details, see #3558
     root_dir = function(filename)
-      return filename:find('/%.github/workflows/.+%.ya?ml') and util.root_pattern('.github') or nil
+      return filename:find('/%.github/workflows/.+%.ya?ml') and util.root_pattern('.github')(filename) or nil
     end,
     -- Disabling "single file support" is a hack to avoid enabling this LS for
     -- every random yaml file, so `root_dir()` can control the enablement.


### PR DESCRIPTION
I believe this is another case of #3513