### PR TITLE
chore(bazelrc_lsp): Invoke `lsp` subcommand explicitly

### DIFF
--- a/lua/lspconfig/configs/bazelrc_lsp.lua
+++ b/lua/lspconfig/configs/bazelrc_lsp.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig/util'
 
 return {
   default_config = {
-    cmd = { 'bazelrc-lsp' },
+    cmd = { 'bazelrc-lsp', 'lsp' },
     filetypes = { 'bazelrc' },
     root_dir = util.root_pattern('WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel'),
   },


### PR DESCRIPTION
The bazelrc-lsp binary added other sub-commands besides the `lsp` functionality (e.g., `bazelrc-lsp format` can be used to format files from the command line). This commit updates the config such that the `bazelrc-lsp lsp` is explicitly invoked. (Currently, `bazelrc-lsp` still defaults to the `lsp` sub-command, but this default will likely be removed in a future version)