### PR TITLE
fix(eslint): update openDoc os call for windows

### DIFF
--- a/lua/lspconfig/configs/eslint.lua
+++ b/lua/lspconfig/configs/eslint.lua
@@ -131,16 +131,8 @@ return {
     end,
     handlers = {
       ['eslint/openDoc'] = function(_, result)
-        if not result then
-          return
-        end
-        local sysname = vim.loop.os_uname().sysname
-        if sysname:match 'Windows' then
-          os.execute(string.format('start %q', result.url))
-        elseif sysname:match 'Linux' then
-          os.execute(string.format('xdg-open %q', result.url))
-        else
-          os.execute(string.format('open %q', result.url))
+        if result then
+          vim.ui.open(result.url)
         end
         return {}
       end,


### PR DESCRIPTION
Problem:
os.execute misinterprets quoted url as window title

Solution:
add an empty title argument