### PR TITLE
feat: util:root_pattern() search folder-first up

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -116,26 +116,13 @@ function M.search_ancestors(startpath, func)
   end
 end
 
-local function escape_wildcards(path)
-  return path:gsub('([%[%]%?%*])', '\\%1')
-end
-
 function M.root_pattern(...)
-  local patterns = M.tbl_flatten { ... }
+  local patterns = M.tbl_flatten({ ... })
   return function(startpath)
-    startpath = M.strip_archive_subpath(startpath)
-    for _, pattern in ipairs(patterns) do
-      local match = M.search_ancestors(startpath, function(path)
-        for _, p in ipairs(vim.fn.glob(table.concat({ escape_wildcards(path), pattern }, '/'), true, true)) do
-          if vim.loop.fs_stat(p) then
-            return path
-          end
-        end
-      end)
+    local match = vim.fs.find(patterns, { path = startpath, upward = true })[1]
 
-      if match ~= nil then
-        return match
-      end
+    if match then
+      return vim.fs.dirname(match)
     end
   end
 end


### PR DESCRIPTION
Hi,

Edit:
Was making this PR based upon the code in master. I've seen all the discussions after.
Seems to work for me.
Feel free to close/reject if this does not make sense to you.
Thanks
- - - - - -

This PR simplify and use the function provided by neovim to find a (set of) file(s) to find the root of the project, and solves the following bug:

Let assume the following (as an example, works with any project):
- you are working in a lua project
- you have a `.stylua.toml` configuration file in your home folder (`/home/mdedonno1337`)
- you have NOT any `.stylua.toml` configuration file in the current project
- you have a `.git` folder in your project (`/home/mdedonno1337/lua_project/.git/`)

The `root_pattern()` function will use the patterns to search for `.stylua.toml` file first, folder up first, then, if not found, search for `.git` folder, folder up first:
1. /home/mdedonno1337/lua_project/.stylua.toml
2. /home/mdedonno1337/.stylua.toml 
3. /home/.stylua.toml 
4. /.stylua.toml 
5. /home/mdedonno1337/lua_project/.git
6. /home/mdedonno1337/.git
7. ...

This will wrongly find the file 2. first, and not the folder 5. as I would expect.

This patch uses the `vim.fs.find()` function, which will search pattern-first as follow:

1. /home/mdedonno1337/lua_project/.stylua.toml
2. /home/mdedonno1337/lua_project/.git
3. /home/mdedonno1337/.stylua.toml 
4. /home/mdedonno1337/.git
5. ...

This will ensure that the folder matching the searched pattern will hit with the closest folder relative to the current file (i.e the smallest folder project).