### PR TITLE
feat(harper-ls): added new languages and updated links

### DIFF
--- a/lua/lspconfig/configs/harper_ls.lua
+++ b/lua/lspconfig/configs/harper_ls.lua
@@ -23,6 +23,8 @@ return {
       'haskell',
       'cmake',
       'typst',
+      'php',
+      'dart',
     },
     root_dir = function(fname)
       return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
@@ -31,13 +33,13 @@ return {
   },
   docs = {
     description = [[
-https://github.com/elijah-potter/harper
+https://github.com/automattic/harper
 
 The language server for Harper, the slim, clean language checker for developers.
 
-See [docs](https://github.com/elijah-potter/harper/blob/master/harper-ls/README.md#configuration) for more information on settings.
+See our [documentation](https://writewithharper.com/docs/integrations/neovim) for more information on settings.
 
-In short, however, they should look something like this:
+In short, they should look something like this:
 ```lua
 lspconfig.harper_ls.setup {
   settings = {


### PR DESCRIPTION
In automattic/harper#495, we're adding support for two new languages: `php` and `dart`. This PR adds those file types and updates links that changed as a result of the [Harper acquisition.](https://techcrunch.com/2024/11/21/wordpress-com-owner-automattic-snaps-up-grammar-checker-harper/)

This will remain a draft until that PR is merged.