### PR TITLE
fix(ltex_plus): add latex to `enabled` settings

### DIFF
--- a/lua/lspconfig/configs/ltex_plus.lua
+++ b/lua/lspconfig/configs/ltex_plus.lua
@@ -58,6 +58,7 @@ return {
           'rnoweb',
           'rst',
           'tex',
+          'latex',
           'text',
           'typst',
           'xhtml',


### PR DESCRIPTION
Problem: LSP not working with latex files. Spell checking skipped in latex files
Solution: Add latex to the enabled section because even though 'tex' is the filetype the language ID is 'latex'