### PR TITLE
gleam: fix broken installation description

### DIFF
--- a/lua/lspconfig/configs/gleam.lua
+++ b/lua/lspconfig/configs/gleam.lua
@@ -13,9 +13,8 @@ return {
 https://github.com/gleam-lang/gleam
 
 A language server for Gleam Programming Language.
-[Installation](https://gleam.run/getting-started/installing/)
 
-It can be i
+It comes with the Gleam compiler, for installation see: [Installing Gleam](https://gleam.run/getting-started/installing/)
 ]],
   },
 }


### PR DESCRIPTION
Seems the description got cut of somehow(?) and went unnoticed in #2266.