### PR TITLE
fix(nushell): root_dir should avoid returning nil

### DIFF
--- a/lua/lspconfig/configs/nushell.lua
+++ b/lua/lspconfig/configs/nushell.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'nu', '--lsp' },
     filetypes = { 'nu' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1] or fname)
     end,
     single_file_support = true,
   },


### PR DESCRIPTION
nushell 0.102 made some changes that a nil `root_dir` will cause lsp server to exit.

This PR tries to mitigate the problem by providing a fallback `root_dir` value.