### PR TITLE
refactor!: deprecate util.root_pattern

### DIFF
--- a/.github/ci/run_sanitizer.sh
+++ b/.github/ci/run_sanitizer.sh
@@ -15,7 +15,7 @@ if git diff --pickaxe-all -U0 -G "${SEARCH_PATTERN}" "${REF_BRANCH}" "${PR_BRANC
   exit 1
 fi
 
-SEARCH_PATTERN='(util\.path\.dirname|util\.path\.sanitize|util\.path\.exists|util\.path\.is_file|util\.path\.is_dir|util\.path\.join|util\.path\.iterate_parents|util\.path\.traverse_parents|util\.find_mercurial_ancestor|util\.find_node_modules_ancestor|util\.find_package_json_ancestor|util\.find_git_ancestor)'
+SEARCH_PATTERN='(util\.path\.dirname|util\.path\.sanitize|util\.path\.exists|util\.path\.is_file|util\.path\.is_dir|util\.path\.join|util\.path\.iterate_parents|util\.path\.traverse_parents|util\.find_mercurial_ancestor|util\.find_node_modules_ancestor|util\.find_package_json_ancestor|util\.find_git_ancestor|util\.root_pattern)'
 
 if git diff --pickaxe-all -U0 -G "${SEARCH_PATTERN}" "${REF_BRANCH}" "${PR_BRANCH}" -- '*.lua' | grep -Ev '\.lua$' | grep -E "^\+.*${SEARCH_PATTERN}" ; then
   echo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,6 @@ Additionally, these options are often useful:
 An example for adding a new config is shown below:
 
 ```lua
-local util = require 'lspconfig.util'
-
 local function organize_imports()
   local params = {
     command = 'pyright.organizeimports',
@@ -67,14 +65,14 @@ return {
   default_config = {
     cmd = { 'pyright-langserver', '--stdio' },
     filetypes = { 'python' },
-    root_dir = util.root_pattern(
-      'pyproject.toml',
-      'setup.py',
-      'setup.cfg',
-      'requirements.txt',
-      'Pipfile',
-      'pyrightconfig.json',
-    ),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { 'pyproject.toml', 'setup.py', 'setup.cfg', 'requirements.txt', 'Pipfile', 'pyrightconfig.json' },
+          { path = fname, upward = true }
+        )[1]
+      )
+    end,
     single_file_support = true,
     settings = {
       python = {

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -245,7 +245,7 @@ ADDING NEW SERVERS                                    *lspconfig-new*
 
 The steps for adding and enabling a new server configuration are:
 
-1. Define the configuration (see also |vim.fs.root()|): >lua
+1. Define the configuration: >lua
    local lspconfig = require 'lspconfig'
    local configs = require 'lspconfig.configs'
 
@@ -256,7 +256,7 @@ The steps for adding and enabling a new server configuration are:
          cmd = {'/home/neovim/lua-language-server/run.sh'},
          filetypes = {'lua'},
          root_dir = function(fname)
-           return lspconfig.util.find_git_ancestor(fname)
+           return vim.fs.root(fname, '.git')
          end,
          settings = {},
        },
@@ -295,34 +295,38 @@ below returns a function that takes as its argument the current buffer path.
   the patterns are specified. >
    root_dir = util.root_pattern('pyproject.toml', 'requirements.txt')
 
+- WARNING: `util.root_pattern` is deprecated and will be removed in the future.
+  Instead, use >lua
+  vim.fs.dirname(vim.fs.find({ 'pyproject.toml', 'requirements.txt' }, { path = fname, upward = true })[1])
+<
 - Locate the first parent dir containing a ".git" file or directory: >lua
-  vim.fs.dirname(vim.fs.find('.git', { path = root_dir, upward = true })[1])
+  vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
 <
   If you have Nvim 0.10 or newer then >lua
-  vim.fs.root(root_dir, ".git")
+  vim.fs.root(fname, ".git")
 <
   can be used instead.
-  - Note: The old `util.find_git_ancestor` API is deprecated and will
+  - WARNING: The old `util.find_git_ancestor` API is deprecated and will
     be removed.
 <
 - Locate the first parent dir containing a "node_modules" dir: >lua
-  vim.fs.dirname(vim.fs.find('node_modules', { path = root_dir, upward = true })[1])
+  vim.fs.dirname(vim.fs.find('node_modules', { path = fname, upward = true })[1])
 <
   If you have Nvim 0.10 or newer then >lua
-  vim.fs.root(root_dir, "node_modules")
+  vim.fs.root(fname, "node_modules")
 <
   can be used instead.
-  - Note: The old `util.find_node_modules_ancestor` API is deprecated and will
+  - WARNING: The old `util.find_node_modules_ancestor` API is deprecated and will
     be removed.
 
 - Locate the first parent dir containing a "package.json" dir: >lua
-  vim.fs.dirname(vim.fs.find('package.json', { path = root_dir, upward = true })[1])
+  vim.fs.dirname(vim.fs.find('package.json', { path = fname, upward = true })[1])
 <
   If you have Nvim 0.10 or newer then >lua
-  vim.fs.root(root_dir, "package.json")
+  vim.fs.root(fname, "package.json")
 <
   can be used instead.
-  - Note: The old `util.find_package_json_ancestor` API is deprecated and will
+  - WARNING: The old `util.find_package_json_ancestor` API is deprecated and will
     be removed.
 <
 Note: On Windows, `lspconfig` always assumes forward slash normalized paths with
@@ -354,8 +358,8 @@ for some project structures. Example (for Kotlin): >lua
     'build.gradle.kts', -- Gradle
   }
   root_dir = function(fname)
-    local primary = util.root_pattern(unpack(root_files))(fname)
-    local fallback = util.root_pattern(unpack(fallback_root_files))(fname)
+    local primary = vim.fs.root(fname, root_files)
+    local fallback = vim.fs.root(fname, fallback_root_files)
     return primary or fallback
   end
 <

--- a/lua/lspconfig/configs/ada_ls.lua
+++ b/lua/lspconfig/configs/ada_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ada_language_server' },
     filetypes = { 'ada' },
-    root_dir = util.root_pattern('Makefile', '.git', '*.gpr', '*.adc'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Makefile', '.git', '*.gpr', '*.adc' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/agda_ls.lua
+++ b/lua/lspconfig/configs/agda_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'als' },
     filetypes = { 'agda' },
-    root_dir = util.root_pattern('.git', '*.agda-lib'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git', '*.agda-lib' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/aiken.lua
+++ b/lua/lspconfig/configs/aiken.lua
@@ -1,11 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'aiken', 'lsp' },
     filetypes = { 'aiken' },
     root_dir = function(fname)
-      return util.root_pattern('aiken.toml', '.git')(fname)
+      return vim.fs.dirname(vim.fs.find({ 'aiken.toml', '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/alloy_ls.lua
+++ b/lua/lspconfig/configs/alloy_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'alloy', 'lsp' },
     filetypes = { 'alloy' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/anakin_language_server.lua
+++ b/lua/lspconfig/configs/anakin_language_server.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'anakinls' },
@@ -12,8 +10,7 @@ return {
         'requirements.txt',
         'Pipfile',
       }
-      return util.root_pattern(unpack(root_files))(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files), '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     settings = {

--- a/lua/lspconfig/configs/angularls.lua
+++ b/lua/lspconfig/configs/angularls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 -- Angular requires a node_modules directory to probe for @angular/language-service and typescript
 -- in order to use your projects configured versions.
 -- This defaults to the vim cwd, but will get overwritten by the resolved root of the file.
@@ -25,7 +23,9 @@ return {
     -- Check for angular.json since that is the root of the project.
     -- Don't check for tsconfig.json or package.json since there are multiple of these
     -- in an angular monorepo setup.
-    root_dir = util.root_pattern 'angular.json',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'angular.json' }, { path = fname, upward = true })[1])
+    end,
   },
   on_new_config = function(new_config, new_root_dir)
     local new_probe_dir = get_probe_dir(new_root_dir)

--- a/lua/lspconfig/configs/ansiblels.lua
+++ b/lua/lspconfig/configs/ansiblels.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ansible-language-server', '--stdio' },
@@ -24,7 +22,9 @@ return {
       },
     },
     filetypes = { 'yaml.ansible' },
-    root_dir = util.root_pattern('ansible.cfg', '.ansible-lint'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'ansible.cfg', '.ansible-lint' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/antlersls.lua
+++ b/lua/lspconfig/configs/antlersls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'antlersls', '--stdio' },
     filetypes = { 'html', 'antlers' },
-    root_dir = util.root_pattern 'composer.json',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'composer.json' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/apex_ls.lua
+++ b/lua/lspconfig/configs/apex_ls.lua
@@ -1,9 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     filetypes = { 'apexcode' },
-    root_dir = util.root_pattern 'sfdx-project.json',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'sfdx-project.json' }, { path = fname, upward = true })[1])
+    end,
     on_new_config = function(config)
       if not config.cmd and config.apex_jar_path then
         config.cmd = {

--- a/lua/lspconfig/configs/arduino_language_server.lua
+++ b/lua/lspconfig/configs/arduino_language_server.lua
@@ -1,9 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     filetypes = { 'arduino' },
-    root_dir = util.root_pattern '*.ino',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.ino' }, { path = fname, upward = true })[1])
+    end,
     cmd = {
       'arduino-language-server',
     },

--- a/lua/lspconfig/configs/ast_grep.lua
+++ b/lua/lspconfig/configs/ast_grep.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ast-grep', 'lsp' },
@@ -18,7 +16,9 @@ return {
       'dart',
       'lua',
     },
-    root_dir = util.root_pattern('sgconfig.yaml', 'sgconfig.yml'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'sgconfig.yaml', 'sgconfig.yml' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/astro.lua
+++ b/lua/lspconfig/configs/astro.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local function get_typescript_server_path(root_dir)
   local project_root = vim.fs.find('node_modules', { path = root_dir, upward = true })[1]
   return project_root and (project_root .. '/typescript/lib') or ''
@@ -9,7 +7,11 @@ return {
   default_config = {
     cmd = { 'astro-ls', '--stdio' },
     filetypes = { 'astro' },
-    root_dir = util.root_pattern('package.json', 'tsconfig.json', 'jsconfig.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'package.json', 'tsconfig.json', 'jsconfig.json', '.git' }, { path = fname, upward = true })[1]
+      )
+    end,
     init_options = {
       typescript = {},
     },

--- a/lua/lspconfig/configs/atlas.lua
+++ b/lua/lspconfig/configs/atlas.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'atlas', 'tool', 'lsp', '--stdio' },
@@ -7,7 +5,7 @@ return {
       'atlas-*',
     },
     root_dir = function(fname)
-      return util.root_pattern('atlas.hcl')(fname)
+      return vim.fs.dirname(vim.fs.find({ 'atlas.hcl' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/autotools_ls.lua
+++ b/lua/lspconfig/configs/autotools_ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local root_files = { 'configure.ac', 'Makefile', 'Makefile.am', '*.mk' }
 
 return {
@@ -7,7 +5,7 @@ return {
     cmd = { 'autotools-language-server' },
     filetypes = { 'config', 'automake', 'make' },
     root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname)
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files) }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/azure_pipelines_ls.lua
+++ b/lua/lspconfig/configs/azure_pipelines_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'azure-pipelines-language-server', '--stdio' },
     filetypes = { 'yaml' },
-    root_dir = util.root_pattern 'azure-pipelines.yml',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'azure-pipelines.yml' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
     settings = {},
   },

--- a/lua/lspconfig/configs/bacon_ls.lua
+++ b/lua/lspconfig/configs/bacon_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'bacon-ls' },
     filetypes = { 'rust' },
-    root_dir = util.root_pattern('.bacon-locations', 'Cargo.toml'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.bacon-locations', 'Cargo.toml' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
     settings = {},
   },

--- a/lua/lspconfig/configs/ballerina.lua
+++ b/lua/lspconfig/configs/ballerina.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'bal', 'start-language-server' },
     filetypes = { 'ballerina' },
-    root_dir = util.root_pattern 'Ballerina.toml',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Ballerina.toml' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/basedpyright.lua
+++ b/lua/lspconfig/configs/basedpyright.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 local root_files = {
   'pyproject.toml',
@@ -16,20 +16,20 @@ local function organize_imports()
     arguments = { vim.uri_from_bufnr(0) },
   }
 
-  local clients = util.get_lsp_clients {
+  local clients = util.get_lsp_clients({
     bufnr = vim.api.nvim_get_current_buf(),
     name = 'basedpyright',
-  }
+  })
   for _, client in ipairs(clients) do
     client.request('workspace/executeCommand', params, nil, 0)
   end
 end
 
 local function set_python_path(path)
-  local clients = util.get_lsp_clients {
+  local clients = util.get_lsp_clients({
     bufnr = vim.api.nvim_get_current_buf(),
     name = 'basedpyright',
-  }
+  })
   for _, client in ipairs(clients) do
     if client.settings then
       client.settings.python = vim.tbl_deep_extend('force', client.settings.python or {}, { pythonPath = path })
@@ -45,7 +45,7 @@ return {
     cmd = { 'basedpyright-langserver', '--stdio' },
     filetypes = { 'python' },
     root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname)
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files) }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     settings = {

--- a/lua/lspconfig/configs/bashls.lua
+++ b/lua/lspconfig/configs/bashls.lua
@@ -15,7 +15,7 @@ return {
     },
     filetypes = { 'bash', 'sh' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/bazelrc_lsp.lua
+++ b/lua/lspconfig/configs/bazelrc_lsp.lua
@@ -1,10 +1,12 @@
-local util = require 'lspconfig/util'
-
 return {
   default_config = {
     cmd = { 'bazelrc-lsp' },
     filetypes = { 'bazelrc' },
-    root_dir = util.root_pattern('WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel' }, { path = fname, upward = true })[1]
+      )
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/beancount.lua
+++ b/lua/lspconfig/configs/beancount.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'beancount-language-server', '--stdio' },
     filetypes = { 'beancount', 'bean' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     init_options = {},

--- a/lua/lspconfig/configs/bicep.lua
+++ b/lua/lspconfig/configs/bicep.lua
@@ -2,7 +2,7 @@ return {
   default_config = {
     filetypes = { 'bicep' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     init_options = {},
   },

--- a/lua/lspconfig/configs/biome.lua
+++ b/lua/lspconfig/configs/biome.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'biome', 'lsp-proxy' },
@@ -17,7 +15,9 @@ return {
       'typescriptreact',
       'vue',
     },
-    root_dir = util.root_pattern('biome.json', 'biome.jsonc'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'biome.json', 'biome.jsonc' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = false,
   },
   docs = {

--- a/lua/lspconfig/configs/bitbake_language_server.lua
+++ b/lua/lspconfig/configs/bitbake_language_server.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'bitbake-language-server' },
     filetypes = { 'bitbake' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/bitbake_ls.lua
+++ b/lua/lspconfig/configs/bitbake_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'language-server-bitbake', '--stdio' },
     filetypes = { 'bitbake' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = false,
   },

--- a/lua/lspconfig/configs/blueprint_ls.lua
+++ b/lua/lspconfig/configs/blueprint_ls.lua
@@ -10,7 +10,7 @@ return {
     },
     filetypes = { 'blueprint' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/bqnlsp.lua
+++ b/lua/lspconfig/configs/bqnlsp.lua
@@ -2,9 +2,9 @@
 local function library_path(path, cmd_env)
   path = path or '/usr/local/lib'
   cmd_env = cmd_env or {}
-  if vim.fn.has 'macunix' and not cmd_env.DYLD_LIBRARY_PATH then
+  if vim.fn.has('macunix') and not cmd_env.DYLD_LIBRARY_PATH then
     cmd_env.DYLD_LIBRARY_PATH = path
-  elseif vim.fn.has 'linux' and not cmd_env.LD_LIBRARY_PATH then
+  elseif vim.fn.has('linux') and not cmd_env.LD_LIBRARY_PATH then
     cmd_env.LD_LIBRARY_PATH = path
   end
   return cmd_env
@@ -15,7 +15,7 @@ return {
     cmd = { 'bqnlsp' },
     filetypes = { 'bqn' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     libcbqnPath = nil,

--- a/lua/lspconfig/configs/bright_script.lua
+++ b/lua/lspconfig/configs/bright_script.lua
@@ -1,11 +1,11 @@
-local util = require 'lspconfig/util'
-
 return {
   default_config = {
     cmd = { 'bsc', '--lsp', '--stdio' },
     filetypes = { 'brs' },
     single_file_support = true,
-    root_dir = util.root_pattern('makefile', 'Makefile', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'makefile', 'Makefile', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/bsl_ls.lua
+++ b/lua/lspconfig/configs/bsl_ls.lua
@@ -2,7 +2,7 @@ return {
   default_config = {
     filetypes = { 'bsl', 'os' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/buck2.lua
+++ b/lua/lspconfig/configs/buck2.lua
@@ -1,11 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'buck2', 'lsp' },
     filetypes = { 'bzl' },
     root_dir = function(fname)
-      return util.root_pattern '.buckconfig'(fname)
+      return vim.fs.dirname(vim.fs.find({ '.buckconfig' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/buddy_ls.lua
+++ b/lua/lspconfig/configs/buddy_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'buddy-lsp-server' },
     filetypes = { 'mlir' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/buf_ls.lua
+++ b/lua/lspconfig/configs/buf_ls.lua
@@ -2,7 +2,9 @@ return {
   default_config = {
     cmd = { 'buf', 'beta', 'lsp', '--timeout=0', '--log-format=text' },
     filetypes = { 'proto' },
-    root_dir = require('lspconfig.util').root_pattern('buf.yaml', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'buf.yaml', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/bufls.lua
+++ b/lua/lspconfig/configs/bufls.lua
@@ -1,11 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'bufls', 'serve' },
     filetypes = { 'proto' },
     root_dir = function(fname)
-      return util.root_pattern('buf.work.yaml', '.git')(fname)
+      return vim.fs.dirname(vim.fs.find({ 'buf.work.yaml', '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/bzl.lua
+++ b/lua/lspconfig/configs/bzl.lua
@@ -1,11 +1,11 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'bzl', 'lsp', 'serve' },
     filetypes = { 'bzl' },
     -- https://docs.bazel.build/versions/5.4.1/build-ref.html#workspace
-    root_dir = util.root_pattern('WORKSPACE', 'WORKSPACE.bazel'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'WORKSPACE', 'WORKSPACE.bazel' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/c3_lsp.lua
+++ b/lua/lspconfig/configs/c3_lsp.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'c3lsp' },
     root_dir = function(fname)
-      return util.root_pattern { 'project.json', 'manifest.json', '.git' }(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'project.json', 'manifest.json', '.git' }, { path = fname, upward = true })[1]
+      )
     end,
     filetypes = { 'c3', 'c3i' },
   },

--- a/lua/lspconfig/configs/cadence.lua
+++ b/lua/lspconfig/configs/cadence.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'flow', 'cadence', 'language-server' },
@@ -7,8 +5,8 @@ return {
     init_options = {
       numberOfAccounts = '1',
     },
-    root_dir = function(fname, _)
-      return util.root_pattern 'flow.json'(fname) or vim.env.HOME
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find('flow.json', { path = fname, upward = true })[1]) or vim.env.HOME
     end,
     on_new_config = function(new_config, new_root_dir)
       new_config.init_options.configPath = new_root_dir .. '/flow.json'

--- a/lua/lspconfig/configs/cairo_ls.lua
+++ b/lua/lspconfig/configs/cairo_ls.lua
@@ -1,11 +1,13 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     init_options = { hostInfo = 'neovim' },
     cmd = { 'scarb-cairo-language-server', '/C', '--node-ipc' },
     filetypes = { 'cairo' },
-    root_dir = util.root_pattern('Scarb.toml', 'cairo_project.toml', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'Scarb.toml', 'cairo_project.toml', '.git' }, { path = fname, upward = true })[1]
+      )
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/ccls.lua
+++ b/lua/lspconfig/configs/ccls.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 local function switch_source_header(bufnr)
   local method_name = 'textDocument/switchSourceHeader'
@@ -25,8 +25,9 @@ return {
     cmd = { 'ccls' },
     filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda' },
     root_dir = function(fname)
-      return util.root_pattern('compile_commands.json', '.ccls')(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(
+        vim.fs.find({ 'compile_commands.json', '.ccls', '.git' }, { path = fname, upward = true })[1]
+      )
     end,
     offset_encoding = 'utf-32',
     -- ccls does not support sending a null root directory

--- a/lua/lspconfig/configs/cds_lsp.lua
+++ b/lua/lspconfig/configs/cds_lsp.lua
@@ -1,11 +1,11 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'cds-lsp', '--stdio' },
     filetypes = { 'cds' },
     -- init_options = { provideFormatter = true }, -- needed to enable formatting capabilities
-    root_dir = util.root_pattern('package.json', 'db', 'srv'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'package.json', 'db', 'srv' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
     settings = {
       cds = { validate = true },

--- a/lua/lspconfig/configs/circom-lsp.lua
+++ b/lua/lspconfig/configs/circom-lsp.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'circom-lsp' },
     filetypes = { 'circom' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/clangd.lua
+++ b/lua/lspconfig/configs/clangd.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 -- https://clangd.llvm.org/extensions.html#switch-between-sourceheader
 local function switch_source_header(bufnr)
@@ -24,7 +24,7 @@ end
 local function symbol_info()
   local bufnr = vim.api.nvim_get_current_buf()
   local clangd_client = util.get_active_client_by_name(bufnr, 'clangd')
-  if not clangd_client or not clangd_client.supports_method 'textDocument/symbolInfo' then
+  if not clangd_client or not clangd_client.supports_method('textDocument/symbolInfo') then
     return vim.notify('Clangd client not found', vim.log.levels.ERROR)
   end
   local win = vim.api.nvim_get_current_win()
@@ -52,14 +52,15 @@ return {
     cmd = { 'clangd' },
     filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda', 'proto' },
     root_dir = function(fname)
-      return util.root_pattern(
+      return vim.fs.dirname(vim.fs.find({
         '.clangd',
         '.clang-tidy',
         '.clang-format',
         'compile_commands.json',
         'compile_flags.txt',
-        'configure.ac' -- AutoTools
-      )(fname) or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+        'configure.ac', -- AutoTools
+        '.git',
+      }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     capabilities = {

--- a/lua/lspconfig/configs/clarity_lsp.lua
+++ b/lua/lspconfig/configs/clarity_lsp.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'clarity-lsp' },
     filetypes = { 'clar', 'clarity' },
-    root_dir = util.root_pattern '.git',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/clojure_lsp.lua
+++ b/lua/lspconfig/configs/clojure_lsp.lua
@@ -1,10 +1,15 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'clojure-lsp' },
     filetypes = { 'clojure', 'edn' },
-    root_dir = util.root_pattern('project.clj', 'deps.edn', 'build.boot', 'shadow-cljs.edn', '.git', 'bb.edn'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { 'project.clj', 'deps.edn', 'build.boot', 'shadow-cljs.edn', '.git', 'bb.edn' },
+          { path = fname, upward = true }
+        )[1]
+      )
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/cmake.lua
+++ b/lua/lspconfig/configs/cmake.lua
@@ -1,11 +1,14 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'cmake-language-server' },
     filetypes = { 'cmake' },
     root_dir = function(fname)
-      return util.root_pattern('CMakePresets.json', 'CTestConfig.cmake', '.git', 'build', 'cmake')(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { 'CMakePresets.json', 'CTestConfig.cmake', '.git', 'build', 'cmake' },
+          { path = fname, upward = true }
+        )[1]
+      )
     end,
     single_file_support = true,
     init_options = {

--- a/lua/lspconfig/configs/cobol_ls.lua
+++ b/lua/lspconfig/configs/cobol_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'cobol-language-support' },
     filetypes = { 'cobol' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/codeqlls.lua
+++ b/lua/lspconfig/configs/codeqlls.lua
@@ -1,12 +1,12 @@
-local util = require 'lspconfig.util'
-
 local workspace_folders = {}
 
 return {
   default_config = {
     cmd = { 'codeql', 'execute', 'language-server', '--check-errors', 'ON_CHANGE', '-q' },
     filetypes = { 'ql' },
-    root_dir = util.root_pattern 'qlpack.yml',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'qlpack.yml' }, { path = fname, upward = true })[1])
+    end,
     log_level = vim.lsp.protocol.MessageType.Warning,
     before_init = function(initialize_params)
       table.insert(workspace_folders, { name = 'workspace', uri = initialize_params['rootUri'] })

--- a/lua/lspconfig/configs/coffeesense.lua
+++ b/lua/lspconfig/configs/coffeesense.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'coffeesense-language-server', '--stdio' },
     filetypes = { 'coffee' },
-    root_dir = util.root_pattern 'package.json',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'package.json' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/contextive.lua
+++ b/lua/lspconfig/configs/contextive.lua
@@ -1,9 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'Contextive.LanguageServer' },
-    root_dir = util.root_pattern('.contextive', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.contextive', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/coq_lsp.lua
+++ b/lua/lspconfig/configs/coq_lsp.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'coq-lsp' },
     filetypes = { 'coq' },
     root_dir = function(fname)
-      return util.root_pattern '_CoqProject'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '_CoqProject', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/crystalline.lua
+++ b/lua/lspconfig/configs/crystalline.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'crystalline' },
     filetypes = { 'crystal' },
     root_dir = function(fname)
-      return util.root_pattern('shard.yml')(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git', 'shard.yml' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/csharp_ls.lua
+++ b/lua/lspconfig/configs/csharp_ls.lua
@@ -1,10 +1,8 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'csharp-ls' },
     root_dir = function(fname)
-      return util.root_pattern '*.sln'(fname) or util.root_pattern '*.csproj'(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.sln', '*.csproj' }, { path = fname, upward = true })[1])
     end,
     filetypes = { 'cs' },
     init_options = {

--- a/lua/lspconfig/configs/css_variables.lua
+++ b/lua/lspconfig/configs/css_variables.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'css-variables-language-server', '--stdio' },
     filetypes = { 'css', 'scss', 'less' },
-    root_dir = util.root_pattern('package.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'package.json', '.git' }, { path = fname, upward = true })[1])
+    end,
     -- Same as inlined defaults that don't seem to work without hardcoding them in the lua config
     -- https://github.com/vunguyentuan/vscode-css-variables/blob/763a564df763f17aceb5f3d6070e0b444a2f47ff/packages/css-variables-language-server/src/CSSVariableManager.ts#L31-L50
     settings = {

--- a/lua/lspconfig/configs/cssls.lua
+++ b/lua/lspconfig/configs/cssls.lua
@@ -1,11 +1,11 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'vscode-css-language-server', '--stdio' },
     filetypes = { 'css', 'scss', 'less' },
     init_options = { provideFormatter = true }, -- needed to enable formatting capabilities
-    root_dir = util.root_pattern('package.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'package.json', '.git' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
     settings = {
       css = { validate = true },

--- a/lua/lspconfig/configs/cucumber_language_server.lua
+++ b/lua/lspconfig/configs/cucumber_language_server.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'cucumber-language-server', '--stdio' },
     filetypes = { 'cucumber' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/cue.lua
+++ b/lua/lspconfig/configs/cue.lua
@@ -1,11 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'cue', 'lsp' },
     filetypes = { 'cue' },
     root_dir = function(fname)
-      return util.root_pattern(unpack({ 'cue.mod', '.git' }))(fname)
+      return vim.fs.dirname(vim.fs.find({ 'cue.mod', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/custom_elements_ls.lua
+++ b/lua/lspconfig/configs/custom_elements_ls.lua
@@ -1,10 +1,12 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     init_options = { hostInfo = 'neovim' },
     cmd = { 'custom-elements-languageserver', '--stdio' },
-    root_dir = util.root_pattern('tsconfig.json', 'package.json', 'jsconfig.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'tsconfig.json', 'package.json', 'jsconfig.json', '.git' }, { path = fname, upward = true })[1]
+      )
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/cypher_ls.lua
+++ b/lua/lspconfig/configs/cypher_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'cypher-language-server', '--stdio' },
     filetypes = { 'cypher' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/daedalus_ls.lua
+++ b/lua/lspconfig/configs/daedalus_ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local root_files = {
   'Gothic.src',
   'Camera.src',
@@ -14,7 +12,9 @@ return {
   default_config = {
     cmd = { 'DaedalusLanguageServer' },
     filetypes = { 'd' },
-    root_dir = util.root_pattern(unpack(root_files)),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files) }, { path = fname, upward = true })[1])
+    end,
     settings = {
       DaedalusLanguageServer = {
         loglevel = 'debug',

--- a/lua/lspconfig/configs/dafny.lua
+++ b/lua/lspconfig/configs/dafny.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'dafny', 'server' },
     filetypes = { 'dfy', 'dafny' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/dagger.lua
+++ b/lua/lspconfig/configs/dagger.lua
@@ -1,11 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'cuelsp' },
     filetypes = { 'cue' },
     root_dir = function(fname)
-      return util.root_pattern('cue.mod', '.git')(fname)
+      return vim.fs.dirname(vim.fs.find({ 'cue.mod', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/dartls.lua
+++ b/lua/lspconfig/configs/dartls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'dart', 'language-server', '--protocol=lsp' },
     filetypes = { 'dart' },
-    root_dir = util.root_pattern 'pubspec.yaml',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'pubspec.yaml' }, { path = fname, upward = true })[1])
+    end,
     init_options = {
       onlyAnalyzeProjectsWithOpenFiles = true,
       suggestFromUnimportedLibraries = true,

--- a/lua/lspconfig/configs/dcmls.lua
+++ b/lua/lspconfig/configs/dcmls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'dcm', 'start-server', '--client=neovim' },
     filetypes = { 'dart' },
-    root_dir = util.root_pattern 'pubspec.yaml',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'pubspec.yaml' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/debputy.lua
+++ b/lua/lspconfig/configs/debputy.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'debputy', 'lsp', 'server' },
     filetypes = { 'debcontrol', 'debcopyright', 'debchangelog', 'make', 'yaml' },
-    root_dir = util.root_pattern 'debian',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'debian' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/delphi_ls.lua
+++ b/lua/lspconfig/configs/delphi_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'DelphiLSP.exe' },
     filetypes = { 'pascal' },
-    root_dir = util.root_pattern '*.dpr',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.dpr' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = false,
   },
   docs = {

--- a/lua/lspconfig/configs/denols.lua
+++ b/lua/lspconfig/configs/denols.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 local lsp = vim.lsp
 
 local function buf_cache(bufnr, client)
@@ -52,7 +52,7 @@ local function denols_handler(err, result, ctx, config)
   local client = vim.lsp.get_client_by_id(ctx.client_id)
   for _, res in pairs(result) do
     local uri = res.uri or res.targetUri
-    if uri:match '^deno:' then
+    if uri:match('^deno:') then
       virtual_text_document(uri, client)
       res['uri'] = uri
       res['targetUri'] = uri
@@ -74,7 +74,9 @@ return {
       'typescriptreact',
       'typescript.tsx',
     },
-    root_dir = util.root_pattern('deno.json', 'deno.jsonc', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'deno.json', 'deno.jsonc', '.git' }, { path = fname, upward = true })[1])
+    end,
     settings = {
       deno = {
         enable = true,
@@ -96,7 +98,7 @@ return {
   commands = {
     DenolsCache = {
       function()
-        local clients = util.get_lsp_clients { bufnr = 0, name = 'denols' }
+        local clients = util.get_lsp_clients({ bufnr = 0, name = 'denols' })
         if #clients > 0 then
           buf_cache(0, clients[#clients])
         end

--- a/lua/lspconfig/configs/dhall_lsp_server.lua
+++ b/lua/lspconfig/configs/dhall_lsp_server.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'dhall-lsp-server' },
     filetypes = { 'dhall' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/diagnosticls.lua
+++ b/lua/lspconfig/configs/diagnosticls.lua
@@ -3,7 +3,7 @@ return {
   default_config = {
     cmd = { 'diagnostic-languageserver', '--stdio' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     -- Empty by default, override to add filetypes.

--- a/lua/lspconfig/configs/digestif.lua
+++ b/lua/lspconfig/configs/digestif.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'digestif' },
     filetypes = { 'tex', 'plaintex', 'context' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/djlsp.lua
+++ b/lua/lspconfig/configs/djlsp.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'djlsp' },
     filetypes = { 'html', 'htmldjango' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     settings = {},
   },

--- a/lua/lspconfig/configs/docker_compose_language_service.lua
+++ b/lua/lspconfig/configs/docker_compose_language_service.lua
@@ -1,10 +1,15 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'docker-compose-langserver', '--stdio' },
     filetypes = { 'yaml.docker-compose' },
-    root_dir = util.root_pattern('docker-compose.yaml', 'docker-compose.yml', 'compose.yaml', 'compose.yml'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { 'docker-compose.yaml', 'docker-compose.yml', 'compose.yaml', 'compose.yml' },
+          { path = fname, upward = true }
+        )[1]
+      )
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/dockerls.lua
+++ b/lua/lspconfig/configs/dockerls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'docker-langserver', '--stdio' },
     filetypes = { 'dockerfile' },
-    root_dir = util.root_pattern 'Dockerfile',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Dockerfile' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/dolmenls.lua
+++ b/lua/lspconfig/configs/dolmenls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'dolmenls' },
     filetypes = { 'smt2', 'tptp', 'p', 'cnf', 'icnf', 'zf' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/dotls.lua
+++ b/lua/lspconfig/configs/dotls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'dot-language-server', '--stdio' },
     filetypes = { 'dot' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/dprint.lua
+++ b/lua/lspconfig/configs/dprint.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'dprint', 'lsp' },
@@ -17,7 +15,11 @@ return {
       'roslyn',
       'graphql',
     },
-    root_dir = util.root_pattern('dprint.json', '.dprint.json', 'dprint.jsonc', '.dprint.jsonc'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'dprint.json', '.dprint.json', 'dprint.jsonc', '.dprint.jsonc' }, { path = fname, upward = true })[1]
+      )
+    end,
     single_file_support = true,
     settings = {},
   },

--- a/lua/lspconfig/configs/drools_lsp.lua
+++ b/lua/lspconfig/configs/drools_lsp.lua
@@ -2,7 +2,7 @@ local function get_java_bin(config)
   local java_bin = vim.tbl_get(config, 'drools', 'java', 'bin')
   if not java_bin then
     java_bin = vim.env.JAVA_HOME and (vim.env.JAVA_HOME .. '/bin/java') or 'java'
-    if vim.fn.has 'win32' == 1 then
+    if vim.fn.has('win32') == 1 then
       java_bin = java_bin .. '.exe'
     end
   end
@@ -36,7 +36,7 @@ return {
   default_config = {
     filetypes = { 'drools' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     on_new_config = function(new_config)

--- a/lua/lspconfig/configs/ds_pinyin_lsp.lua
+++ b/lua/lspconfig/configs/ds_pinyin_lsp.lua
@@ -1,7 +1,7 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 local bin_name = 'ds-pinyin-lsp'
-if vim.fn.has 'win32' == 1 then
+if vim.fn.has('win32') == 1 then
   bin_name = bin_name .. '.exe'
 end
 
@@ -13,7 +13,7 @@ local function ds_pinyin_lsp_off(bufnr)
       ['completion_on'] = false,
     })
   else
-    vim.notify 'notification $/turn/completion is not supported by any servers active on the current buffer'
+    vim.notify('notification $/turn/completion is not supported by any servers active on the current buffer')
   end
 end
 
@@ -25,7 +25,7 @@ local function ds_pinyin_lsp_on(bufnr)
       ['completion_on'] = true,
     })
   else
-    vim.notify 'notification $/turn/completion is not supported by any servers active on the current buffer'
+    vim.notify('notification $/turn/completion is not supported by any servers active on the current buffer')
   end
 end
 
@@ -34,7 +34,7 @@ return {
     cmd = { bin_name },
     filetypes = { 'markdown', 'org' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     init_options = {

--- a/lua/lspconfig/configs/earthlyls.lua
+++ b/lua/lspconfig/configs/earthlyls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig/util'
-
 return {
   default_config = {
     cmd = { 'earthlyls' },
     filetypes = { 'earthfile' },
-    root_dir = util.root_pattern 'Earthfile',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Earthfile' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/ecsact.lua
+++ b/lua/lspconfig/configs/ecsact.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ecsact_lsp_server', '--stdio' },
     filetypes = { 'ecsact' },
-    root_dir = util.root_pattern '.git',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
 

--- a/lua/lspconfig/configs/efm.lua
+++ b/lua/lspconfig/configs/efm.lua
@@ -2,7 +2,7 @@ return {
   default_config = {
     cmd = { 'efm-langserver' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/elmls.lua
+++ b/lua/lspconfig/configs/elmls.lua
@@ -1,7 +1,8 @@
-local util = require 'lspconfig.util'
 local api = vim.api
 
-local elm_root_pattern = util.root_pattern 'elm.json'
+local elm_root_pattern = function(fname)
+  return vim.fs.dirname(vim.fs.find({ 'elm.json' }, { path = fname, upward = true })[1])
+end
 
 return {
   default_config = {
@@ -10,7 +11,7 @@ return {
     filetypes = { 'elm' },
     root_dir = function(fname)
       local filetype = api.nvim_buf_get_option(0, 'filetype')
-      if filetype == 'elm' or (filetype == 'json' and fname:match 'elm%.json$') then
+      if filetype == 'elm' or (filetype == 'json' and fname:match('elm%.json$')) then
         return elm_root_pattern(fname)
       end
     end,

--- a/lua/lspconfig/configs/elp.lua
+++ b/lua/lspconfig/configs/elp.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'elp', 'server' },
     filetypes = { 'erlang' },
-    root_dir = util.root_pattern('rebar.config', 'erlang.mk', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'rebar.config', 'erlang.mk', '.git' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/ember.lua
+++ b/lua/lspconfig/configs/ember.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ember-language-server', '--stdio' },
     filetypes = { 'handlebars', 'typescript', 'javascript', 'typescript.glimmer', 'javascript.glimmer' },
-    root_dir = util.root_pattern('ember-cli-build.js', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'ember-cli-build.js', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/emmet_language_server.lua
+++ b/lua/lspconfig/configs/emmet_language_server.lua
@@ -15,7 +15,7 @@ return {
       'htmlangular',
     },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/emmet_ls.lua
+++ b/lua/lspconfig/configs/emmet_ls.lua
@@ -18,7 +18,7 @@ return {
       'htmlangular',
     },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/erg_language_server.lua
+++ b/lua/lspconfig/configs/erg_language_server.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'erg', '--language-server' },
     filetypes = { 'erg' },
     root_dir = function(fname)
-      return util.root_pattern 'package.er'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'package.er', '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/erlangls.lua
+++ b/lua/lspconfig/configs/erlangls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'erlang_ls' },
     filetypes = { 'erlang' },
-    root_dir = util.root_pattern('rebar.config', 'erlang.mk', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'rebar.config', 'erlang.mk', '.git' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/esbonio.lua
+++ b/lua/lspconfig/configs/esbonio.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'python3', '-m', 'esbonio' },
     filetypes = { 'rst' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/eslint.lua
+++ b/lua/lspconfig/configs/eslint.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 local lsp = vim.lsp
 
 local function fix_all(opts)
@@ -64,7 +64,7 @@ return {
     -- https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats
     root_dir = function(fname)
       root_file = util.insert_package_json(root_file, 'eslintConfig', fname)
-      return util.root_pattern(unpack(root_file))(fname)
+      return vim.fs.dirname(vim.fs.find(root_file, { path = fname, upward = true })[1])
     end,
     -- Refer to https://github.com/Microsoft/vscode-eslint#settings-options for documentation.
     settings = {
@@ -135,9 +135,9 @@ return {
           return
         end
         local sysname = vim.loop.os_uname().sysname
-        if sysname:match 'Windows' then
+        if sysname:match('Windows') then
           os.execute(string.format('start %q', result.url))
-        elseif sysname:match 'Linux' then
+        elseif sysname:match('Linux') then
           os.execute(string.format('xdg-open %q', result.url))
         else
           os.execute(string.format('open %q', result.url))
@@ -163,7 +163,7 @@ return {
   commands = {
     EslintFixAll = {
       function()
-        fix_all { sync = true, bufnr = 0 }
+        fix_all({ sync = true, bufnr = 0 })
       end,
       description = 'Fix all eslint problems for this buffer',
     },

--- a/lua/lspconfig/configs/facility_language_server.lua
+++ b/lua/lspconfig/configs/facility_language_server.lua
@@ -4,7 +4,7 @@ return {
     filetypes = { 'fsd' },
     single_file_support = true,
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/fennel_language_server.lua
+++ b/lua/lspconfig/configs/fennel_language_server.lua
@@ -4,7 +4,7 @@ return {
     filetypes = { 'fennel' },
     single_file_support = true,
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     settings = {},
   },

--- a/lua/lspconfig/configs/fennel_ls.lua
+++ b/lua/lspconfig/configs/fennel_ls.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 return {
   default_config = {

--- a/lua/lspconfig/configs/fish_lsp.lua
+++ b/lua/lspconfig/configs/fish_lsp.lua
@@ -4,7 +4,7 @@ return {
     cmd_env = { fish_lsp_show_client_popups = false },
     filetypes = { 'fish' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/flow.lua
+++ b/lua/lspconfig/configs/flow.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'npx', '--no-install', 'flow', 'lsp' },
     filetypes = { 'javascript', 'javascriptreact', 'javascript.jsx' },
-    root_dir = util.root_pattern '.flowconfig',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.flowconfig' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/flux_lsp.lua
+++ b/lua/lspconfig/configs/flux_lsp.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'flux-lsp' },
     filetypes = { 'flux' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/foam_ls.lua
+++ b/lua/lspconfig/configs/foam_ls.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 return {
   default_config = {

--- a/lua/lspconfig/configs/fortls.lua
+++ b/lua/lspconfig/configs/fortls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = {
@@ -11,8 +9,7 @@ return {
     },
     filetypes = { 'fortran' },
     root_dir = function(fname)
-      return util.root_pattern '.fortls'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.fortls', '.git' }, { path = fname, upward = true })[1])
     end,
     settings = {},
   },

--- a/lua/lspconfig/configs/fsautocomplete.lua
+++ b/lua/lspconfig/configs/fsautocomplete.lua
@@ -1,9 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'fsautocomplete', '--adaptive-lsp-server-enabled' },
-    root_dir = util.root_pattern('*.sln', '*.fsproj', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.sln', '*.fsproj', '.git' }, { path = fname, upward = true })[1])
+    end,
     filetypes = { 'fsharp' },
     init_options = {
       AutomaticWorkspaceInit = true,

--- a/lua/lspconfig/configs/fsharp_language_server.lua
+++ b/lua/lspconfig/configs/fsharp_language_server.lua
@@ -1,9 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'dotnet', 'FSharpLanguageServer.dll' },
-    root_dir = util.root_pattern('*.sln', '*.fsproj', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.sln', '*.fsproj', '.git' }, { path = fname, upward = true })[1])
+    end,
     filetypes = { 'fsharp' },
     init_options = {
       AutomaticWorkspaceInit = true,

--- a/lua/lspconfig/configs/fstar.lua
+++ b/lua/lspconfig/configs/fstar.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'fstar.exe', '--lsp' },
     filetypes = { 'fstar' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/futhark_lsp.lua
+++ b/lua/lspconfig/configs/futhark_lsp.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'futhark', 'lsp' },
     filetypes = { 'futhark', 'fut' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/gdscript.lua
+++ b/lua/lspconfig/configs/gdscript.lua
@@ -1,13 +1,13 @@
-local util = require 'lspconfig.util'
-
-local port = os.getenv 'GDScript_Port' or '6005'
+local port = os.getenv('GDScript_Port') or '6005'
 local cmd = vim.lsp.rpc.connect('127.0.0.1', tonumber(port))
 
 return {
   default_config = {
     cmd = cmd,
     filetypes = { 'gd', 'gdscript', 'gdscript3' },
-    root_dir = util.root_pattern('project.godot', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'project.godot', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/gdshader_lsp.lua
+++ b/lua/lspconfig/configs/gdshader_lsp.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'gdshader-lsp', '--stdio' },
     filetypes = { 'gdshader', 'gdshaderinc' },
-    root_dir = util.root_pattern 'project.godot',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'project.godot' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/gh_actions_ls.lua
+++ b/lua/lspconfig/configs/gh_actions_ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'gh-actions-language-server', '--stdio' },
@@ -10,7 +8,7 @@ return {
     -- attaching.) For details, see #3558
     root_dir = function(filename)
       return filename:find('/%.(github|forgejo|gitea)/workflows/.+%.ya?ml')
-          and util.root_pattern('.github', '.forgejo', '.gitea')(filename)
+          and vim.fs.dirname(vim.fs.find('.github', { path = filename, upward = true })[1])
         or nil
     end,
 

--- a/lua/lspconfig/configs/ghcide.lua
+++ b/lua/lspconfig/configs/ghcide.lua
@@ -1,10 +1,15 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ghcide', '--lsp' },
     filetypes = { 'haskell', 'lhaskell' },
-    root_dir = util.root_pattern('stack.yaml', 'hie-bios', 'BUILD.bazel', 'cabal.config', 'package.yaml'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { 'stack.yaml', 'hie-bios', 'BUILD.bazel', 'cabal.config', 'package.yaml' },
+          { path = fname, upward = true }
+        )[1]
+      )
+    end,
   },
 
   docs = {

--- a/lua/lspconfig/configs/ghdl_ls.lua
+++ b/lua/lspconfig/configs/ghdl_ls.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ghdl-ls' },
     filetypes = { 'vhdl' },
     root_dir = function(fname)
-      return util.root_pattern 'hdl-prj.json'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'hdl-prj.json', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/ginko_ls.lua
+++ b/lua/lspconfig/configs/ginko_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'ginko_ls' },
     filetypes = { 'dts' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     settings = {},
   },

--- a/lua/lspconfig/configs/gitlab_ci_ls.lua
+++ b/lua/lspconfig/configs/gitlab_ci_ls.lua
@@ -1,11 +1,11 @@
-local util = require 'lspconfig.util'
-
 local cache_dir = vim.loop.os_homedir() .. '/.cache/gitlab-ci-ls/'
 return {
   default_config = {
     cmd = { 'gitlab-ci-ls' },
     filetypes = { 'yaml.gitlab' },
-    root_dir = util.root_pattern('.gitlab*', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.gitlab*', '.git' }, { path = fname, upward = true })[1])
+    end,
     init_options = {
       cache_path = cache_dir,
       log_path = cache_dir .. '/log/gitlab-ci-ls.log',

--- a/lua/lspconfig/configs/glasgow.lua
+++ b/lua/lspconfig/configs/glasgow.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'glasgow' },
     filetypes = { 'wgsl' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     settings = {},

--- a/lua/lspconfig/configs/gleam.lua
+++ b/lua/lspconfig/configs/gleam.lua
@@ -1,11 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'gleam', 'lsp' },
     filetypes = { 'gleam' },
     root_dir = function(fname)
-      return util.root_pattern('gleam.toml', '.git')(fname)
+      return vim.fs.dirname(vim.fs.find({ 'gleam.toml', '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/glint.lua
+++ b/lua/lspconfig/configs/glint.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'glint-language-server' },
@@ -22,14 +20,14 @@ return {
       'javascript',
       'javascript.glimmer',
     },
-    root_dir = util.root_pattern(
-      '.glintrc.yml',
-      '.glintrc',
-      '.glintrc.json',
-      '.glintrc.js',
-      'glint.config.js',
-      'package.json'
-    ),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { '.glintrc.yml', '.glintrc', '.glintrc.json', '.glintrc.js', 'glint.config.js', 'package.json' },
+          { path = fname, upward = true }
+        )[1]
+      )
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/glsl_analyzer.lua
+++ b/lua/lspconfig/configs/glsl_analyzer.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'glsl_analyzer' },
     filetypes = { 'glsl', 'vert', 'tesc', 'tese', 'frag', 'geom', 'comp' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     capabilities = {},

--- a/lua/lspconfig/configs/glslls.lua
+++ b/lua/lspconfig/configs/glslls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'glslls', '--stdin' },
     filetypes = { 'glsl', 'vert', 'tesc', 'tese', 'frag', 'geom', 'comp' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     capabilities = {

--- a/lua/lspconfig/configs/golangci_lint_ls.lua
+++ b/lua/lspconfig/configs/golangci_lint_ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'golangci-lint-langserver' },
@@ -8,15 +6,12 @@ return {
       command = { 'golangci-lint', 'run', '--out-format', 'json' },
     },
     root_dir = function(fname)
-      return util.root_pattern(
-        '.golangci.yml',
-        '.golangci.yaml',
-        '.golangci.toml',
-        '.golangci.json',
-        'go.work',
-        'go.mod',
-        '.git'
-      )(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { '.golangci.yml', '.golangci.yaml', '.golangci.toml', '.golangci.json', 'go.work', 'go.mod', '.git' },
+          { path = fname, upward = true }
+        )[1]
+      )
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/gopls.lua
+++ b/lua/lspconfig/configs/gopls.lua
@@ -1,5 +1,5 @@
-local util = require 'lspconfig.util'
-local async = require 'lspconfig.async'
+local util = require('lspconfig.util')
+local async = require('lspconfig.async')
 local mod_cache = nil
 
 return {
@@ -9,20 +9,20 @@ return {
     root_dir = function(fname)
       -- see: https://github.com/neovim/nvim-lspconfig/issues/804
       if not mod_cache then
-        local result = async.run_command { 'go', 'env', 'GOMODCACHE' }
+        local result = async.run_command({ 'go', 'env', 'GOMODCACHE' })
         if result and result[1] then
           mod_cache = vim.trim(result[1])
         else
-          mod_cache = vim.fn.system 'go env GOMODCACHE'
+          mod_cache = vim.fn.system('go env GOMODCACHE')
         end
       end
       if mod_cache and fname:sub(1, #mod_cache) == mod_cache then
-        local clients = util.get_lsp_clients { name = 'gopls' }
+        local clients = util.get_lsp_clients({ name = 'gopls' })
         if #clients > 0 then
           return clients[#clients].config.root_dir
         end
       end
-      return util.root_pattern('go.work', 'go.mod', '.git')(fname)
+      return vim.fs.dirname(vim.fs.find({ 'go.work', 'go.mod', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/gradle_ls.lua
+++ b/lua/lspconfig/configs/gradle_ls.lua
@@ -1,17 +1,17 @@
-local util = require 'lspconfig.util'
-
 local bin_name = 'gradle-language-server'
-if vim.fn.has 'win32' == 1 then
+if vim.fn.has('win32') == 1 then
   bin_name = bin_name .. '.bat'
 end
 
 return {
   default_config = {
     filetypes = { 'groovy' },
-    root_dir = util.root_pattern(
-      'settings.gradle', -- Gradle (multi-project)
-      'build.gradle' -- Gradle
-    ),
+    root_dir = function(fname)
+      vim.fs.dirname(vim.fs.find({
+        'settings.gradle', -- Gradle (multi-project)
+        'build.gradle', -- Gradle
+      }, { path = fname, upward = true })[1])
+    end,
     cmd = { bin_name },
     -- gradle-language-server expects init_options.settings to be defined
     init_options = {

--- a/lua/lspconfig/configs/grammarly.lua
+++ b/lua/lspconfig/configs/grammarly.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'grammarly-languageserver', '--stdio' },
     filetypes = { 'markdown' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     handlers = {

--- a/lua/lspconfig/configs/graphql.lua
+++ b/lua/lspconfig/configs/graphql.lua
@@ -1,10 +1,12 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'graphql-lsp', 'server', '-m', 'stream' },
     filetypes = { 'graphql', 'typescriptreact', 'javascriptreact' },
-    root_dir = util.root_pattern('.graphqlrc*', '.graphql.config.*', 'graphql.config.*'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ '.graphqlrc*', '.graphql.config.*', 'graphql.config.*' }, { path = fname, upward = true })[1]
+      )
+    end,
   },
 
   docs = {

--- a/lua/lspconfig/configs/groovyls.lua
+++ b/lua/lspconfig/configs/groovyls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = {
@@ -9,8 +7,7 @@ return {
     },
     filetypes = { 'groovy' },
     root_dir = function(fname)
-      return util.root_pattern 'Jenkinsfile'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'Jenkinsfile', '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/guile_ls.lua
+++ b/lua/lspconfig/configs/guile_ls.lua
@@ -1,4 +1,3 @@
-local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'guile-lsp-server' },
@@ -6,8 +5,7 @@ return {
       'scheme.guile',
     },
     root_dir = function(fname)
-      return util.root_pattern 'guix.scm'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'guix.scm', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/harper_ls.lua
+++ b/lua/lspconfig/configs/harper_ls.lua
@@ -25,7 +25,7 @@ return {
       'typst',
     },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/haxe_language_server.lua
+++ b/lua/lspconfig/configs/haxe_language_server.lua
@@ -1,8 +1,6 @@
-local util = require 'lspconfig.util'
-
 local function find_hxml(path)
   return vim.fs.find(function(name)
-    return name:match '.hxml$'
+    return name:match('.hxml$')
   end, { path = path, type = 'file' })
 end
 
@@ -10,7 +8,9 @@ return {
   default_config = {
     cmd = { 'haxe-language-server' },
     filetypes = { 'haxe' },
-    root_dir = util.root_pattern('*.hxml', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.hxml', '.git' }, { path = fname, upward = true })[1])
+    end,
     settings = {
       haxe = {
         executable = 'haxe',

--- a/lua/lspconfig/configs/hdl_checker.lua
+++ b/lua/lspconfig/configs/hdl_checker.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'hdl_checker', '--lsp' },
     filetypes = { 'vhdl', 'verilog', 'systemverilog' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/helm_ls.lua
+++ b/lua/lspconfig/configs/helm_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'helm_ls', 'serve' },
     filetypes = { 'helm' },
-    root_dir = util.root_pattern 'Chart.yaml',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Chart.yaml' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
     capabilities = {
       workspace = {

--- a/lua/lspconfig/configs/hhvm.lua
+++ b/lua/lspconfig/configs/hhvm.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'hh_client', 'lsp' },
     filetypes = { 'php', 'hack' },
-    root_dir = util.root_pattern '.hhconfig',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.hhconfig' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/hie.lua
+++ b/lua/lspconfig/configs/hie.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'hie-wrapper', '--lsp' },
     filetypes = { 'haskell' },
-    root_dir = util.root_pattern('stack.yaml', 'package.yaml', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'stack.yaml', 'package.yaml', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
 
   docs = {

--- a/lua/lspconfig/configs/hlasm.lua
+++ b/lua/lspconfig/configs/hlasm.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'hlasm_language_server' },
     filetypes = { 'hlasm' },
-    root_dir = util.root_pattern '.hlasmplugin',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.hlasmplugin' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/hls.lua
+++ b/lua/lspconfig/configs/hls.lua
@@ -1,10 +1,15 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'haskell-language-server-wrapper', '--lsp' },
     filetypes = { 'haskell', 'lhaskell' },
-    root_dir = util.root_pattern('hie.yaml', 'stack.yaml', 'cabal.project', '*.cabal', 'package.yaml'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { 'hie.yaml', 'stack.yaml', 'cabal.project', '*.cabal', 'package.yaml' },
+          { path = fname, upward = true }
+        )[1]
+      )
+    end,
     single_file_support = true,
     settings = {
       haskell = {

--- a/lua/lspconfig/configs/hoon_ls.lua
+++ b/lua/lspconfig/configs/hoon_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'hoon-language-server' },
     filetypes = { 'hoon' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/html.lua
+++ b/lua/lspconfig/configs/html.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'vscode-html-language-server', '--stdio' },
     filetypes = { 'html', 'templ' },
-    root_dir = util.root_pattern('package.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'package.json', '.git' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
     settings = {},
     init_options = {

--- a/lua/lspconfig/configs/htmx.lua
+++ b/lua/lspconfig/configs/htmx.lua
@@ -51,7 +51,7 @@ return {
     },
     single_file_support = true,
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/hydra_lsp.lua
+++ b/lua/lspconfig/configs/hydra_lsp.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'hydra-lsp' },
     filetypes = { 'yaml' },
-    root_dir = util.root_pattern '.git',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/hyprls.lua
+++ b/lua/lspconfig/configs/hyprls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'hyprls', '--stdio' },
     filetypes = { 'hyprlang' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/idris2_lsp.lua
+++ b/lua/lspconfig/configs/idris2_lsp.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'idris2-lsp' },
     filetypes = { 'idris2' },
-    root_dir = util.root_pattern '*.ipkg',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.ipkg' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/intelephense.lua
+++ b/lua/lspconfig/configs/intelephense.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 return {
   default_config = {
@@ -6,7 +6,7 @@ return {
     filetypes = { 'php' },
     root_dir = function(pattern)
       local cwd = vim.loop.cwd()
-      local root = util.root_pattern('composer.json', '.git')(pattern)
+      local root = vim.fs.dirname(vim.fs.find({ 'composer.json', '.git' }, { path = pattern, upward = true })[1])
 
       -- prefer cwd if root is a descendant
       return util.path.is_descendant(cwd, root) and cwd or root

--- a/lua/lspconfig/configs/janet_lsp.lua
+++ b/lua/lspconfig/configs/janet_lsp.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = {
@@ -8,8 +6,7 @@ return {
     },
     filetypes = { 'janet' },
     root_dir = function(fname)
-      return util.root_pattern('project.janet')(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'project.janet', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },
@@ -19,6 +16,5 @@ https://github.com/CFiggers/janet-lsp
 
 A Language Server Protocol implementation for Janet.
 ]],
-    root_dir = [[root_pattern("project.janet", ".git")]],
   },
 }

--- a/lua/lspconfig/configs/java_language_server.lua
+++ b/lua/lspconfig/configs/java_language_server.lua
@@ -1,9 +1,11 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     filetypes = { 'java' },
-    root_dir = util.root_pattern('build.gradle', 'build.gradle.kts', 'pom.xml', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'build.gradle', 'build.gradle.kts', 'pom.xml', '.git' }, { path = fname, upward = true })[1]
+      )
+    end,
     settings = {},
   },
   docs = {

--- a/lua/lspconfig/configs/jdtls.lua
+++ b/lua/lspconfig/configs/jdtls.lua
@@ -1,10 +1,9 @@
-local util = require 'lspconfig.util'
-local handlers = require 'vim.lsp.handlers'
+local handlers = require('vim.lsp.handlers')
 
 local env = {
   HOME = vim.loop.os_homedir(),
-  XDG_CACHE_HOME = os.getenv 'XDG_CACHE_HOME',
-  JDTLS_JVM_ARGS = os.getenv 'JDTLS_JVM_ARGS',
+  XDG_CACHE_HOME = os.getenv('XDG_CACHE_HOME'),
+  JDTLS_JVM_ARGS = os.getenv('JDTLS_JVM_ARGS'),
 }
 
 local function get_cache_dir()
@@ -71,9 +70,9 @@ end
 -- Non-standard notification that can be used to display progress
 local function on_language_status(_, result)
   local command = vim.api.nvim_command
-  command 'echohl ModeMsg'
+  command('echohl ModeMsg')
   command(string.format('echo "%s"', result.message))
-  command 'echohl None'
+  command('echohl None')
 end
 
 return {
@@ -100,7 +99,7 @@ return {
         },
       }
       for _, patterns in ipairs(root_files) do
-        local root = util.root_pattern(unpack(patterns))(fname)
+        local root = vim.fs.dirname(vim.fs.find(patterns, { path = fname, upward = true })[1])
         if root then
           return root
         end

--- a/lua/lspconfig/configs/jedi_language_server.lua
+++ b/lua/lspconfig/configs/jedi_language_server.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local root_files = {
   'pyproject.toml',
   'setup.py',
@@ -13,7 +11,9 @@ return {
   default_config = {
     cmd = { 'jedi-language-server' },
     filetypes = { 'python' },
-    root_dir = util.root_pattern(unpack(root_files)),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files) }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/jinja_lsp.lua
+++ b/lua/lspconfig/configs/jinja_lsp.lua
@@ -4,7 +4,7 @@ return {
     cmd = { 'jinja-lsp' },
     filetypes = { 'jinja' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/jqls.lua
+++ b/lua/lspconfig/configs/jqls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'jq-lsp' },
     filetypes = { 'jq' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/jsonls.lua
+++ b/lua/lspconfig/configs/jsonls.lua
@@ -6,7 +6,7 @@ return {
       provideFormatter = true,
     },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/jsonnet_ls.lua
+++ b/lua/lspconfig/configs/jsonnet_ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 -- common jsonnet library paths
 local function jsonnet_path(root_dir)
   local paths = {
@@ -15,8 +13,7 @@ return {
     filetypes = { 'jsonnet', 'libsonnet' },
     single_file_support = true,
     root_dir = function(fname)
-      return util.root_pattern 'jsonnetfile.json'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'jsonnetfile.json', '.git' }, { path = fname, upward = true })[1])
     end,
     on_new_config = function(new_config, root_dir)
       if not new_config.cmd_env then

--- a/lua/lspconfig/configs/julials.lua
+++ b/lua/lspconfig/configs/julials.lua
@@ -1,11 +1,9 @@
-local util = require 'lspconfig.util'
-
 local root_files = { 'Project.toml', 'JuliaProject.toml' }
 
 local function activate_env(path)
-  assert(vim.fn.has 'nvim-0.10' == 1, 'requires Nvim 0.10 or newer')
+  assert(vim.fn.has('nvim-0.10') == 1, 'requires Nvim 0.10 or newer')
   local bufnr = vim.api.nvim_get_current_buf()
-  local julials_clients = vim.lsp.get_clients { bufnr = bufnr, name = 'julials' }
+  local julials_clients = vim.lsp.get_clients({ bufnr = bufnr, name = 'julials' })
   assert(
     #julials_clients > 0,
     'method julia/activateenvironment is not supported by any servers active on the current buffer'
@@ -35,8 +33,8 @@ local function activate_env(path)
     _activate_env(path)
   else
     local depot_paths = vim.env.JULIA_DEPOT_PATH
-        and vim.split(vim.env.JULIA_DEPOT_PATH, vim.fn.has 'win32' == 1 and ';' or ':')
-      or { vim.fn.expand '~/.julia' }
+        and vim.split(vim.env.JULIA_DEPOT_PATH, vim.fn.has('win32') == 1 and ';' or ':')
+      or { vim.fn.expand('~/.julia') }
     local environments = {}
     vim.list_extend(environments, vim.fs.find(root_files, { type = 'file', upward = true, limit = math.huge }))
     for _, depot_path in ipairs(depot_paths) do
@@ -44,7 +42,7 @@ local function activate_env(path)
       vim.list_extend(
         environments,
         vim.fs.find(function(name, env_path)
-          return vim.tbl_contains(root_files, name) and string.sub(env_path, #depot_env + 1):match '^/[^/]*$'
+          return vim.tbl_contains(root_files, name) and string.sub(env_path, #depot_env + 1):match('^/[^/]*$')
         end, { path = depot_env, type = 'file', limit = math.huge })
       )
     end
@@ -98,8 +96,7 @@ return {
     cmd = cmd,
     filetypes = { 'julia' },
     root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files), '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/kcl.lua
+++ b/lua/lspconfig/configs/kcl.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'kcl-language-server' },
     filetypes = { 'kcl' },
-    root_dir = util.root_pattern '.git',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/koka.lua
+++ b/lua/lspconfig/configs/koka.lua
@@ -4,7 +4,7 @@ return {
     filetypes = { 'koka' },
     single_file_support = true,
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
 

--- a/lua/lspconfig/configs/kotlin_language_server.lua
+++ b/lua/lspconfig/configs/kotlin_language_server.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local bin_name = 'kotlin-language-server'
 
 --- The presence of one of these files indicates a project root directory
@@ -19,11 +17,13 @@ local root_files = {
 return {
   default_config = {
     filetypes = { 'kotlin' },
-    root_dir = util.root_pattern(unpack(root_files)),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find(root_files, { path = fname, upward = true })[1])
+    end,
     cmd = { bin_name }, -- kotlin-language-server
     init_options = {
       -- Enables caching and use project root to store cache data.
-      storagePath = util.root_pattern(unpack(root_files))(vim.fn.expand '%:p:h'),
+      storagePath = vim.fs.dirname(vim.fs.find(root_files, { path = vim.fn.expand('%:p:h'), upward = true })[1]),
     },
   },
   docs = {

--- a/lua/lspconfig/configs/kulala_ls.lua
+++ b/lua/lspconfig/configs/kulala_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'kulala-ls', '--stdio' },
     filetypes = { 'http' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/lean3ls.lua
+++ b/lua/lspconfig/configs/lean3ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'lean-language-server', '--stdio', '--', '-M', '4096', '-T', '100000' },
@@ -10,16 +8,16 @@ return {
       -- check if inside elan stdlib
       local stdlib_dir
       do
-        local _, endpos = fname:find '/lean/library'
+        local _, endpos = fname:find('/lean/library')
         if endpos then
           stdlib_dir = fname:sub(1, endpos)
         end
       end
 
-      return util.root_pattern 'leanpkg.toml'(fname)
-        or util.root_pattern 'leanpkg.path'(fname)
+      return vim.fs.dirname(vim.fs.find('leanpkg.toml', { path = fname, upward = true })[1])
+        or vim.fs.dirname(vim.fs.find('leanpkg.path', { path = fname, upward = true })[1])
         or stdlib_dir
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+        or vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/leanls.lua
+++ b/lua/lspconfig/configs/leanls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'lake', 'serve', '--' },
@@ -9,21 +7,21 @@ return {
       fname = vim.fs.normalize(fname)
       local stdlib_dir
       do
-        local _, endpos = fname:find '/src/lean'
+        local _, endpos = fname:find('/src/lean')
         if endpos then
           stdlib_dir = fname:sub(1, endpos)
         end
       end
       if not stdlib_dir then
-        local _, endpos = fname:find '/lib/lean'
+        local _, endpos = fname:find('/lib/lean')
         if endpos then
           stdlib_dir = fname:sub(1, endpos)
         end
       end
 
-      return util.root_pattern('lakefile.toml', 'lakefile.lean', 'lean-toolchain')(fname)
-        or stdlib_dir
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(
+        vim.fs.find({ 'lakefile.toml', 'lakefile.lean', 'lean-toolchain' }, { path = fname, upward = true })[1]
+      ) or stdlib_dir or vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     on_new_config = function(config, root_dir)
       -- add root dir as command-line argument for `ps aux`

--- a/lua/lspconfig/configs/lelwel_ls.lua
+++ b/lua/lspconfig/configs/lelwel_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'lelwel-ls' },
     filetypes = { 'llw' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/lemminx.lua
+++ b/lua/lspconfig/configs/lemminx.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'lemminx' },
     filetypes = { 'xml', 'xsd', 'xsl', 'xslt', 'svg' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/lexical.lua
+++ b/lua/lspconfig/configs/lexical.lua
@@ -1,11 +1,8 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
     root_dir = function(fname)
-      return util.root_pattern 'mix.exs'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'mix.exs', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/ltex.lua
+++ b/lua/lspconfig/configs/ltex.lua
@@ -52,7 +52,7 @@ return {
     cmd = { 'ltex-ls' },
     filetypes = filetypes,
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     get_language_id = get_language_id,

--- a/lua/lspconfig/configs/ltex_plus.lua
+++ b/lua/lspconfig/configs/ltex_plus.lua
@@ -36,7 +36,7 @@ return {
       'xhtml',
     },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     get_language_id = get_language_id,

--- a/lua/lspconfig/configs/lua_ls.lua
+++ b/lua/lspconfig/configs/lua_ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local root_files = {
   '.luarc.json',
   '.luarc.jsonc',
@@ -15,12 +13,12 @@ return {
     cmd = { 'lua-language-server' },
     filetypes = { 'lua' },
     root_dir = function(fname)
-      local root = util.root_pattern(unpack(root_files))(fname)
+      local root = vim.fs.dirname(vim.fs.find(root_files, { path = fname, upward = true })[1])
       if root and root ~= vim.env.HOME then
         return root
       end
-      local root_lua = util.root_pattern 'lua/'(fname) or ''
-      local root_git = vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1]) or ''
+      local root_lua = vim.fs.dirname(vim.fs.find('lua/', { path = fname, upward = true })[1]) or ''
+      local root_git = vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1]) or ''
       if root_lua == '' and root_git == '' then
         return
       end

--- a/lua/lspconfig/configs/luau_lsp.lua
+++ b/lua/lspconfig/configs/luau_lsp.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'luau-lsp', 'lsp' },
     filetypes = { 'luau' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/lwc_ls.lua
+++ b/lua/lspconfig/configs/lwc_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'lwc-language-server', '--stdio' },
     filetypes = { 'javascript', 'html' },
-    root_dir = util.root_pattern 'sfdx-project.json',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'sfdx-project.json' }, { path = fname, upward = true })[1])
+    end,
     init_options = {
       embeddedLanguages = {
         javascript = true,

--- a/lua/lspconfig/configs/m68k.lua
+++ b/lua/lspconfig/configs/m68k.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'm68k-lsp-server', '--stdio' },
     filetypes = { 'asm68k' },
-    root_dir = util.root_pattern('Makefile', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Makefile', '.git' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/markdown_oxide.lua
+++ b/lua/lspconfig/configs/markdown_oxide.lua
@@ -1,7 +1,7 @@
 return {
   default_config = {
-    root_dir = function(fname, _)
-      return require('lspconfig').util.root_pattern('.git', '.obsidian', '.moxide.toml')(fname)
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git', '.obsidian', '.moxide.toml' }, { path = fname, upward = true })[1])
     end,
     filetypes = { 'markdown' },
     single_file_support = true,
@@ -22,19 +22,19 @@ Check the readme to see how to properly setup.
   commands = {
     Today = {
       function()
-        vim.lsp.buf.execute_command { command = 'jump', arguments = { 'today' } }
+        vim.lsp.buf.execute_command({ command = 'jump', arguments = { 'today' } })
       end,
       description = "Open today's daily note",
     },
     Tomorrow = {
       function()
-        vim.lsp.buf.execute_command { command = 'jump', arguments = { 'tomorrow' } }
+        vim.lsp.buf.execute_command({ command = 'jump', arguments = { 'tomorrow' } })
       end,
       description = "Open tomorrow's daily note",
     },
     Yesterday = {
       function()
-        vim.lsp.buf.execute_command { command = 'jump', arguments = { 'yesterday' } }
+        vim.lsp.buf.execute_command({ command = 'jump', arguments = { 'yesterday' } })
       end,
       description = "Open yesterday's daily note",
     },

--- a/lua/lspconfig/configs/marko-js.lua
+++ b/lua/lspconfig/configs/marko-js.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'marko-language-server', '--stdio' },
     filetypes = { 'marko' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/marksman.lua
+++ b/lua/lspconfig/configs/marksman.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local bin_name = 'marksman'
 local cmd = { bin_name, 'server' }
 
@@ -9,8 +7,7 @@ return {
     filetypes = { 'markdown', 'markdown.mdx' },
     root_dir = function(fname)
       local root_files = { '.marksman.toml' }
-      return util.root_pattern(unpack(root_files))(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files), '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/matlab_ls.lua
+++ b/lua/lspconfig/configs/matlab_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'matlab-language-server', '--stdio' },
     filetypes = { 'matlab' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = false,
     settings = {

--- a/lua/lspconfig/configs/mdx_analyzer.lua
+++ b/lua/lspconfig/configs/mdx_analyzer.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local function get_typescript_server_path(root_dir)
   local project_root = vim.fs.dirname(vim.fs.find('node_modules', { path = root_dir, upward = true })[1])
   return project_root and (project_root .. '/node_modules/typescript/lib') or ''
@@ -9,7 +7,9 @@ return {
   default_config = {
     cmd = { 'mdx-language-server', '--stdio' },
     filetypes = { 'mdx' },
-    root_dir = util.root_pattern 'package.json',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'package.json' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
     settings = {},
     init_options = {

--- a/lua/lspconfig/configs/mesonlsp.lua
+++ b/lua/lspconfig/configs/mesonlsp.lua
@@ -1,10 +1,12 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'mesonlsp', '--lsp' },
     filetypes = { 'meson' },
-    root_dir = util.root_pattern('meson.build', 'meson_options.txt', 'meson.options', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'meson.build', 'meson_options.txt', 'meson.options', '.git' }, { path = fname, upward = true })[1]
+      )
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/metals.lua
+++ b/lua/lspconfig/configs/metals.lua
@@ -1,10 +1,12 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'metals' },
     filetypes = { 'scala' },
-    root_dir = util.root_pattern('build.sbt', 'build.sc', 'build.gradle', 'pom.xml'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'build.sbt', 'build.sc', 'build.gradle', 'pom.xml' }, { path = fname, upward = true })[1]
+      )
+    end,
     message_level = vim.lsp.protocol.MessageType.Log,
     init_options = {
       statusBarProvider = 'show-message',

--- a/lua/lspconfig/configs/millet.lua
+++ b/lua/lspconfig/configs/millet.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'millet' },
     filetypes = { 'sml' },
-    root_dir = util.root_pattern 'millet.toml',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'millet.toml' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/mint.lua
+++ b/lua/lspconfig/configs/mint.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'mint', 'ls' },
     filetypes = { 'mint' },
     root_dir = function(fname)
-      return util.root_pattern 'mint.json'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'mint.json', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/mlir_lsp_server.lua
+++ b/lua/lspconfig/configs/mlir_lsp_server.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'mlir-lsp-server' },
     filetypes = { 'mlir' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/mlir_pdll_lsp_server.lua
+++ b/lua/lspconfig/configs/mlir_pdll_lsp_server.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'mlir-pdll-lsp-server' },
     filetypes = { 'pdll' },
     root_dir = function(fname)
-      return util.root_pattern 'pdll_compile_commands.yml'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'pdll_compile_commands.yml', '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/mm0_ls.lua
+++ b/lua/lspconfig/configs/mm0_ls.lua
@@ -2,7 +2,7 @@ return {
   default_config = {
     cmd = { 'mm0-rs', 'server' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     filetypes = { 'metamath-zero' },
     single_file_support = true,

--- a/lua/lspconfig/configs/mojo.lua
+++ b/lua/lspconfig/configs/mojo.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'mojo-lsp-server' },
     filetypes = { 'mojo' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/motoko_lsp.lua
+++ b/lua/lspconfig/configs/motoko_lsp.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'motoko-lsp', '--stdio' },
     filetypes = { 'motoko' },
-    root_dir = util.root_pattern('dfx.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'dfx.json', '.git' }, { path = fname, upward = true })[1])
+    end,
     init_options = {
       formatter = 'auto',
     },

--- a/lua/lspconfig/configs/move_analyzer.lua
+++ b/lua/lspconfig/configs/move_analyzer.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'move-analyzer' },
     filetypes = { 'move' },
     root_dir = function(fname)
-      local move_package_dir = util.root_pattern 'Move.toml'(fname)
-      return move_package_dir
+      return vim.fs.dirname(vim.fs.find({ 'Move.toml' }, { path = fname, upward = true })[1])
     end,
   },
   commands = {},

--- a/lua/lspconfig/configs/msbuild_project_tools_server.lua
+++ b/lua/lspconfig/configs/msbuild_project_tools_server.lua
@@ -1,10 +1,11 @@
 local host_dll_name = 'MSBuildProjectTools.LanguageServer.Host.dll'
-local util = require 'lspconfig.util'
 
 return {
   default_config = {
     filetypes = { 'msbuild' },
-    root_dir = util.root_pattern('*.sln', '*.slnx', '*.*proj', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.sln', '*.slnx', '*.*proj', '.git' }, { path = fname, upward = true })[1])
+    end,
     init_options = {},
     cmd = { 'dotnet', host_dll_name },
   },

--- a/lua/lspconfig/configs/mutt_ls.lua
+++ b/lua/lspconfig/configs/mutt_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'mutt-language-server' },
     filetypes = { 'muttrc', 'neomuttrc' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     settings = {},

--- a/lua/lspconfig/configs/nelua_lsp.lua
+++ b/lua/lspconfig/configs/nelua_lsp.lua
@@ -1,9 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     filetypes = { 'nelua' },
-    root_dir = util.root_pattern('Makefile', '.git', '*.nelua'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Makefile', '.git', '*.nelua' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/neocmake.lua
+++ b/lua/lspconfig/configs/neocmake.lua
@@ -1,11 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'neocmakelsp', '--stdio' },
     filetypes = { 'cmake' },
     root_dir = function(fname)
-      return util.root_pattern(unpack({ '.git', 'build', 'cmake' }))(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git', 'build', 'cmake' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/nextflow_ls.lua
+++ b/lua/lspconfig/configs/nextflow_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'java', '-jar', 'nextflow-language-server-all.jar' },
     filetypes = { 'nextflow' },
-    root_dir = util.root_pattern('nextflow.config', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'nextflow.config', '.git' }, { path = fname, upward = true })[1])
+    end,
     settings = {
       nextflow = {
         files = {
@@ -28,7 +28,7 @@ If you have installed nextflow language server, you can set the `cmd` custom pat
 require'lspconfig'.nextflow_ls.setup{
     cmd = { 'java', '-jar', 'nextflow-language-server-all.jar' },
     filetypes = { 'nextflow' },
-    root_dir = util.root_pattern('nextflow.config', '.git'),
+    root_dir =  function(fname) return vim.fs.dirname(vim.fs.find({'nextflow.config', '.git'}, { path = fname, upward = true })[1])    end,
     settings = {
       nextflow = {
         files = {

--- a/lua/lspconfig/configs/nextls.lua
+++ b/lua/lspconfig/configs/nextls.lua
@@ -1,11 +1,8 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
     root_dir = function(fname)
-      return util.root_pattern 'mix.exs'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'mix.exs', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/nginx_language_server.lua
+++ b/lua/lspconfig/configs/nginx_language_server.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'nginx-language-server' },
     filetypes = { 'nginx' },
     root_dir = function(fname)
-      return util.root_pattern('nginx.conf', '.git')(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'nginx.conf', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/nickel_ls.lua
+++ b/lua/lspconfig/configs/nickel_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'nls' },
     filetypes = { 'ncl', 'nickel' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
 

--- a/lua/lspconfig/configs/nil_ls.lua
+++ b/lua/lspconfig/configs/nil_ls.lua
@@ -1,11 +1,11 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'nil' },
     filetypes = { 'nix' },
     single_file_support = true,
-    root_dir = util.root_pattern('flake.nix', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'flake.nix', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/nim_langserver.lua
+++ b/lua/lspconfig/configs/nim_langserver.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'nimlangserver' },
     filetypes = { 'nim' },
     root_dir = function(fname)
-      return util.root_pattern '*.nimble'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '*.nimble', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/nimls.lua
+++ b/lua/lspconfig/configs/nimls.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'nimlsp' },
     filetypes = { 'nim' },
     root_dir = function(fname)
-      return util.root_pattern '*.nimble'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '*.nimble', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/nixd.lua
+++ b/lua/lspconfig/configs/nixd.lua
@@ -1,13 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'nixd' },
     filetypes = { 'nix' },
     single_file_support = true,
     root_dir = function(fname)
-      return util.root_pattern 'flake.nix'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'flake.nix', '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/nomad_lsp.lua
+++ b/lua/lspconfig/configs/nomad_lsp.lua
@@ -1,7 +1,6 @@
-local util = require 'lspconfig.util'
 local bin_name = 'nomad-lsp'
 
-if vim.fn.has 'win32' == 1 then
+if vim.fn.has('win32') == 1 then
   bin_name = bin_name .. '.exe'
 end
 
@@ -9,7 +8,9 @@ return {
   default_config = {
     cmd = { bin_name },
     filetypes = { 'hcl.nomad', 'nomad' },
-    root_dir = util.root_pattern '*.nomad',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.nomad' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/ntt.lua
+++ b/lua/lspconfig/configs/ntt.lua
@@ -1,11 +1,12 @@
-local util = require 'lspconfig.util'
 local bin_name = 'ntt'
 
 return {
   default_config = {
     cmd = { bin_name, 'langserver' },
     filetypes = { 'ttcn' },
-    root_dir = util.root_pattern '.git',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/nushell.lua
+++ b/lua/lspconfig/configs/nushell.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'nu', '--lsp' },
     filetypes = { 'nu' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/nxls.lua
+++ b/lua/lspconfig/configs/nxls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'nxls', '--stdio' },
     filetypes = { 'json', 'jsonc' },
-    root_dir = util.root_pattern('nx.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'nx.json', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/ocamlls.lua
+++ b/lua/lspconfig/configs/ocamlls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ocaml-language-server', '--stdio' },
     filetypes = { 'ocaml', 'reason' },
-    root_dir = util.root_pattern('*.opam', 'esy.json', 'package.json'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.opam', 'esy.json', 'package.json' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/ocamllsp.lua
+++ b/lua/lspconfig/configs/ocamllsp.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local language_id_of = {
   menhir = 'ocaml.menhir',
   ocaml = 'ocaml',
@@ -17,7 +15,14 @@ return {
   default_config = {
     cmd = { 'ocamllsp' },
     filetypes = { 'ocaml', 'menhir', 'ocamlinterface', 'ocamllex', 'reason', 'dune' },
-    root_dir = util.root_pattern('*.opam', 'esy.json', 'package.json', '.git', 'dune-project', 'dune-workspace'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { '*.opam', 'esy.json', 'package.json', '.git', 'dune-project', 'dune-workspace' },
+          { path = fname, upward = true }
+        )[1]
+      )
+    end,
     get_language_id = get_language_id,
   },
   docs = {

--- a/lua/lspconfig/configs/ols.lua
+++ b/lua/lspconfig/configs/ols.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ols' },
     filetypes = { 'odin' },
-    root_dir = util.root_pattern('ols.json', '.git', '*.odin'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'ols.json', '.git', '*.odin' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/omnisharp.lua
+++ b/lua/lspconfig/configs/omnisharp.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     settings = {
@@ -42,7 +40,11 @@ return {
     },
 
     filetypes = { 'cs', 'vb' },
-    root_dir = util.root_pattern('*.sln', '*.csproj', 'omnisharp.json', 'function.json'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ '*.sln', '*.csproj', 'omnisharp.json', 'function.json' }, { path = fname, upward = true })[1]
+      )
+    end,
     on_new_config = function(new_config, _)
       -- Get the initially configured value of `cmd`
       new_config.cmd = { unpack(new_config.cmd or {}) }

--- a/lua/lspconfig/configs/opencl_ls.lua
+++ b/lua/lspconfig/configs/opencl_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'opencl-language-server' },
     filetypes = { 'opencl' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/openedge_ls.lua
+++ b/lua/lspconfig/configs/openedge_ls.lua
@@ -1,9 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     filetypes = { 'progress' },
-    root_dir = util.root_pattern 'openedge-project.json',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'openedge-project.json' }, { path = fname, upward = true })[1])
+    end,
     on_new_config = function(config)
       if not config.cmd and config.oe_jar_path then
         config.cmd = {

--- a/lua/lspconfig/configs/openscad_ls.lua
+++ b/lua/lspconfig/configs/openscad_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'openscad-language-server' },
     filetypes = { 'openscad' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/openscad_lsp.lua
+++ b/lua/lspconfig/configs/openscad_lsp.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'openscad-lsp', '--stdio' },
     filetypes = { 'openscad' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/pact_ls.lua
+++ b/lua/lspconfig/configs/pact_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'pact-lsp' },
     filetypes = { 'pact' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/pasls.lua
+++ b/lua/lspconfig/configs/pasls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'pasls' },
     filetypes = { 'pascal' },
-    root_dir = util.root_pattern('*.lpi', '*.lpk', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.lpi', '*.lpk', '.git' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/pbls.lua
+++ b/lua/lspconfig/configs/pbls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'pbls' },
     filetypes = { 'proto' },
-    root_dir = util.root_pattern('.pbls.toml', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.pbls.toml', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/perlls.lua
+++ b/lua/lspconfig/configs/perlls.lua
@@ -19,7 +19,7 @@ return {
     },
     filetypes = { 'perl' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/perlnavigator.lua
+++ b/lua/lspconfig/configs/perlnavigator.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'perlnavigator' },
     filetypes = { 'perl' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/perlpls.lua
+++ b/lua/lspconfig/configs/perlpls.lua
@@ -9,7 +9,7 @@ return {
     },
     filetypes = { 'perl' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/pest_ls.lua
+++ b/lua/lspconfig/configs/pest_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'pest-language-server' },
     filetypes = { 'pest' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/phan.lua
+++ b/lua/lspconfig/configs/phan.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 local cmd = {
   'phan',
@@ -20,7 +20,7 @@ return {
     single_file_support = true,
     root_dir = function(pattern)
       local cwd = vim.loop.cwd()
-      local root = util.root_pattern('composer.json', '.git')(pattern)
+      local root = vim.fs.dirname(vim.fs.find({ 'composer.json', '.git' }, { path = pattern, upward = true })[1])
 
       -- prefer cwd if root is a descendant
       return util.path.is_descendant(cwd, root) and cwd or root

--- a/lua/lspconfig/configs/phpactor.lua
+++ b/lua/lspconfig/configs/phpactor.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 return {
   default_config = {
@@ -6,7 +6,9 @@ return {
     filetypes = { 'php' },
     root_dir = function(pattern)
       local cwd = vim.loop.cwd()
-      local root = util.root_pattern('composer.json', '.git', '.phpactor.json', '.phpactor.yml')(pattern)
+      local root = vim.fs.dirname(
+        vim.fs.find({ 'composer.json', '.git', '.phpactor.json', '.phpactor.yml' }, { path = pattern, upward = true })[1]
+      )
 
       -- prefer cwd if root is a descendant
       return util.path.is_descendant(cwd, root) and cwd or root

--- a/lua/lspconfig/configs/pico8_ls.lua
+++ b/lua/lspconfig/configs/pico8_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'pico8-ls', '--stdio' },
     filetypes = { 'p8' },
-    root_dir = util.root_pattern '*.p8',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.p8' }, { path = fname, upward = true })[1])
+    end,
     settings = {},
   },
   docs = {

--- a/lua/lspconfig/configs/pkgbuild_language_server.lua
+++ b/lua/lspconfig/configs/pkgbuild_language_server.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'pkgbuild-language-server' },
     filetypes = { 'PKGBUILD' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/please.lua
+++ b/lua/lspconfig/configs/please.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'plz', 'tool', 'lps' },
     filetypes = { 'bzl' },
-    root_dir = util.root_pattern '.plzconfig',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.plzconfig' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/poryscript_pls.lua
+++ b/lua/lspconfig/configs/poryscript_pls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'poryscript-pls' },
     filetypes = { 'pory' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/postgres_lsp.lua
+++ b/lua/lspconfig/configs/postgres_lsp.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'postgres_lsp' },
     filetypes = { 'sql' },
-    root_dir = util.root_pattern 'root-file.txt',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'root-file.txt' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/powershell_es.lua
+++ b/lua/lspconfig/configs/powershell_es.lua
@@ -1,5 +1,4 @@
-local temp_path = vim.fn.stdpath 'cache'
-local util = require 'lspconfig.util'
+local temp_path = vim.fn.stdpath('cache')
 
 local function make_cmd(new_config)
   if new_config.bundle_path ~= nil then
@@ -21,7 +20,11 @@ return {
     end,
 
     filetypes = { 'ps1' },
-    root_dir = util.root_pattern('PSScriptAnalyzerSettings.psd1', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'PSScriptAnalyzerSettings.psd1', '.git' }, { path = fname, upward = true })[1]
+      )
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/prismals.lua
+++ b/lua/lspconfig/configs/prismals.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'prisma-language-server', '--stdio' },
@@ -9,7 +7,9 @@ return {
         prismaFmtBinPath = '',
       },
     },
-    root_dir = util.root_pattern('.git', 'package.json'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git', 'package.json' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/prolog_ls.lua
+++ b/lua/lspconfig/configs/prolog_ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = {
@@ -14,7 +12,9 @@ return {
       'stdio',
     },
     filetypes = { 'prolog' },
-    root_dir = util.root_pattern 'pack.pl',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'pack.pl' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/prosemd_lsp.lua
+++ b/lua/lspconfig/configs/prosemd_lsp.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'prosemd-lsp', '--stdio' },
     filetypes = { 'markdown' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/protols.lua
+++ b/lua/lspconfig/configs/protols.lua
@@ -4,7 +4,7 @@ return {
     filetypes = { 'proto' },
     single_file_support = true,
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/psalm.lua
+++ b/lua/lspconfig/configs/psalm.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'psalm', '--language-server' },
     filetypes = { 'php' },
-    root_dir = util.root_pattern('psalm.xml', 'psalm.xml.dist'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'psalm.xml', 'psalm.xml.dist' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/puppet.lua
+++ b/lua/lspconfig/configs/puppet.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local root_files = {
   'manifests',
   '.puppet-lint.rc',
@@ -11,7 +9,9 @@ return {
   default_config = {
     cmd = { 'puppet-languageserver', '--stdio' },
     filetypes = { 'puppet' },
-    root_dir = util.root_pattern(unpack(root_files)),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files) }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/purescriptls.lua
+++ b/lua/lspconfig/configs/purescriptls.lua
@@ -1,17 +1,15 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'purescript-language-server', '--stdio' },
     filetypes = { 'purescript' },
-    root_dir = util.root_pattern(
-      'bower.json',
-      'flake.nix',
-      'psc-package.json',
-      'shell.nix',
-      'spago.dhall',
-      'spago.yaml'
-    ),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { 'bower.json', 'flake.nix', 'psc-package.json', 'shell.nix', 'spago.dhall', 'spago.yaml' },
+          { path = fname, upward = true }
+        )[1]
+      )
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/pylsp.lua
+++ b/lua/lspconfig/configs/pylsp.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'pylsp' },
@@ -12,8 +10,7 @@ return {
         'requirements.txt',
         'Pipfile',
       }
-      return util.root_pattern(unpack(root_files))(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files), '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/pylyzer.lua
+++ b/lua/lspconfig/configs/pylyzer.lua
@@ -1,5 +1,3 @@
-local util = require('lspconfig').util
-
 return {
   default_config = {
     cmd = { 'pylyzer', '--server' },
@@ -12,8 +10,7 @@ return {
         'Pipfile',
         'pyproject.toml',
       }
-      return util.root_pattern(unpack(root_files))(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files), '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     settings = {

--- a/lua/lspconfig/configs/pyre.lua
+++ b/lua/lspconfig/configs/pyre.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'pyre', 'persistent' },
     filetypes = { 'python' },
-    root_dir = util.root_pattern '.pyre_configuration',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.pyre_configuration' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/pyright.lua
+++ b/lua/lspconfig/configs/pyright.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 local root_files = {
   'pyproject.toml',
@@ -16,20 +16,20 @@ local function organize_imports()
     arguments = { vim.uri_from_bufnr(0) },
   }
 
-  local clients = util.get_lsp_clients {
+  local clients = util.get_lsp_clients({
     bufnr = vim.api.nvim_get_current_buf(),
     name = 'pyright',
-  }
+  })
   for _, client in ipairs(clients) do
     client.request('workspace/executeCommand', params, nil, 0)
   end
 end
 
 local function set_python_path(path)
-  local clients = util.get_lsp_clients {
+  local clients = util.get_lsp_clients({
     bufnr = vim.api.nvim_get_current_buf(),
     name = 'pyright',
-  }
+  })
   for _, client in ipairs(clients) do
     if client.settings then
       client.settings.python = vim.tbl_deep_extend('force', client.settings.python, { pythonPath = path })
@@ -45,7 +45,7 @@ return {
     cmd = { 'pyright-langserver', '--stdio' },
     filetypes = { 'python' },
     root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname)
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files) }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     settings = {

--- a/lua/lspconfig/configs/qml_lsp.lua
+++ b/lua/lspconfig/configs/qml_lsp.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'qml-lsp' },
     filetypes = { 'qmljs' },
-    root_dir = util.root_pattern '*.qml',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.qml' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/qmlls.lua
+++ b/lua/lspconfig/configs/qmlls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'qmlls' },
     filetypes = { 'qml', 'qmljs' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/quick_lint_js.lua
+++ b/lua/lspconfig/configs/quick_lint_js.lua
@@ -1,10 +1,12 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'quick-lint-js', '--lsp-server' },
     filetypes = { 'javascript', 'typescript' },
-    root_dir = util.root_pattern('package.json', 'jsconfig.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'package.json', 'jsconfig.json', '.git' }, { path = fname, upward = true })[1]
+      )
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/r_language_server.lua
+++ b/lua/lspconfig/configs/r_language_server.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'R', '--no-echo', '-e', 'languageserver::run()' },
     filetypes = { 'r', 'rmd' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1]) or vim.loop.os_homedir()
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1]) or vim.loop.os_homedir()
     end,
     log_level = vim.lsp.protocol.MessageType.Warning,
   },

--- a/lua/lspconfig/configs/racket_langserver.lua
+++ b/lua/lspconfig/configs/racket_langserver.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'racket', '--lib', 'racket-langserver' },
     filetypes = { 'racket', 'scheme' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/raku_navigator.lua
+++ b/lua/lspconfig/configs/raku_navigator.lua
@@ -3,7 +3,7 @@ return {
     cmd = {},
     filetypes = { 'raku' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/reason_ls.lua
+++ b/lua/lspconfig/configs/reason_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'reason-language-server' },
     filetypes = { 'reason' },
-    root_dir = util.root_pattern('bsconfig.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'bsconfig.json', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/regal.lua
+++ b/lua/lspconfig/configs/regal.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'regal', 'language-server' },
     filetypes = { 'rego' },
     root_dir = function(fname)
-      return util.root_pattern '*.rego'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '*.rego', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/regols.lua
+++ b/lua/lspconfig/configs/regols.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'regols' },
     filetypes = { 'rego' },
     root_dir = function(fname)
-      return util.root_pattern '*.rego'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '*.rego', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/relay_lsp.lua
+++ b/lua/lspconfig/configs/relay_lsp.lua
@@ -1,5 +1,4 @@
-local util = require 'lspconfig.util'
-local log = require 'vim.lsp.log'
+local log = require('vim.lsp.log')
 
 return {
   default_config = {
@@ -21,7 +20,9 @@ return {
       'typescriptreact',
       'typescript.tsx',
     },
-    root_dir = util.root_pattern('relay.config.*', 'package.json'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'relay.config.*', 'package.json' }, { path = fname, upward = true })[1])
+    end,
     on_new_config = function(config, root_dir)
       local project_root = vim.fs.find('node_modules', { path = root_dir, upward = true })[1]
       local node_bin_path = project_root .. '/node_modules/.bin'
@@ -40,13 +41,13 @@ return {
           vim.list_extend(config.cmd, { config.path_to_config })
           vim.list_extend(compiler_cmd, { config.path_to_config })
         else
-          log.error "[Relay LSP] Can't find Relay config file. Fallback to the default location..."
+          log.error("[Relay LSP] Can't find Relay config file. Fallback to the default location...")
         end
       end
       if config.auto_start_compiler then
         vim.fn.jobstart(compiler_cmd, {
           on_exit = function()
-            log.info '[Relay LSP] Relay Compiler exited'
+            log.info('[Relay LSP] Relay Compiler exited')
           end,
           cwd = project_root,
         })

--- a/lua/lspconfig/configs/remark_ls.lua
+++ b/lua/lspconfig/configs/remark_ls.lua
@@ -1,19 +1,19 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'remark-language-server', '--stdio' },
     filetypes = { 'markdown' },
-    root_dir = util.root_pattern(
-      '.remarkrc',
-      '.remarkrc.json',
-      '.remarkrc.js',
-      '.remarkrc.cjs',
-      '.remarkrc.mjs',
-      '.remarkrc.yml',
-      '.remarkrc.yaml',
-      '.remarkignore'
-    ),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({
+        '.remarkrc',
+        '.remarkrc.json',
+        '.remarkrc.js',
+        '.remarkrc.cjs',
+        '.remarkrc.mjs',
+        '.remarkrc.yml',
+        '.remarkrc.yaml',
+        '.remarkignore',
+      }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/rescriptls.lua
+++ b/lua/lspconfig/configs/rescriptls.lua
@@ -1,10 +1,12 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'rescript-language-server', '--stdio' },
     filetypes = { 'rescript' },
-    root_dir = util.root_pattern('bsconfig.json', 'rescript.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'bsconfig.json', 'rescript.json', '.git' }, { path = fname, upward = true })[1]
+      )
+    end,
     settings = {},
     init_options = {
       extensionConfiguration = {
@@ -47,6 +49,5 @@ require'lspconfig'.pylsp.setup{
 }
 ```
 ]],
