### PR TITLE
build: add -q flag to luacheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ test:
 
 lint:
 	@printf "\nRunning luacheck\n"
-	luacheck lua/* test/*
+	luacheck -q lua/* test/*
 	@printf "\nRunning selene\n"
 	selene --display-style=quiet .
 	@printf "\nRunning stylua\n"


### PR DESCRIPTION
Otherwise it will print out all the files that passes which makes it
extremely tedious as you need to search for the files that failed.
