### PR TITLE
fix(astro,volar): correct 'typescript/lib' path for TypeScript LSP initialization

### DIFF
--- a/lua/lspconfig/configs/astro.lua
+++ b/lua/lspconfig/configs/astro.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 local function get_typescript_server_path(root_dir)
   local project_root = vim.fs.dirname(vim.fs.find('node_modules', { path = root_dir, upward = true })[1])
-  return project_root and (project_root .. '/typescript/lib') or ''
+  return project_root and (project_root .. '/node_modules/typescript/lib') or ''
 end
 
 return {

--- a/lua/lspconfig/configs/volar.lua
+++ b/lua/lspconfig/configs/volar.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 local function get_typescript_server_path(root_dir)
   local project_root = vim.fs.dirname(vim.fs.find('node_modules', { path = root_dir, upward = true })[1])
-  return project_root and (project_root .. '/typescript/lib') or ''
+  return project_root and (project_root .. '/node_modules/typescript/lib') or ''
 end
 
 -- https://github.com/vuejs/language-tools/blob/master/packages/language-server/lib/types.ts


### PR DESCRIPTION
The issue occurred because the path generated by the `get_typescript_server_path` function omitted the `node_modules` folder, causing failures when initializing the TypeScript LSP client:
Error: "Can't find typescript.js or tsserverlibrary.js in .../typescript/lib"
The function was updated to correctly include `node_modules` in the path. Now, the generated path is valid, and the LSP client works without issues.