### PR TITLE
feat(r_language_server): add quarto filetype

### DIFF
--- a/lua/lspconfig/configs/r_language_server.lua
+++ b/lua/lspconfig/configs/r_language_server.lua
@@ -1,7 +1,7 @@
 return {
   default_config = {
     cmd = { 'R', '--no-echo', '-e', 'languageserver::run()' },
-    filetypes = { 'r', 'rmd' },
+    filetypes = { 'r', 'rmd', 'quarto' },
     root_dir = function(fname)
       return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1]) or vim.loop.os_homedir()
     end,


### PR DESCRIPTION
[Quarto](https://quarto.org/) is a (more or less new) scientific and technical publishing system. There is also a [quarto filetype](https://github.com/neovim/neovim/blob/master/runtime/ftplugin/quarto.vim) which is very similar to [rmarkdown](https://rmarkdown.rstudio.com/) but has some extensions.

The quarto filetype can also be used with python and julia. The r_language_server detects code chunks / blocks that use the R programming language and runs only on them.