### PR TITLE
fix(turbo_ls): Fix `root_dir`

### DIFF
--- a/lua/lspconfig/configs/turbo_ls.lua
+++ b/lua/lspconfig/configs/turbo_ls.lua
@@ -1,8 +1,10 @@
+local util = require 'lspconfig.util'
+
 return {
   default_config = {
     cmd = { 'turbo-language-server', '--stdio' },
     filetypes = { 'html', 'ruby', 'eruby', 'blade', 'php' },
-    root_dir = vim.fs.root(0, { 'Gemfile', '.git' }),
+    root_dir = util.root_pattern('Gemfile', '.git'),
   },
   docs = {
     description = [[


### PR DESCRIPTION
Currently, `root_dir` in `configs.md` is

- `root_dir` : ```lua "/home/runner/work/nvim-lspconfig/nvim-lspconfig" ```

This is wrong, so this commit fixes this.