### PR TITLE
don't skip VIMRUNTIME in lua lsp if ~/.config/nvim/.luarc.json exists

### DIFF
--- a/lua/lspconfig/configs/lua_ls.lua
+++ b/lua/lspconfig/configs/lua_ls.lua
@@ -48,7 +48,7 @@ require'lspconfig'.lua_ls.setup {
   on_init = function(client)
     if client.workspace_folders then
       local path = client.workspace_folders[1].name
-      if vim.loop.fs_stat(path..'/.luarc.json') or vim.loop.fs_stat(path..'/.luarc.jsonc') then
+      if path ~= vim.fn.stdpath('config') and (vim.loop.fs_stat(path..'/.luarc.json') or vim.loop.fs_stat(path..'/.luarc.jsonc')) then
         return
       end
     end


### PR DESCRIPTION
.luarc is created by lua-lsp itself (e.g. if you hit "disable diagnostics" in a code action), at which point the lsp will start showing errors that the `vim` global is undefined after the next restart.