### PR TITLE
fix(biome): improved biomejs detection

### DIFF
--- a/lua/lspconfig/configs/biome.lua
+++ b/lua/lspconfig/configs/biome.lua
@@ -17,7 +17,11 @@ return {
       'typescriptreact',
       'vue',
     },
-    root_dir = util.root_pattern('biome.json', 'biome.jsonc'),
+    root_dir = function(fname)
+      local root_files = { 'biome.json', 'biome.jsonc' }
+      root_files = util.insert_package_json(root_files, 'biome', fname)
+      return vim.fs.dirname(vim.fs.find(root_files, { path = fname, upward = true })[1])
+    end,
     single_file_support = false,
   },
   docs = {


### PR DESCRIPTION
Biome configuration files (`biome.json`, `biome.jsonc`) are [not required](https://biomejs.dev/guides/configure-biome/#configuration-file-resolution) for Biome to function within a project. If no configuration file is present, Biome defaults to its built-in settings. Therefore, I suggest to check for the Biome package in the `package.json` file in addition to looking for configuration files.