### PR TITLE
build: remove `docgen.sh`

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -18,7 +18,7 @@ jobs:
         version: nightly
     - name: Run docgen
       run: |
-        scripts/docgen.sh
+        scripts/docgen.lua
     - name: Commit changes
       env:
         COMMIT_MSG: |

--- a/scripts/docgen.sh
+++ b/scripts/docgen.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec nvim -u NONE -E -R --headless +'set rtp+=$PWD' +'luafile scripts/docgen.lua' +q


### PR DESCRIPTION
Instead, generate documentation by running the `docgen.lua` executable.
