### PR TITLE
feat: add wasm-language-tools

### DIFF
--- a/lua/lspconfig/configs/wasm_language_tools.lua
+++ b/lua/lspconfig/configs/wasm_language_tools.lua
@@ -1,0 +1,17 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'wat_server' },
+    filetypes = { 'wat' },
+    single_file_support = true,
+  },
+  docs = {
+    description = [[
+https://github.com/g-plane/wasm-language-tools
+
+WebAssembly Language Tools aims to provide and improve the editing experience of WebAssembly Text Format.
+It also provides an out-of-the-box formatter (a.k.a. pretty printer) for WebAssembly Text Format.
+]],
+  },
+}

--- a/lua/lspconfig/configs/wasm_language_tools.lua
+++ b/lua/lspconfig/configs/wasm_language_tools.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'wat_server' },


### PR DESCRIPTION
This PR adds [wasm-language-tools](https://github.com/g-plane/wasm-language-tools) which contains a language server for WebAssembly Text Format.