### PR TITLE
fix(docgen): root_dir doc shows paths from CI env

### DIFF
--- a/doc/configs.md
+++ b/doc/configs.md
@@ -469,10 +469,7 @@ Default config:
   ```lua
   { "r" }
   ```
-- `root_dir` :
-  ```lua
-  "/home/runner/work/nvim-lspconfig/nvim-lspconfig"
-  ```
+- `root_dir` source (use "gF" to visit): [../lua/lspconfig/configs/air.lua:2](../lua/lspconfig/configs/air.lua#L2)
 - `single_file_support` : `true`
 
 
@@ -11296,10 +11293,7 @@ Default config:
   ```lua
   { "html", "ruby", "eruby", "blade", "php" }
   ```
-- `root_dir` :
-  ```lua
-  "/home/runner/work/nvim-lspconfig/nvim-lspconfig"
-  ```
+- `root_dir` source (use "gF" to visit): [../lua/lspconfig/configs/turbo_ls.lua:2](../lua/lspconfig/configs/turbo_ls.lua#L2)
 
 
 ## turtle_ls

--- a/doc/configs.txt
+++ b/doc/configs.txt
@@ -469,10 +469,7 @@ Default config:
   ```lua
   { "r" }
   ```
-- `root_dir` :
-  ```lua
-  "/home/runner/work/nvim-lspconfig/nvim-lspconfig"
-  ```
+- `root_dir` source (use "gF" to visit): [../lua/lspconfig/configs/air.lua:2](../lua/lspconfig/configs/air.lua#L2)
 - `single_file_support` : `true`
 
 
@@ -11296,10 +11293,7 @@ Default config:
   ```lua
   { "html", "ruby", "eruby", "blade", "php" }
   ```
-- `root_dir` :
-  ```lua
-  "/home/runner/work/nvim-lspconfig/nvim-lspconfig"
-  ```
+- `root_dir` source (use "gF" to visit): [../lua/lspconfig/configs/turbo_ls.lua:2](../lua/lspconfig/configs/turbo_ls.lua#L2)
 
 
 ## turtle_ls

--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -131,7 +131,7 @@ local function make_lsp_sections()
             map_sorted(template_def.default_config, function(k, v)
               if type(v) == 'boolean' then
                 return ('- `%s` : `%s`'):format(k, v)
-              elseif type(v) ~= 'function' then
+              elseif type(v) ~= 'function' and k ~= 'root_dir' then
                 return ('- `%s` :\n  ```lua\n%s\n  ```'):format(k, indent(2, inspect(v)))
               end
 


### PR DESCRIPTION
## Problem:
When `root_dir` is not defined as a function, the generated docs show the paths resolved in the CI env:

    root_dir : lua "/home/runner/work/nvim-lspconfig/nvim-lspconfig"

## Solution:
Always show the "gF" message for `root_dir`, even if it is not a function.

Fix #3628