### PR TITLE
fix(tblgen): find tablegen_compile_commands.yml

### DIFF
--- a/lua/lspconfig/configs/tblgen_lsp_server.lua
+++ b/lua/lspconfig/configs/tblgen_lsp_server.lua
@@ -1,8 +1,19 @@
 local util = require 'lspconfig.util'
 
+local function get_command()
+  local cmd = { 'tblgen-lsp-server' }
+  local files = vim.fs.find('tablegen_compile_commands.yml', { path = vim.fn.expand('%:p:h'), upward = true })
+  if #files > 0 then
+    local file = files[1]
+    table.insert(cmd, '--tablegen-compilation-database=' .. vim.fs.dirname(file) .. '/tablegen_compile_commands.yml')
+  end
+
+  return cmd
+end
+
 return {
   default_config = {
-    cmd = { 'tblgen-lsp-server' },
+    cmd = get_command(),
     filetypes = { 'tablegen' },
     root_dir = function(fname)
       return util.root_pattern 'tablegen_compile_commands.yml'(fname)


### PR DESCRIPTION
The `tblgen_lsp_server` doesn't seem to load any specific compilation database server and hence we need to explicitly specify the command-line argument to pick the correct database path.