### PR TITLE
fix(tailwindcss): improved tailwindcss detection

### DIFF
--- a/lua/lspconfig/configs/tailwindcss.lua
+++ b/lua/lspconfig/configs/tailwindcss.lua
@@ -100,7 +100,7 @@ return {
       end
     end,
     root_dir = function(fname)
-      return util.root_pattern(
+      local root_file = {
         'tailwind.config.js',
         'tailwind.config.cjs',
         'tailwind.config.mjs',
@@ -108,10 +108,10 @@ return {
         'postcss.config.js',
         'postcss.config.cjs',
         'postcss.config.mjs',
-        'postcss.config.ts'
-      )(fname) or vim.fs.dirname(vim.fs.find('package.json', { path = fname, upward = true })[1]) or vim.fs.dirname(
-        vim.fs.find('node_modules', { path = fname, upward = true })[1]
-      ) or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+        'postcss.config.ts',
+      }
+      root_file = util.insert_package_json(root_file, 'tailwindcss', fname)
+      return util.root_pattern(unpack(root_file))(fname)
     end,
   },
   docs = {


### PR DESCRIPTION
Currently, the Tailwind CSS language server is enabled for any workspace containing a `.git` folder, a `node_modules` folder, or a `package.json` file, which is not ideal. This PR introduces a specific check for the `tailwindcss` package within `package.json` file using `insert_package_json` method from `util` (this approach is used in `eslint` config). Since the latest version of Tailwind CSS (v4) no longer requires `postcss.config.*` and `tailwind.config.*` files, these can no longer be relied upon as sole criteria for enabling Tailwind CSS LSP.