### PR TITLE
docs: fix broken documentation link in rust_analyzer config

### DIFF
--- a/lua/lspconfig/configs/rust_analyzer.lua
+++ b/lua/lspconfig/configs/rust_analyzer.lua
@@ -99,7 +99,7 @@ https://github.com/rust-lang/rust-analyzer
 rust-analyzer (aka rls 2.0), a language server for Rust
 
 
-See [docs](https://github.com/rust-lang/rust-analyzer/blob/master/docs/user/generated_config.adoc) for extra settings. The settings can be used like this:
+See [docs](https://github.com/rust-lang/rust-analyzer/blob/release/docs/user/generated_config.adoc) for extra settings. The settings can be used like this:
 ```lua
 require'lspconfig'.rust_analyzer.setup{
   settings = {


### PR DESCRIPTION
Generated documentation is only available in the release branch of rust-analyzer, so the current link leads to a 404.