### PR TITLE
refactor(gh_actions_ls): allow .forgejo and .gitea as root_dir

### DIFF
--- a/doc/configs.md
+++ b/doc/configs.md
@@ -4116,12 +4116,6 @@ Default config:
 - `root_dir` source (use "gF" to visit): [../lua/lspconfig/configs/gh_actions_ls.lua:4](../lua/lspconfig/configs/gh_actions_ls.lua#L4)
 - `single_file_support` : `false`
 
-### Compatibility with forgejo/gitea
-
-The projects [forgejo](https://forgejo.org/) and [gitea](https://about.gitea.com/)
-design their actions to be as compatible to github as possible.  
-There are only [a few differences](https://docs.gitea.com/usage/actions/comparison#unsupported-workflows-syntax) between the systems.  
-The `gh_actions_ls` is therefore enabled for those `yaml` files as well.
 
 ## ghcide
 

--- a/doc/configs.md
+++ b/doc/configs.md
@@ -4116,6 +4116,12 @@ Default config:
 - `root_dir` source (use "gF" to visit): [../lua/lspconfig/configs/gh_actions_ls.lua:4](../lua/lspconfig/configs/gh_actions_ls.lua#L4)
 - `single_file_support` : `false`
 
+### Compatibility with forgejo/gitea
+
+The projects [forgejo](https://forgejo.org/) and [gitea](https://about.gitea.com/)
+design their actions to be as compatible to github as possible.  
+There are only [a few differences](https://docs.gitea.com/usage/actions/comparison#unsupported-workflows-syntax) between the systems.  
+The `gh_actions_ls` is therefore enabled for those `yaml` files as well.
 
 ## ghcide
 

--- a/lua/lspconfig/configs/gh_actions_ls.lua
+++ b/lua/lspconfig/configs/gh_actions_ls.lua
@@ -32,7 +32,12 @@ https://github.com/lttb/gh-actions-language-server
 
 Language server for GitHub Actions.
 
-`gh-actions-language-server` can be installed via `npm`:
+The projects [forgejo](https://forgejo.org/) and [gitea](https://about.gitea.com/)
+design their actions to be as compatible to github as possible
+with only [a few differences](https://docs.gitea.com/usage/actions/comparison#unsupported-workflows-syntax) between the systems.
+The `gh_actions_ls` is therefore enabled for those `yaml` files as well.
+
+The `gh-actions-language-server` can be installed via `npm`:
 
 ```sh
 npm install -g gh-actions-language-server

--- a/lua/lspconfig/configs/gh_actions_ls.lua
+++ b/lua/lspconfig/configs/gh_actions_ls.lua
@@ -9,8 +9,9 @@ return {
     -- files. (A nil root_dir and no single_file_support results in the LSP not
     -- attaching.) For details, see #3558
     root_dir = function(filename)
-      return filename:find('/%.github/workflows/.+%.ya?ml') and util.root_pattern('.github')(filename) or nil
+      return filename:find('/%.(github|forgejo|gitea)/workflows/.+%.ya?ml') and util.root_pattern('.github', '.forgejo', '.gitea')(filename) or nil
     end,
+
     -- Disabling "single file support" is a hack to avoid enabling this LS for
     -- every random yaml file, so `root_dir()` can control the enablement.
     single_file_support = false,

--- a/lua/lspconfig/configs/gh_actions_ls.lua
+++ b/lua/lspconfig/configs/gh_actions_ls.lua
@@ -9,7 +9,9 @@ return {
     -- files. (A nil root_dir and no single_file_support results in the LSP not
     -- attaching.) For details, see #3558
     root_dir = function(filename)
-      return filename:find('/%.(github|forgejo|gitea)/workflows/.+%.ya?ml') and util.root_pattern('.github', '.forgejo', '.gitea')(filename) or nil
+      return filename:find('/%.(github|forgejo|gitea)/workflows/.+%.ya?ml')
+          and util.root_pattern('.github', '.forgejo', '.gitea')(filename)
+        or nil
     end,
 
     -- Disabling "single file support" is a hack to avoid enabling this LS for


### PR DESCRIPTION
The projects [forgejo](https://forgejo.org/) and [gitea](https://about.gitea.com/) share the same syntax even across the composite actions.
There are only negligible differences IMHO which besides the actions author should be aware of.
Besides its only a matter of time until those become implemented as well.

It'd be a nice addition to let it attach for those systems as well