### PR TITLE
feat: upgrade for golangci-lint v2

### DIFF
--- a/lua/lspconfig/configs/golangci_lint_ls.lua
+++ b/lua/lspconfig/configs/golangci_lint_ls.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'golangci-lint-langserver' },
     filetypes = { 'go', 'gomod' },
     init_options = {
-      command = { 'golangci-lint', 'run', '--out-format', 'json' },
+      command = { 'golangci-lint', 'run', '--out.json.path', 'stdout' },
     },
     root_dir = function(fname)
       return util.root_pattern(


### PR DESCRIPTION
`--out-format=json` was replaced by `--out.json.path=stdout`
https://github.com/golangci/golangci-lint/blob/86cc7c6bfbe4d6ca515f9c45b58cfa03cfd0c3da/docs/src/docs/product/migration-guide.mdx#command-line-flags