### PR TITLE
docs: Use a maintained fork for `kubernetes-json-schema` in the example

### DIFF
--- a/lua/lspconfig/configs/yamlls.lua
+++ b/lua/lspconfig/configs/yamlls.lua
@@ -64,7 +64,7 @@ require('lspconfig').yamlls.setup {
     yaml = {
       ... -- other settings. note this overrides the lspconfig defaults.
       schemas = {
-        ["https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.18.0-standalone-strict/all.json"] = "/*.k8s.yaml",
+        ["https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.32.1-standalone-strict/all.json"] = "/*.k8s.yaml",
         ... -- other schemas
       },
     },


### PR DESCRIPTION
The `instrumenta/kubernetes-json-schema` repo is apparently dead: https://github.com/instrumenta/kubernetes-json-schema/issues/32#issuecomment-1021133568 And nobody has the credentials anymore to archive it: https://github.com/instrumenta/kubeval/issues/268#issuecomment-1376490498 The recommended migration from instrumenta is to https://github.com/yannh/kubeconform, see (https://github.com/instrumenta/kubernetes-json-schema/issues/32#issuecomment-1021133568) and the recommended `kubernetes-json-schema` fork is also from the same new maintainer: https://github.com/yannh/kubernetes-json-schema/