-    root_dir = [[root_pattern('bsconfig.json', 'rescript.json', '.git')]],
   },
 }

--- a/lua/lspconfig/configs/rls.lua
+++ b/lua/lspconfig/configs/rls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'rls' },
     filetypes = { 'rust' },
-    root_dir = util.root_pattern 'Cargo.toml',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Cargo.toml' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/rnix.lua
+++ b/lua/lspconfig/configs/rnix.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'rnix-lsp' },
     filetypes = { 'nix' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1]) or vim.loop.os_homedir()
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1]) or vim.loop.os_homedir()
     end,
     settings = {},
     init_options = {},

--- a/lua/lspconfig/configs/robotcode.lua
+++ b/lua/lspconfig/configs/robotcode.lua
@@ -1,10 +1,12 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'robotcode', 'language-server' },
     filetypes = { 'robot', 'resource' },
-    root_dir = util.root_pattern('robot.toml', 'pyproject.toml', 'Pipfile', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'robot.toml', 'pyproject.toml', 'Pipfile', '.git' }, { path = fname, upward = true })[1]
+      )
+    end,
     single_file_support = true,
     get_language_id = function(_, _)
       return 'robotframework'
@@ -17,7 +19,7 @@ https://robotcode.io
 RobotCode - Language Server Protocol implementation for Robot Framework.
 ]],
     default_config = {
-      root_dir = "util.root_pattern('robot.toml', 'pyproject.toml', 'Pipfile')(fname) or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])",
+      root_dir = " function(fname) return vim.fs.dirname(vim.fs.find({'robot.toml', 'pyproject.toml', 'Pipfile')(fname) or vim.fs.dirname(vim.fs.find({'.git'}, { path = fname, upward = true })[1]}, { path = fname, upward = true })[1])    end",
       settings = {},
     },
   },

