### PR TITLE
fix(sourcekit): use textDocument/diagnostic over publishDiagnostics

### DIFF
--- a/lua/lspconfig/configs/sourcekit.lua
+++ b/lua/lspconfig/configs/sourcekit.lua
@@ -15,6 +15,14 @@ return {
       local t = { objc = 'objective-c', objcpp = 'objective-cpp' }
       return t[ftype] or ftype
     end,
+    capabilities = {
+      textDocument = {
+        diagnostic = {
+          dynamicRegistration = true,
+          relatedDocumentSupport = true,
+        },
+      },
+    },
   },
   docs = {
     description = [[


### PR DESCRIPTION
Problem:
nvim doesn't recognize that sourcekit supports `textDocument/diagnostic` requests, causing it to rely on `textDocument/publishDiagnostics`, which results in delayed diagnostics.

Solution:
Manually configure `client.server_capabilities.diagnosticProvider` in `on_init` to enable `textDocument/diagnostic` support. Override the `textDocument/publishDiagnostics` handler to prevent duplicate diagnostics. 

fix neovim/neovim#31873

~~I'm not sure if there's a way to configure `server_capabilities` without `on_init` :sweat_smile:~~