### PR TITLE
feat: oxc-language-server

### DIFF
--- a/lua/lspconfig/configs/oxlint.lua
+++ b/lua/lspconfig/configs/oxlint.lua
@@ -1,0 +1,30 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'oxc_language_server' },
+    filetypes = {
+      'astro',
+      'javascript',
+      'javascriptreact',
+      'svelte',
+      'typescript',
+      'typescript.tsx',
+      'typescriptreact',
+      'vue',
+    },
+    root_dir = util.root_pattern('.oxlintrc.json'),
+    single_file_support = false,
+  },
+  docs = {
+    description = [[
+https://oxc.rs
+
+A collection of JavaScript tools written in Rust.
+
+```sh
+npm install [-g] oxlint
+```
+]],
+  },
+}


### PR DESCRIPTION
This pull request adds the minimal working config for [`oxlint`](https://oxc.rs) [github](https://github.com/oxc-project/oxc).
The configuration is highly inspired by the `biome` config. The `oxc_language_server` binary is part of the `oxlint` package (It has 2 binaries, `oxlint` and `oxlint_language_server`).

Sadly I was unable to generate the config.md and config.txt docs files. After executing the command in CONTRIBUTING.md, I got no error and the file was unchanged...

Related to #3062