### PR TITLE
revert: "refactor!: make available_servers function private"

### DIFF
--- a/lua/lspconfig/health.lua
+++ b/lua/lspconfig/health.lua
@@ -224,7 +224,7 @@ local function check_lspconfig(bufnr)
   bufnr = (bufnr and bufnr ~= -1) and bufnr or nil
 
   health.start('LSP configs active in this session (globally)')
-  health.info('Configured servers: ' .. table.concat(util._available_servers(), ', '))
+  health.info('Configured servers: ' .. table.concat(util.available_servers(), ', '))
   local deprecated_servers = {}
   for server_name, deprecate in pairs(require('lspconfig').server_aliases()) do
     table.insert(deprecated_servers, ('%s -> %s'):format(server_name, deprecate.to))

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -223,7 +223,8 @@ function M.get_managed_clients()
   return clients
 end
 
-function M._available_servers()
+--- @deprecated use `vim.lsp.config` in Nvim 0.11+ instead.
+function M.available_servers()
   local servers = {}
   local configs = require 'lspconfig.configs'
   for server, config in pairs(configs) do

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -14,7 +14,7 @@ end
 local lsp_complete_configured_servers = function(arg)
   return completion_sort(vim.tbl_filter(function(s)
     return s:sub(1, #arg) == arg
-  end, util._available_servers()))
+  end, util.available_servers()))
 end
 
 local lsp_get_active_clients = function(arg)

--- a/test/lspconfig_spec.lua
+++ b/test/lspconfig_spec.lua
@@ -144,7 +144,7 @@ describe('lspconfig', function()
       local _ = lspconfig.lua_ls
       local _ = lspconfig.tsserver
       lspconfig.rust_analyzer.setup {}
-      same({ 'rust_analyzer' }, require('lspconfig.util')._available_servers())
+      same({ 'rust_analyzer' }, require('lspconfig.util').available_servers())
     end)
 
     it('provides user_config to the on_setup hook', function()


### PR DESCRIPTION
This reverts commit e118ce58dab72c17216292eef7df4cee3cf60885.

It turns out `util.available_servers` is used more than anticipated, so
we revert the privatization for the time being.

Closes https://github.com/neovim/nvim-lspconfig/issues/3588.
