### PR TITLE
feat(oxc_language_server): add OxcFixAll command

### DIFF
--- a/lua/lspconfig/configs/oxlint.lua
+++ b/lua/lspconfig/configs/oxlint.lua
@@ -19,7 +19,7 @@ return {
     commands = {
       OxcFixAll = {
         function()
-          local client = util.get_active_client_by_name(0, 'oxlint')
+          local client = vim.lsp.get_clients({ bufnr = 0, name = 'oxlint' })[0]
           if client == nil then
             return
           end

--- a/lua/lspconfig/configs/oxlint.lua
+++ b/lua/lspconfig/configs/oxlint.lua
@@ -19,7 +19,7 @@ return {
     commands = {
       OxcFixAll = {
         function()
-          local client = vim.lsp.get_clients({ bufnr = 0, name = 'oxlint' })[0]
+          local client = vim.lsp.get_clients({ bufnr = 0, name = 'oxlint' })[1]
           if client == nil then
             return
           end

--- a/lua/lspconfig/configs/oxlint.lua
+++ b/lua/lspconfig/configs/oxlint.lua
@@ -15,6 +15,27 @@ return {
     },
     root_dir = util.root_pattern('.oxlintrc.json'),
     single_file_support = false,
+
+    commands = {
+      OxcFixAll = {
+        function()
+          local client = util.get_active_client_by_name(0, 'oxlint')
+          if client == nil then
+            return
+          end
+
+          client.request('workspace/executeCommand', {
+            command = 'oxc.fixAll',
+            arguments = {
+              {
+                uri = vim.uri_from_bufnr(0),
+              },
+            },
+          }, nil, 0)
+        end,
+        description = 'Apply fixes to current buffer using oxlint (--fix)',
+      },
+    },
   },
   docs = {
     description = [[


### PR DESCRIPTION
This pull request adds the `OxcFixAll` command for basic `--fix` functionality. (as mentioned in https://github.com/neovim/nvim-lspconfig/pull/3586#issuecomment-2613930725)

Note this functionality was added to the language server very recently (https://github.com/oxc-project/oxc/pull/8858) and only works with `oxc_language_server` >=`0.15.10`. (Still not in mason-registry, see https://github.com/mason-org/mason-registry/pull/8717)