### PR TITLE
feat: Alloy language server

### DIFF
--- a/lua/lspconfig/configs/alloy_ls.lua
+++ b/lua/lspconfig/configs/alloy_ls.lua
@@ -1,0 +1,17 @@
+return {
+  default_config = {
+    cmd = { 'alloy', 'lsp' },
+    filetypes = { 'alloy' },
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+    end,
+    single_file_support = true,
+  },
+  docs = {
+    description = [[
+https://github.com/AlloyTools/org.alloytools.alloy
+
+Alloy is a formal specification language for describing structures and a tool for exploring them.
+]],
+  },
+}


### PR DESCRIPTION
This PR adds support for the Alloy language (https://github.com/AlloyTools/org.alloytools.alloy) by integrating its official language server (`alloy lsp` or `java -jar alloy6.2.0.jar lsp`).

Alloy is a well-known formal specification language and model checker, used for describing and exploring structures and systems.