### PR TITLE
feat: vectorcode-server

### DIFF
--- a/lua/lspconfig/configs/vectorcode_server.lua
+++ b/lua/lspconfig/configs/vectorcode_server.lua
@@ -1,0 +1,15 @@
+return {
+  default_config = {
+    cmd = { 'vectorcode-server' },
+    root_dir = vim.fs.root(0, { '.vectorcode', '.git' }),
+    single_file_support = false,
+    settings = {},
+  },
+  docs = {
+    description = [[
+https://github.com/Davidyz/VectorCode
+
+A Language Server Protocol implementation for VectorCode, a code repository indexing tool.
+    ]],
+  },
+}


### PR DESCRIPTION
vectorcode-server is the LSP frontend for [vectorcode](https://github.com/davidyz/vectorcode), a code repository indexing tool that provides extra context for LLM. The upstream project has 180+ stars at the time of this PR.

I've gone through CONTRIBUTING.md and several other PRs about adding new configs, and there seems to be some reviews against the use of `utils.root_pattern` but the example in CONTRIBUTING.md is still using it, so I left it as is. If there's a particular reason that this should be changed to `vim.fs.root`, please let me know and I'll change it.