### PR TITLE
fix(health.lua): increased version check cmd timeout

### DIFF
--- a/lua/lspconfig/health.lua
+++ b/lua/lspconfig/health.lua
@@ -51,7 +51,7 @@ local function try_get_cmd_output(cmd)
     on_stdout = on_data,
     on_stderr = on_data,
   })
-  local rv = vim.fn.jobwait({ chanid }, 300)
+  local rv = vim.fn.jobwait({ chanid }, 500)
   vim.fn.jobstop(chanid)
   return rv[1] == 0 and out or nil
 end


### PR DESCRIPTION
Problem:
LspInfo returns '?' for version string when using the codeqlls language server. This is because codeql is slow to return its version number due to the underlying JVM.

Solution:
Increase the timeout from 300ms to 500ms.
1000 iterations of `codeql version` resulted in (349 +- 13) ms which informed the choice of 500ms.