--- a/lua/lspconfig/configs/robotframework_ls.lua
+++ b/lua/lspconfig/configs/robotframework_ls.lua
@@ -1,12 +1,14 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'robotframework_ls' },
     filetypes = { 'robot' },
     root_dir = function(fname)
-      return util.root_pattern('robotidy.toml', 'pyproject.toml', 'conda.yaml', 'robot.yaml')(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(
+        vim.fs.find(
+          { 'robotidy.toml', 'pyproject.toml', 'conda.yaml', 'robot.yaml', '.git' },
+          { path = fname, upward = true }
+        )[1]
+      )
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/roc_ls.lua
+++ b/lua/lspconfig/configs/roc_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'roc_language_server' },
     filetypes = { 'roc' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/rome.lua
+++ b/lua/lspconfig/configs/rome.lua
@@ -12,7 +12,7 @@ return {
     root_dir = function(fname)
       return vim.fs.dirname(vim.fs.find('package.json', { path = fname, upward = true })[1])
         or vim.fs.dirname(vim.fs.find('node_modules', { path = fname, upward = true })[1])
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+        or vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/rubocop.lua
+++ b/lua/lspconfig/configs/rubocop.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'rubocop', '--lsp' },
     filetypes = { 'ruby' },
-    root_dir = util.root_pattern('Gemfile', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Gemfile', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/ruby_lsp.lua
+++ b/lua/lspconfig/configs/ruby_lsp.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ruby-lsp' },
     filetypes = { 'ruby', 'eruby' },
-    root_dir = util.root_pattern('Gemfile', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Gemfile', '.git' }, { path = fname, upward = true })[1])
+    end,
     init_options = {
       formatter = 'auto',
     },

--- a/lua/lspconfig/configs/ruff.lua
+++ b/lua/lspconfig/configs/ruff.lua
@@ -1,12 +1,11 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ruff', 'server' },
     filetypes = { 'python' },
     root_dir = function(fname)
-      return util.root_pattern('pyproject.toml', 'ruff.toml', '.ruff.toml')(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(
+        vim.fs.find({ 'pyproject.toml', 'ruff.toml', '.ruff.toml', '.git' }, { path = fname, upward = true })[1]
+      )
     end,
     single_file_support = true,
     settings = {},

--- a/lua/lspconfig/configs/ruff_lsp.lua
+++ b/lua/lspconfig/configs/ruff_lsp.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ruff-lsp' },
     filetypes = { 'python' },
     root_dir = function(fname)
-      return util.root_pattern('pyproject.toml', 'ruff.toml')(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'pyproject.toml', 'ruff.toml', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     settings = {},

--- a/lua/lspconfig/configs/rune_languageserver.lua
+++ b/lua/lspconfig/configs/rune_languageserver.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'rune-languageserver' },
     filetypes = { 'rune' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/rust_analyzer.lua
+++ b/lua/lspconfig/configs/rust_analyzer.lua
@@ -1,32 +1,32 @@
-local util = require 'lspconfig.util'
-local async = require 'lspconfig.async'
+local util = require('lspconfig.util')
+local async = require('lspconfig.async')
 
 local function reload_workspace(bufnr)
   bufnr = util.validate_bufnr(bufnr)
-  local clients = util.get_lsp_clients { bufnr = bufnr, name = 'rust_analyzer' }
+  local clients = util.get_lsp_clients({ bufnr = bufnr, name = 'rust_analyzer' })
   for _, client in ipairs(clients) do
-    vim.notify 'Reloading Cargo Workspace'
+    vim.notify('Reloading Cargo Workspace')
     client.request('rust-analyzer/reloadWorkspace', nil, function(err)
       if err then
         error(tostring(err))
       end
-      vim.notify 'Cargo workspace reloaded'
+      vim.notify('Cargo workspace reloaded')
     end, 0)
   end
 end
 
 local function is_library(fname)
   local user_home = vim.fs.normalize(vim.env.HOME)
-  local cargo_home = os.getenv 'CARGO_HOME' or user_home .. '/.cargo'
+  local cargo_home = os.getenv('CARGO_HOME') or user_home .. '/.cargo'
   local registry = cargo_home .. '/registry/src'
   local git_registry = cargo_home .. '/git/checkouts'
 
-  local rustup_home = os.getenv 'RUSTUP_HOME' or user_home .. '/.rustup'
+  local rustup_home = os.getenv('RUSTUP_HOME') or user_home .. '/.rustup'
   local toolchains = rustup_home .. '/toolchains'
 
-  for _, item in ipairs { toolchains, registry, git_registry } do
+  for _, item in ipairs({ toolchains, registry, git_registry }) do
     if util.path.is_descendant(item, fname) then
-      local clients = util.get_lsp_clients { name = 'rust_analyzer' }
+      local clients = util.get_lsp_clients({ name = 'rust_analyzer' })
       return #clients > 0 and clients[#clients].config.root_dir or nil
     end
   end
@@ -43,7 +43,7 @@ return {
         return reuse_active
       end
 
-      local cargo_crate_dir = util.root_pattern 'Cargo.toml'(fname)
+      local cargo_crate_dir = vim.fs.dirname(vim.fs.find('Cargo.toml', { path = fname, upward = true })[1])
       local cargo_workspace_root
 
       if cargo_crate_dir ~= nil then
@@ -69,8 +69,8 @@ return {
 
       return cargo_workspace_root
         or cargo_crate_dir
-        or util.root_pattern 'rust-project.json'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+        or vim.fs.dirname(vim.fs.find('rust-project.json', { path = fname, upward = true })[1])
+        or vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     capabilities = {
       experimental = {

--- a/lua/lspconfig/configs/salt_ls.lua
+++ b/lua/lspconfig/configs/salt_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'salt_lsp_server' },
     filetypes = { 'sls' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/scheme_langserver.lua
+++ b/lua/lspconfig/configs/scheme_langserver.lua
@@ -1,4 +1,3 @@
-local util = require 'lspconfig.util'
 local cmd = { 'scheme-langserver', '~/.scheme-langserver.log', 'enable', 'disable' }
 local root_files = {
   'Akku.manifest',
@@ -9,7 +8,9 @@ return {
   default_config = {
     cmd = cmd,
     filetypes = { 'scheme' },
-    root_dir = util.root_pattern(unpack(root_files)),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files) }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/scry.lua
+++ b/lua/lspconfig/configs/scry.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'scry' },
     filetypes = { 'crystal' },
     root_dir = function(fname)
-      return util.root_pattern 'shard.yml'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'shard.yml', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/selene3p_ls.lua
+++ b/lua/lspconfig/configs/selene3p_ls.lua
@@ -1,10 +1,10 @@
-local util = require('lspconfig.util')
-
 return {
   default_config = {
     cmd = { 'selene-3p-language-server' },
     filetypes = { 'lua' },
-    root_dir = util.root_pattern('selene.toml'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'selene.toml' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/serve_d.lua
+++ b/lua/lspconfig/configs/serve_d.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'serve-d' },
     filetypes = { 'd' },
-    root_dir = util.root_pattern('dub.json', 'dub.sdl', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'dub.json', 'dub.sdl', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/shopify_theme_ls.lua
+++ b/lua/lspconfig/configs/shopify_theme_ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local root_files = {
   '.shopifyignore',
   '.theme-check.yml',
@@ -15,7 +13,9 @@ return {
       'language-server',
     },
     filetypes = { 'liquid' },
-    root_dir = util.root_pattern(unpack(root_files)),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files) }, { path = fname, upward = true })[1])
+    end,
     settings = {},
   },
   docs = {

--- a/lua/lspconfig/configs/slangd.lua
+++ b/lua/lspconfig/configs/slangd.lua
@@ -1,6 +1,6 @@
 local bin_name = 'slangd'
 
-if vim.fn.has 'win32' == 1 then
+if vim.fn.has('win32') == 1 then
   bin_name = 'slangd.exe'
 end
 
@@ -9,7 +9,7 @@ return {
     cmd = { bin_name },
     filetypes = { 'hlsl', 'shaderslang' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/slint_lsp.lua
+++ b/lua/lspconfig/configs/slint_lsp.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'slint-lsp' },
     filetypes = { 'slint' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/smarty_ls.lua
+++ b/lua/lspconfig/configs/smarty_ls.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 return {
   default_config = {
@@ -6,7 +6,7 @@ return {
     filetypes = { 'smarty' },
     root_dir = function(pattern)
       local cwd = vim.loop.cwd()
-      local root = util.root_pattern('composer.json', '.git')(pattern)
+      local root = vim.fs.dirname(vim.fs.find({ 'composer.json', '.git' }, { path = pattern, upward = true })[1])
 
       -- prefer cwd if root is a descendant
       return util.path.is_descendant(cwd, root) and cwd or root

--- a/lua/lspconfig/configs/smithy_ls.lua
+++ b/lua/lspconfig/configs/smithy_ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 -- pass 0 as the first argument to use STDIN/STDOUT for communication
 local cmd = { 'smithy-language-server', '0' }
 
@@ -8,7 +6,14 @@ return {
     cmd = cmd,
     filetypes = { 'smithy' },
     single_file_support = true,
-    root_dir = util.root_pattern('smithy-build.json', 'build.gradle', 'build.gradle.kts', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { 'smithy-build.json', 'build.gradle', 'build.gradle.kts', '.git' },
+          { path = fname, upward = true }
+        )[1]
+      )
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/snakeskin_ls.lua
+++ b/lua/lspconfig/configs/snakeskin_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'snakeskin-cli', 'lsp', '--stdio' },
     filetypes = { 'ss' },
-    root_dir = util.root_pattern 'package.json',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'package.json' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/snyk_ls.lua
+++ b/lua/lspconfig/configs/snyk_ls.lua
@@ -1,9 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'snyk-ls' },
-    root_dir = util.root_pattern('.git', '.snyk'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git', '.snyk' }, { path = fname, upward = true })[1])
+    end,
     filetypes = {
       'go',
       'gomod',

--- a/lua/lspconfig/configs/solang.lua
+++ b/lua/lspconfig/configs/solang.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'solang', 'language-server', '--target', 'evm' },
     filetypes = { 'solidity' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/solargraph.lua
+++ b/lua/lspconfig/configs/solargraph.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'solargraph', 'stdio' },
@@ -10,7 +8,9 @@ return {
     },
     init_options = { formatting = true },
     filetypes = { 'ruby' },
-    root_dir = util.root_pattern('Gemfile', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Gemfile', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/solc.lua
+++ b/lua/lspconfig/configs/solc.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'solc', '--lsp' },
     filetypes = { 'solidity' },
-    root_dir = util.root_pattern('hardhat.config.*', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'hardhat.config.*', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/solidity.lua
+++ b/lua/lspconfig/configs/solidity.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'solidity-ls', '--stdio' },
     filetypes = { 'solidity' },
-    root_dir = util.root_pattern('.git', 'package.json'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git', 'package.json' }, { path = fname, upward = true })[1])
+    end,
     settings = { solidity = { includePath = '', remapping = {} } },
   },
   docs = {
@@ -18,7 +18,7 @@ Make sure that solc is installed and it's the same version of the file.  solc-se
 Solidity language server is a LSP with autocomplete, go to definition and diagnostics.
 
 If you use brownie, use this root_dir:
-root_dir = util.root_pattern('brownie-config.yaml', '.git')
+root_dir =  function(fname) return vim.fs.dirname(vim.fs.find({'brownie-config.yaml', '.git'}, { path = fname, upward = true })[1])    end
 
 on includePath, you can add an extra path to search for external libs, on remapping you can remap lib <> path, like:
 
@@ -30,7 +30,9 @@ on includePath, you can add an extra path to search for external libs, on remapp
 Change the root_dir to:
 
 ```lua
-root_pattern("brownie-config.yaml", ".git")
+root_dir = function(fname)
+  return vim.fs.dirname(vim.fs.find({ 'brownie-config.yaml', '.git' }, { path = fname, upward = true })[1])
+end
 ```
 
 The best way of using it is to have a package.json in your project folder with the packages that you will use.

--- a/lua/lspconfig/configs/solidity_ls.lua
+++ b/lua/lspconfig/configs/solidity_ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local root_files = {
   'hardhat.config.js',
   'hardhat.config.ts',
@@ -14,7 +12,9 @@ return {
   default_config = {
     cmd = { 'vscode-solidity-server', '--stdio' },
     filetypes = { 'solidity' },
-    root_dir = util.root_pattern(unpack(root_files)) or util.root_pattern('.git', 'package.json'),
+    root_dir = function(fname)
+      vim.fs.dirname(vim.fs.find({ unpack(root_files), '.git', 'package.json' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/solidity_ls_nomicfoundation.lua
+++ b/lua/lspconfig/configs/solidity_ls_nomicfoundation.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local root_files = {
   'hardhat.config.js',
   'hardhat.config.ts',
@@ -14,7 +12,9 @@ return {
   default_config = {
     cmd = { 'nomicfoundation-solidity-language-server', '--stdio' },
     filetypes = { 'solidity' },
-    root_dir = util.root_pattern(unpack(root_files)) or util.root_pattern('.git', 'package.json'),
+    root_dir = function(fname)
+      vim.fs.dirname(vim.fs.find({ unpack(root_files), '.git', 'package.json' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/somesass_ls.lua
+++ b/lua/lspconfig/configs/somesass_ls.lua
@@ -1,11 +1,11 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     name = 'somesass_ls',
     cmd = { 'some-sass-language-server', '--stdio' },
     filetypes = { 'scss', 'sass' },
-    root_dir = util.root_pattern('.git', '.package.json'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git', '.package.json' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
     settings = {
       somesass = {

--- a/lua/lspconfig/configs/sorbet.lua
+++ b/lua/lspconfig/configs/sorbet.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'srb', 'tc', '--lsp' },
     filetypes = { 'ruby' },
-    root_dir = util.root_pattern('Gemfile', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Gemfile', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/sourcekit.lua
+++ b/lua/lspconfig/configs/sourcekit.lua
@@ -1,15 +1,15 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'sourcekit-lsp' },
     filetypes = { 'swift', 'objc', 'objcpp', 'c', 'cpp' },
     root_dir = function(filename, _)
-      return util.root_pattern 'buildServer.json'(filename)
-        or util.root_pattern('*.xcodeproj', '*.xcworkspace')(filename)
+      return vim.fs.dirname(vim.fs.find('buildServer.json', { path = filename, upward = true })[1])
+        or vim.fs.dirname(vim.fs.find({ '*.xcodeproj', '*.xcworkspace' }, { path = filename, upward = true })[1])
         -- better to keep it at the end, because some modularized apps contain multiple Package.swift files
-        or util.root_pattern('compile_commands.json', 'Package.swift')(filename)
-        or vim.fs.dirname(vim.fs.find('.git', { path = filename, upward = true })[1])
+        or vim.fs.dirname(
+          vim.fs.find({ 'compile_commands.json', 'Package.swift' }, { path = filename, upward = true })[1]
+        )
+        or vim.fs.dirname(vim.fs.find({ '.git' }, { path = filename, upward = true })[1])
     end,
     get_language_id = function(_, ftype)
       local t = { objc = 'objective-c', objcpp = 'objective-cpp' }

--- a/lua/lspconfig/configs/sourcery.lua
+++ b/lua/lspconfig/configs/sourcery.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local root_files = {
   'pyproject.toml',
   'setup.py',
@@ -10,16 +8,16 @@ local root_files = {
 }
 
 local token_in_auth_file = function()
-  local is_windows = vim.fn.has 'win32' == 1
+  local is_windows = vim.fn.has('win32') == 1
   local path_sep = is_windows and '\\' or '/'
 
-  local config_home = is_windows and vim.fn.getenv 'APPDATA' or vim.fn.expand '~/.config'
+  local config_home = is_windows and vim.fn.getenv('APPDATA') or vim.fn.expand('~/.config')
   local auth_file_path = config_home .. path_sep .. 'sourcery' .. path_sep .. 'auth.yaml'
 
   if vim.fn.filereadable(auth_file_path) == 1 then
     local content = vim.fn.readfile(auth_file_path)
     for _, line in ipairs(content) do
-      if line:match 'sourcery_token: (.+)' then
+      if line:match('sourcery_token: (.+)') then
         return true
       end
     end
@@ -38,8 +36,7 @@ return {
       token = nil,
     },
     root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git', unpack(root_files) }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/spectral.lua
+++ b/lua/lspconfig/configs/spectral.lua
@@ -1,12 +1,17 @@
-local util = require 'lspconfig.util'
-
 local bin_name = 'spectral-language-server'
 
 return {
   default_config = {
     cmd = { bin_name, '--stdio' },
     filetypes = { 'yaml', 'json', 'yml' },
-    root_dir = util.root_pattern('.spectral.yaml', '.spectral.yml', '.spectral.json', '.spectral.js'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { '.spectral.yaml', '.spectral.yml', '.spectral.json', '.spectral.js' },
+          { path = fname, upward = true }
+        )[1]
+      )
+    end,
     single_file_support = true,
     settings = {
       enable = true,

--- a/lua/lspconfig/configs/spyglassmc_language_server.lua
+++ b/lua/lspconfig/configs/spyglassmc_language_server.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'spyglassmc-language-server', '--stdio' },
     filetypes = { 'mcfunction' },
-    root_dir = util.root_pattern 'pack.mcmeta',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'pack.mcmeta' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/sqlls.lua
+++ b/lua/lspconfig/configs/sqlls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'sql-language-server', 'up', '--method', 'stdio' },
     filetypes = { 'sql', 'mysql' },
-    root_dir = util.root_pattern '.sqllsrc.json',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.sqllsrc.json' }, { path = fname, upward = true })[1])
+    end,
     settings = {},
   },
   docs = {

--- a/lua/lspconfig/configs/sqls.lua
+++ b/lua/lspconfig/configs/sqls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'sqls' },
     filetypes = { 'sql', 'mysql' },
-    root_dir = util.root_pattern 'config.yml',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'config.yml' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
     settings = {},
   },

--- a/lua/lspconfig/configs/standardrb.lua
+++ b/lua/lspconfig/configs/standardrb.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'standardrb', '--lsp' },
     filetypes = { 'ruby' },
-    root_dir = util.root_pattern('Gemfile', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Gemfile', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/starlark_rust.lua
+++ b/lua/lspconfig/configs/starlark_rust.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'starlark', '--lsp' },
     filetypes = { 'star', 'bzl', 'BUILD.bazel' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/starpls.lua
+++ b/lua/lspconfig/configs/starpls.lua
@@ -1,10 +1,12 @@
-local util = require 'lspconfig/util'
-
 return {
   default_config = {
     cmd = { 'starpls' },
     filetypes = { 'bzl' },
-    root_dir = util.root_pattern('WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel' }, { path = fname, upward = true })[1]
+      )
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/statix.lua
+++ b/lua/lspconfig/configs/statix.lua
@@ -1,11 +1,11 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'statix', 'check', '--stdin' },
     filetypes = { 'nix' },
     single_file_support = true,
-    root_dir = util.root_pattern('flake.nix', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'flake.nix', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/steep.lua
+++ b/lua/lspconfig/configs/steep.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'steep', 'langserver' },
     filetypes = { 'ruby', 'eruby' },
-    root_dir = util.root_pattern('Steepfile', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Steepfile', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/stimulus_ls.lua
+++ b/lua/lspconfig/configs/stimulus_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'stimulus-language-server', '--stdio' },
     filetypes = { 'html', 'ruby', 'eruby', 'blade', 'php' },
-    root_dir = util.root_pattern('Gemfile', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Gemfile', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/stylelint_lsp.lua
+++ b/lua/lspconfig/configs/stylelint_lsp.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 local root_file = {
   '.stylelintrc',
@@ -24,7 +24,9 @@ return {
       'vue',
       'wxss',
     },
-    root_dir = util.root_pattern(unpack(root_file)),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ unpack(root_file) }, { path = fname, upward = true })[1])
+    end,
     settings = {},
   },
   docs = {

--- a/lua/lspconfig/configs/stylua3p_ls.lua
+++ b/lua/lspconfig/configs/stylua3p_ls.lua
@@ -1,10 +1,10 @@
-local util = require('lspconfig.util')
-
 return {
   default_config = {
     cmd = { 'stylua-3p-language-server' },
     filetypes = { 'lua' },
-    root_dir = util.root_pattern('.stylua.toml', 'stylua.toml'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.stylua.toml', 'stylua.toml' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/superhtml.lua
+++ b/lua/lspconfig/configs/superhtml.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'superhtml', 'lsp' },
     filetypes = { 'superhtml', 'html' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/svelte.lua
+++ b/lua/lspconfig/configs/svelte.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'svelteserver', '--stdio' },
     filetypes = { 'svelte' },
-    root_dir = util.root_pattern('package.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'package.json', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/svlangserver.lua
+++ b/lua/lspconfig/configs/svlangserver.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local function build_index()
   local params = {
     command = 'systemverilog.build_index',
@@ -10,7 +8,7 @@ end
 local function report_hierarchy()
   local params = {
     command = 'systemverilog.report_hierarchy',
-    arguments = { vim.fn.expand '<cword>' },
+    arguments = { vim.fn.expand('<cword>') },
   }
   vim.lsp.buf.execute_command(params)
 end
@@ -20,8 +18,7 @@ return {
     cmd = { 'svlangserver' },
     filetypes = { 'verilog', 'systemverilog' },
     root_dir = function(fname)
-      return util.root_pattern '.svlangserver'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.svlangserver', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     settings = {

--- a/lua/lspconfig/configs/svls.lua
+++ b/lua/lspconfig/configs/svls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'svls' },
     filetypes = { 'verilog', 'systemverilog' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/swift_mesonls.lua
+++ b/lua/lspconfig/configs/swift_mesonls.lua
@@ -1,10 +1,12 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'Swift-MesonLSP', '--lsp' },
     filetypes = { 'meson' },
-    root_dir = util.root_pattern('meson.build', 'meson_options.txt', 'meson.options', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'meson.build', 'meson_options.txt', 'meson.options', '.git' }, { path = fname, upward = true })[1]
+      )
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/syntax_tree.lua
+++ b/lua/lspconfig/configs/syntax_tree.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'stree', 'lsp' },
     filetypes = { 'ruby' },
-    root_dir = util.root_pattern('.streerc', 'Gemfile', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.streerc', 'Gemfile', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/tabby_ml.lua
+++ b/lua/lspconfig/configs/tabby_ml.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'tabby-agent', '--lsp', '--stdio' },
     filetypes = {},
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/tailwindcss.lua
+++ b/lua/lspconfig/configs/tailwindcss.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'tailwindcss-language-server', '--stdio' },
@@ -100,7 +98,7 @@ return {
       end
     end,
     root_dir = function(fname)
-      return util.root_pattern(
+      return vim.fs.dirname(vim.fs.find({
         'tailwind.config.js',
         'tailwind.config.cjs',
         'tailwind.config.mjs',
@@ -108,10 +106,12 @@ return {
         'postcss.config.js',
         'postcss.config.cjs',
         'postcss.config.mjs',
-        'postcss.config.ts'
-      )(fname) or vim.fs.dirname(vim.fs.find('package.json', { path = fname, upward = true })[1]) or vim.fs.dirname(
-        vim.fs.find('node_modules', { path = fname, upward = true })[1]
-      ) or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+        'postcss.config.ts',
+      }, { path = fname, upward = true })[1]) or vim.fs.dirname(
+        vim.fs.find('package.json', { path = fname, upward = true })[1]
+      ) or vim.fs.dirname(vim.fs.find('node_modules', { path = fname, upward = true })[1]) or vim.fs.dirname(
+        vim.fs.find({ '.git' }, { path = fname, upward = true })[1]
+      )
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/taplo.lua
+++ b/lua/lspconfig/configs/taplo.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'taplo', 'lsp', 'stdio' },
     filetypes = { 'toml' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/tblgen_lsp_server.lua
+++ b/lua/lspconfig/configs/tblgen_lsp_server.lua
@@ -1,12 +1,11 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'tblgen-lsp-server' },
     filetypes = { 'tablegen' },
     root_dir = function(fname)
-      return util.root_pattern 'tablegen_compile_commands.yml'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(
+        vim.fs.find({ 'tablegen_compile_commands.yml', '.git' }, { path = fname, upward = true })[1]
+      )
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/teal_ls.lua
+++ b/lua/lspconfig/configs/teal_ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = {
@@ -8,7 +6,9 @@ return {
     filetypes = {
       'teal',
     },
-    root_dir = util.root_pattern 'tlconfig.lua',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'tlconfig.lua' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/templ.lua
+++ b/lua/lspconfig/configs/templ.lua
@@ -1,11 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'templ', 'lsp' },
     filetypes = { 'templ' },
     root_dir = function(fname)
-      return util.root_pattern('go.work', 'go.mod', '.git')(fname)
+      return vim.fs.dirname(vim.fs.find({ 'go.work', 'go.mod', '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/terraform_lsp.lua
+++ b/lua/lspconfig/configs/terraform_lsp.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'terraform-lsp' },
     filetypes = { 'terraform', 'hcl' },
-    root_dir = util.root_pattern('.terraform', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.terraform', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/terraformls.lua
+++ b/lua/lspconfig/configs/terraformls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'terraform-ls', 'serve' },
     filetypes = { 'terraform', 'terraform-vars' },
-    root_dir = util.root_pattern('.terraform', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.terraform', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/texlab.lua
+++ b/lua/lspconfig/configs/texlab.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 local function client_with_fn(fn)
   return function()
@@ -46,13 +46,13 @@ local function buf_search(client, bufnr)
 end
 
 local function buf_cancel_build(client, bufnr)
-  if vim.fn.has 'nvim-0.11' == 1 then
+  if vim.fn.has('nvim-0.11') == 1 then
     return client:exec_cmd({
       title = 'cancel',
       command = 'texlab.cancelBuild',
     }, { bufnr = bufnr })
   end
-  vim.lsp.buf.execute_command { command = 'texlab.cancelBuild' }
+  vim.lsp.buf.execute_command({ command = 'texlab.cancelBuild' })
   vim.notify('Build cancelled', vim.log.levels.INFO)
 end
 
@@ -72,7 +72,7 @@ local function command_factory(cmd)
     CancelBuild = 'texlab.cancelBuild',
   }
   return function(client, bufnr)
-    if vim.fn.has 'nvim-0.11' == 1 then
+    if vim.fn.has('nvim-0.11') == 1 then
       return client:exec_cmd({
         title = ('clean_%s'):format(cmd),
         command = cmd_tbl[cmd],
@@ -86,10 +86,10 @@ local function command_factory(cmd)
       end)
     end
 
-    vim.lsp.buf.execute_command {
+    vim.lsp.buf.execute_command({
       command = cmd_tbl[cmd],
       arguments = { { uri = vim.uri_from_bufnr(bufnr) } },
-    }
+    })
     vim.notify(('command %s execute successfully'):format(cmd_tbl[cmd]))
   end
 end
@@ -114,7 +114,7 @@ local function buf_find_envs(client, bufnr)
     end
     vim.lsp.util.open_floating_preview(env_names, '', {
       height = #env_names,
-      width = math.max((max_length + #env_names - 1), (string.len 'Environments')),
+      width = math.max((max_length + #env_names - 1), (string.len('Environments'))),
       focusable = false,
       focus = false,
       border = 'single',
@@ -124,12 +124,12 @@ local function buf_find_envs(client, bufnr)
 end
 
 local function buf_change_env(client, bufnr)
-  local new = vim.fn.input 'Enter the new environment name: '
+  local new = vim.fn.input('Enter the new environment name: ')
   if not new or new == '' then
     return vim.notify('No environment name provided', vim.log.levels.WARN)
   end
   local pos = vim.api.nvim_win_get_cursor(0)
-  if vim.fn.has 'nvim-0.11' == 1 then
+  if vim.fn.has('nvim-0.11') == 1 then
     return client:exec_cmd({
       title = 'change_environment',
       command = 'texlab.changeEnvironment',
@@ -143,7 +143,7 @@ local function buf_change_env(client, bufnr)
     }, { bufnr = bufnr })
   end
 
-  vim.lsp.buf.execute_command {
+  vim.lsp.buf.execute_command({
     command = 'texlab.changeEnvironment',
     arguments = {
       {
@@ -152,14 +152,21 @@ local function buf_change_env(client, bufnr)
         newName = tostring(new),
       },
     },
-  }
+  })
 end
 
 return {
   default_config = {
     cmd = { 'texlab' },
     filetypes = { 'tex', 'plaintex', 'bib' },
-    root_dir = util.root_pattern('.git', '.latexmkrc', '.texlabroot', 'texlabroot', 'Tectonic.toml'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { '.git', '.latexmkrc', '.texlabroot', 'texlabroot', 'Tectonic.toml' },
+          { path = fname, upward = true }
+        )[1]
+      )
+    end,
     single_file_support = true,
     settings = {
       texlab = {

--- a/lua/lspconfig/configs/textlsp.lua
+++ b/lua/lspconfig/configs/textlsp.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'textlsp' },
     filetypes = { 'text', 'tex', 'org' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     settings = {

--- a/lua/lspconfig/configs/tflint.lua
+++ b/lua/lspconfig/configs/tflint.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'tflint', '--langserver' },
     filetypes = { 'terraform' },
-    root_dir = util.root_pattern('.terraform', '.git', '.tflint.hcl'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.terraform', '.git', '.tflint.hcl' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/theme_check.lua
+++ b/lua/lspconfig/configs/theme_check.lua
@@ -1,12 +1,12 @@
-local util = require 'lspconfig.util'
-
 local bin_name = 'theme-check-language-server'
 
 return {
   default_config = {
     cmd = { bin_name, '--stdio' },
     filetypes = { 'liquid' },
-    root_dir = util.root_pattern '.theme-check.yml',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.theme-check.yml' }, { path = fname, upward = true })[1])
+    end,
     settings = {},
   },
   docs = {

--- a/lua/lspconfig/configs/thriftls.lua
+++ b/lua/lspconfig/configs/thriftls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'thriftls' },
     filetypes = { 'thrift' },
-    root_dir = util.root_pattern '.thrift',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.thrift' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/tilt_ls.lua
+++ b/lua/lspconfig/configs/tilt_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'tilt', 'lsp', 'start' },
     filetypes = { 'tiltfile' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/tinymist.lua
+++ b/lua/lspconfig/configs/tinymist.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'tinymist' },
     filetypes = { 'typst' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/ts_ls.lua
+++ b/lua/lspconfig/configs/ts_ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     init_options = { hostInfo = 'neovim' },
@@ -12,7 +10,11 @@ return {
       'typescriptreact',
       'typescript.tsx',
     },
-    root_dir = util.root_pattern('tsconfig.json', 'jsconfig.json', 'package.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'tsconfig.json', 'jsconfig.json', 'package.json', '.git' }, { path = fname, upward = true })[1]
+      )
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/ts_query_ls.lua
+++ b/lua/lspconfig/configs/ts_query_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ts_query_ls' },
     filetypes = { 'query' },
-    root_dir = util.root_pattern('queries', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'queries', '.git' }, { path = fname, upward = true })[1])
+    end,
     settings = {
       parser_aliases = {
         ecma = 'javascript',

--- a/lua/lspconfig/configs/tsp_server.lua
+++ b/lua/lspconfig/configs/tsp_server.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'tsp-server', '--stdio' },
     filetypes = { 'typespec' },
-    root_dir = util.root_pattern('tspconfig.yaml', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'tspconfig.yaml', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/ttags.lua
+++ b/lua/lspconfig/configs/ttags.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'ttags', 'lsp' },
     filetypes = { 'ruby', 'rust', 'javascript', 'haskell' },
-    root_dir = util.root_pattern '.git',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/turtle_ls.lua
+++ b/lua/lspconfig/configs/turtle_ls.lua
@@ -1,13 +1,13 @@
 local bin_name = 'turtle-language-server'
-local bin_path = os.getenv 'NVM_BIN'
+local bin_path = os.getenv('NVM_BIN')
 local full_path
 if bin_path == nil then
   local paths = {}
   local sep = ':'
-  if vim.fn.has 'win32' == 1 then
+  if vim.fn.has('win32') == 1 then
     sep = ';'
   end
-  local path = os.getenv 'PATH'
+  local path = os.getenv('PATH')
   if path ~= nil then
     for str in string.gmatch(path, '([^' .. sep .. ']+)') do
       paths[#paths + 1] = str
@@ -29,7 +29,7 @@ return {
     cmd = { 'node', full_path, '--stdio' },
     filetypes = { 'turtle', 'ttl' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/tvm_ffi_navigator.lua
+++ b/lua/lspconfig/configs/tvm_ffi_navigator.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'python', '-m', 'ffi_navigator.langserver' },
     filetypes = { 'python', 'cpp' },
-    root_dir = util.root_pattern('pyproject.toml', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'pyproject.toml', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/twiggy_language_server.lua
+++ b/lua/lspconfig/configs/twiggy_language_server.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'twiggy-language-server', '--stdio' },
     filetypes = { 'twig' },
-    root_dir = util.root_pattern('composer.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'composer.json', '.git' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/typeprof.lua
+++ b/lua/lspconfig/configs/typeprof.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'typeprof', '--lsp', '--stdio' },
     filetypes = { 'ruby', 'eruby' },
-    root_dir = util.root_pattern('Gemfile', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'Gemfile', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/typos_lsp.lua
+++ b/lua/lspconfig/configs/typos_lsp.lua
@@ -1,9 +1,11 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'typos-lsp' },
-    root_dir = util.root_pattern('typos.toml', '_typos.toml', '.typos.toml'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'typos.toml', '_typos.toml', '.typos.toml' }, { path = fname, upward = true })[1]
+      )
+    end,
     single_file_support = true,
     settings = {},
   },

--- a/lua/lspconfig/configs/typst_lsp.lua
+++ b/lua/lspconfig/configs/typst_lsp.lua
@@ -4,7 +4,7 @@ return {
     filetypes = { 'typst' },
     single_file_support = true,
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/uiua.lua
+++ b/lua/lspconfig/configs/uiua.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'uiua', 'lsp' },
     filetypes = { 'uiua' },
     root_dir = function(fname)
-      return util.root_pattern('main.ua', '.fmt.ua')(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ 'main.ua', '.fmt.ua', '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/ungrammar_languageserver.lua
+++ b/lua/lspconfig/configs/ungrammar_languageserver.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'ungrammar-languageserver', '--stdio' },
     filetypes = { 'ungrammar' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     settings = {

--- a/lua/lspconfig/configs/unison.lua
+++ b/lua/lspconfig/configs/unison.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
-    cmd = { 'nc', 'localhost', os.getenv 'UNISON_LSP_PORT' or '5757' },
+    cmd = { 'nc', 'localhost', os.getenv('UNISON_LSP_PORT') or '5757' },
     filetypes = { 'unison' },
-    root_dir = util.root_pattern '*.u',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '*.u' }, { path = fname, upward = true })[1])
+    end,
     settings = {},
   },
   docs = {

--- a/lua/lspconfig/configs/unocss.lua
+++ b/lua/lspconfig/configs/unocss.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'unocss-language-server', '--stdio' },
@@ -30,7 +28,12 @@ return {
       'rust',
     },
     root_dir = function(fname)
-      return util.root_pattern('unocss.config.js', 'unocss.config.ts', 'uno.config.js', 'uno.config.ts')(fname)
+      return vim.fs.dirname(
+        vim.fs.find(
+          { 'unocss.config.js', 'unocss.config.ts', 'uno.config.js', 'uno.config.ts' },
+          { path = fname, upward = true }
+        )[1]
+      )
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/uvls.lua
+++ b/lua/lspconfig/configs/uvls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'uvls' },
     filetypes = { 'uvl' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/v_analyzer.lua
+++ b/lua/lspconfig/configs/v_analyzer.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'v-analyzer' },
     filetypes = { 'v', 'vsh', 'vv' },
-    root_dir = util.root_pattern('v.mod', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'v.mod', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/vacuum.lua
+++ b/lua/lspconfig/configs/vacuum.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'vacuum', 'language-server' },
     filetypes = { 'yaml.openapi', 'json.openapi' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/vala_ls.lua
+++ b/lua/lspconfig/configs/vala_ls.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 local meson_matcher = function(path)
   local pattern = 'meson.build'
@@ -8,10 +8,10 @@ local meson_matcher = function(path)
   end
   for line in io.lines(f) do
     -- skip meson comments
-    if not line:match '^%s*#.*' then
+    if not line:match('^%s*#.*') then
       local str = line:gsub('%s+', '')
       if str ~= '' then
-        if str:match '^project%(' then
+        if str:match('^project%(') then
           return path
         else
           break
@@ -27,7 +27,7 @@ return {
     filetypes = { 'vala', 'genie' },
     root_dir = function(fname)
       local root = util.search_ancestors(fname, meson_matcher)
-      return root or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return root or vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/vale_ls.lua
+++ b/lua/lspconfig/configs/vale_ls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'vale-ls' },
     filetypes = { 'markdown', 'text', 'tex', 'rst' },
-    root_dir = util.root_pattern '.vale.ini',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.vale.ini' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/vdmj.lua
+++ b/lua/lspconfig/configs/vdmj.lua
@@ -1,4 +1,4 @@
-local util = require 'lspconfig.util'
+local util = require('lspconfig.util')
 
 local function get_default_mavenrepo()
   local repo = vim.env.HOME .. '/.m2/repository/dk/au/ece/vdmj'
@@ -45,7 +45,7 @@ return {
     cmd = { 'java' },
     filetypes = { 'vdmsl', 'vdmpp', 'vdmrt' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1]) or find_vscode_ancestor(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1]) or find_vscode_ancestor(fname)
     end,
     options = {
       java = vim.env.JAVA_HOME and (vim.env.JAVA_HOME .. '/bin/java') or 'java',
@@ -115,6 +115,6 @@ by neovim.
       dap,
     }
 
-    config.cmd = util.tbl_flatten { java_cmd, vdmj_cmd }
+    config.cmd = util.tbl_flatten({ java_cmd, vdmj_cmd })
   end,
 }

--- a/lua/lspconfig/configs/verible.lua
+++ b/lua/lspconfig/configs/verible.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'verible-verilog-ls' },
     filetypes = { 'systemverilog', 'verilog' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/veridian.lua
+++ b/lua/lspconfig/configs/veridian.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'veridian' },
     filetypes = { 'systemverilog', 'verilog' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/veryl_ls.lua
+++ b/lua/lspconfig/configs/veryl_ls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'veryl-ls' },
     filetypes = { 'veryl' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/vhdl_ls.lua
+++ b/lua/lspconfig/configs/vhdl_ls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local root_files = {
   'vhdl_ls.toml',
   '.vhdl_ls.toml',
@@ -9,7 +7,9 @@ return {
   default_config = {
     cmd = { 'vhdl_ls' },
     filetypes = { 'vhd', 'vhdl' },
-    root_dir = util.root_pattern(unpack(root_files)),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ unpack(root_files) }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/vimls.lua
+++ b/lua/lspconfig/configs/vimls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'vim-language-server', '--stdio' },
     filetypes = { 'vim' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     init_options = {

--- a/lua/lspconfig/configs/visualforce_ls.lua
+++ b/lua/lspconfig/configs/visualforce_ls.lua
@@ -1,9 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     filetypes = { 'visualforce' },
-    root_dir = util.root_pattern 'sfdx-project.json',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'sfdx-project.json' }, { path = fname, upward = true })[1])
+    end,
     init_options = {
       embeddedLanguages = {
         css = true,

--- a/lua/lspconfig/configs/vls.lua
+++ b/lua/lspconfig/configs/vls.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'v', 'ls' },
     filetypes = { 'v', 'vlang' },
-    root_dir = util.root_pattern('v.mod', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'v.mod', '.git' }, { path = fname, upward = true })[1])
+    end,
   },
   docs = {
     description = [[

--- a/lua/lspconfig/configs/volar.lua
+++ b/lua/lspconfig/configs/volar.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local function get_typescript_server_path(root_dir)
   local project_root = vim.fs.find('node_modules', { path = root_dir, upward = true })[1]
   return project_root and (project_root .. '/typescript/lib') or ''
@@ -16,7 +14,9 @@ return {
   default_config = {
     cmd = { 'vue-language-server', '--stdio' },
     filetypes = { 'vue' },
-    root_dir = util.root_pattern 'package.json',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'package.json' }, { path = fname, upward = true })[1])
+    end,
     init_options = volar_init_options,
     on_new_config = function(new_config, new_root_dir)
       if

--- a/lua/lspconfig/configs/vscoqtop.lua
+++ b/lua/lspconfig/configs/vscoqtop.lua
@@ -1,12 +1,9 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'vscoqtop' },
     filetypes = { 'coq' },
     root_dir = function(fname)
-      return util.root_pattern '_CoqProject'(fname)
-        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '_CoqProject', '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/vtsls.lua
+++ b/lua/lspconfig/configs/vtsls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'vtsls', '--stdio' },
@@ -11,7 +9,11 @@ return {
       'typescriptreact',
       'typescript.tsx',
     },
-    root_dir = util.root_pattern('tsconfig.json', 'package.json', 'jsconfig.json', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(
+        vim.fs.find({ 'tsconfig.json', 'package.json', 'jsconfig.json', '.git' }, { path = fname, upward = true })[1]
+      )
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/configs/vuels.lua
+++ b/lua/lspconfig/configs/vuels.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'vls' },
     filetypes = { 'vue' },
-    root_dir = util.root_pattern('package.json', 'vue.config.js'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'package.json', 'vue.config.js' }, { path = fname, upward = true })[1])
+    end,
     init_options = {
       config = {
         vetur = {

--- a/lua/lspconfig/configs/wgsl_analyzer.lua
+++ b/lua/lspconfig/configs/wgsl_analyzer.lua
@@ -1,10 +1,10 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'wgsl_analyzer' },
     filetypes = { 'wgsl' },
-    root_dir = util.root_pattern '.git',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
+    end,
     settings = {},
   },
   docs = {

--- a/lua/lspconfig/configs/yamlls.lua
+++ b/lua/lspconfig/configs/yamlls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'yaml-language-server', '--stdio' },
     filetypes = { 'yaml', 'yaml.docker-compose', 'yaml.gitlab' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
     settings = {

--- a/lua/lspconfig/configs/yang_lsp.lua
+++ b/lua/lspconfig/configs/yang_lsp.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'yang-language-server' },
     filetypes = { 'yang' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
   },
   docs = {

--- a/lua/lspconfig/configs/yls.lua
+++ b/lua/lspconfig/configs/yls.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'yls', '-vv' },
     filetypes = { 'yar', 'yara' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/ziggy.lua
+++ b/lua/lspconfig/configs/ziggy.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'ziggy', 'lsp' },
     filetypes = { 'ziggy' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/ziggy_schema.lua
+++ b/lua/lspconfig/configs/ziggy_schema.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'ziggy', 'lsp', '--schema' },
     filetypes = { 'ziggy_schema' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find({ '.git' }, { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/zk.lua
+++ b/lua/lspconfig/configs/zk.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 local function find_zk_root(startpath)
   for dir in vim.fs.parents(startpath) do
     if vim.fn.isdirectory(vim.fs.joinpath(dir, '.zk')) == 1 then
@@ -12,15 +10,17 @@ return {
   default_config = {
     cmd = { 'zk', 'lsp' },
     filetypes = { 'markdown' },
-    root_dir = util.root_pattern '.zk',
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ '.zk' }, { path = fname, upward = true })[1])
+    end,
   },
   commands = {
     ZkIndex = {
       function()
-        vim.lsp.buf.execute_command {
+        vim.lsp.buf.execute_command({
           command = 'zk.index',
           arguments = { vim.api.nvim_buf_get_name(0) },
-        }
+        })
       end,
       description = 'ZkIndex',
     },

--- a/lua/lspconfig/configs/zls.lua
+++ b/lua/lspconfig/configs/zls.lua
@@ -1,5 +1,3 @@
-local util = require 'lspconfig.util'
-
 return {
   default_config = {
     cmd = { 'zls' },
@@ -9,7 +7,9 @@ return {
       end
     end,
     filetypes = { 'zig', 'zir' },
-    root_dir = util.root_pattern('zls.json', 'build.zig', '.git'),
+    root_dir = function(fname)
+      return vim.fs.dirname(vim.fs.find({ 'zls.json', 'build.zig', '.git' }, { path = fname, upward = true })[1])
+    end,
     single_file_support = true,
   },
   docs = {

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -120,26 +120,6 @@ local function escape_wildcards(path)
   return path:gsub('([%[%]%?%*])', '\\%1')
 end
 
-function M.root_pattern(...)
-  local patterns = M.tbl_flatten { ... }
-  return function(startpath)
-    startpath = M.strip_archive_subpath(startpath)
-    for _, pattern in ipairs(patterns) do
-      local match = M.search_ancestors(startpath, function(path)
-        for _, p in ipairs(vim.fn.glob(table.concat({ escape_wildcards(path), pattern }, '/'), true, true)) do
-          if vim.loop.fs_stat(p) then
-            return path
-          end
-        end
-      end)
-
-      if match ~= nil then
-        return match
-      end
-    end
-  end
-end
-
 function M.insert_package_json(config_files, field, fname)
   local path = vim.fn.fnamemodify(fname, ':h')
   local root_with_package = vim.fs.dirname(vim.fs.find('package.json', { path = path, upward = true })[1])
@@ -359,6 +339,27 @@ end
 --- @deprecated use `vim.fs.dirname(vim.fs.find('.git', { path = startpath, upward = true })[1])` instead
 function M.find_git_ancestor(startpath)
   return vim.fs.dirname(vim.fs.find('.git', { path = startpath, upward = true })[1])
+end
+
+--- @deprecated use `vim.fs.dirname(vim.fs.find({'fname1', 'fname2'}, { path = startpath, upward = true })[1])` instead
+function M.root_pattern(...)
+  local patterns = M.tbl_flatten { ... }
+  return function(startpath)
+    startpath = M.strip_archive_subpath(startpath)
+    for _, pattern in ipairs(patterns) do
+      local match = M.search_ancestors(startpath, function(path)
+        for _, p in ipairs(vim.fn.glob(table.concat({ escape_wildcards(path), pattern }, '/'), true, true)) do
+          if vim.loop.fs_stat(p) then
+            return path
+          end
+        end
+      end)
+
+      if match ~= nil then
+        return match
+      end
+    end
+  end
 end
 
 return M

--- a/test/lspconfig_spec.lua
+++ b/test/lspconfig_spec.lua
@@ -2,8 +2,6 @@ local root = vim.fn.getcwd()
 
 describe('lspconfig', function()
   --- @diagnostic disable-next-line:undefined-field
-  local eq = assert.are.equal
-  --- @diagnostic disable-next-line:undefined-field
   local same = assert.are.same
 
   before_each(function()
@@ -11,49 +9,6 @@ describe('lspconfig', function()
   end)
 
   describe('util', function()
-    describe('root_pattern', function()
-      it('resolves to a_marker.txt', function()
-        local lspconfig = require 'lspconfig'
-        -- change the working directory to test directory
-        vim.api.nvim_command 'cd ./test/test_dir/a'
-        local cwd = vim.fn.getcwd()
-        eq(true, cwd == lspconfig.util.root_pattern { 'a_marker.txt', 'root_marker.txt' }(cwd))
-      end)
-
-      it('resolves to root_marker.txt', function()
-        local lspconfig = require 'lspconfig'
-
-        -- change the working directory to test directory
-        vim.api.nvim_command 'cd ./test/test_dir/a'
-
-        local cwd = vim.fn.getcwd()
-        local resolved = lspconfig.util.root_pattern { 'root_marker.txt' }(cwd)
-        vim.api.nvim_command 'cd ..'
-
-        eq(true, vim.fn.getcwd() == resolved)
-      end)
-    end)
-
-    describe('strip_archive_subpath', function()
-      it('strips zipfile subpaths', function()
-        local lspconfig = require 'lspconfig'
-        local res = lspconfig.util.strip_archive_subpath 'zipfile:///one/two.zip::three/four'
-        eq('/one/two.zip', res)
-      end)
-
-      it('strips tarfile subpaths', function()
-        local lspconfig = require 'lspconfig'
-        local res = lspconfig.util.strip_archive_subpath 'tarfile:/one/two.tgz::three/four'
-        eq('/one/two.tgz', res)
-      end)
-
-      it('returns non-archive paths as-is', function()
-        local lspconfig = require 'lspconfig'
-        local res = lspconfig.util.strip_archive_subpath '/one/two.zip'
-        eq('/one/two.zip', res)
-      end)
-    end)
-
     describe('user commands', function()
       it('should translate command definition to nvim_create_user_command options', function()
         local util = require 'lspconfig.util'


### PR DESCRIPTION
The primary (and potentially breaking) change is that
`util.root_pattern` traverses once per provided file pattern, while
`vim.fs.find` only traverses once. This means that the search will no
longer be prioritized by file order, which may break user configurations
who unkowingly rely on this behavior.

This will also be breaking for language servers that rely on code
dependencies that is archived but still needs to be read. More context:
https://github.com/neovim/nvim-lspconfig/pull/1687.

Work on https://github.com/neovim/nvim-lspconfig/issues/2079.