### PR TITLE
ci: use the head ref when checking out

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - run: npm install --save-dev @commitlint/{cli,config-conventional}
       - run: |
           echo "module.exports = { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js


### PR DESCRIPTION
Otherwise the action will default to githubs own merge branch which
doesn't follow the actual git history.
