### PR TITLE
fix(angularls): use correct executable on windows

### DIFF
--- a/lua/lspconfig/configs/angularls.lua
+++ b/lua/lspconfig/configs/angularls.lua
@@ -59,7 +59,7 @@ return {
 
     -- We need to check our probe directories because they may have changed.
     new_config.cmd = {
-      'ngserver',
+      vim.fn.exepath('ngserver'),
       '--stdio',
       '--tsProbeLocations',
       new_probe_dir,


### PR DESCRIPTION
Use the correct binary on windows, otherwise the server won't start.