### PR TITLE
feat: alias `:LspInfo` to `:checkhealth vim.lsp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Most of the time, the reason for failure is present in the logs.
 
 ## Commands
 
-* `:LspInfo` (deprecated alias to `:che lspconfig`) shows the status of active and configured language servers.
+* `:LspInfo` (alias to `:checkhealth vim.lsp`) shows the status of active and configured language servers.
 * `:LspStart <config_name>` Start the requested server name. Will only successfully start if the command detects a root directory matching the current config. Pass `autostart = false` to your `.setup{}` call for a language server if you would like to launch clients solely with this command. Defaults to all servers matching current buffer filetype.
 * `:LspStop [<client_id_or_name> ...]` Stops the given server(s). Defaults to
 stopping all servers active on the current buffer. To force stop add `++force`

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -392,14 +392,8 @@ standard for single-file mode, lspconfig will adopt that standard.
 COMMANDS                                                    *lspconfig-commands*
 
 :LspInfo                                                            *:LspInfo*
-Deprecated alias to `:check lspconfig`.
-Shows the status of all configured language servers. Note that client id
-refers to the Nvim RPC channel connected to a given language server. Also
-lists deprecated servers.
-
-The following commands support tab-completion for all arguments. All commands
-that require a client id can either leverage tab-completion or the info
-contained in `:LspInfo`:
+Alias to `:checkhealth vim.lsp`. Shows the status of active LSP clients and
+servers.
 
 :LspStart [config_name]                                            *:LspStart*
 Launches the requested (configured) client, but only if it successfully
@@ -474,8 +468,7 @@ For debugging nvim-lspconfig issues, the most common hurdles users face are:
     `handlers`. Ensure that you debug by using a stock configuration to ensure
     your customizations are not introducing issues.
 
-|LspInfo| provides an overview of your active and configured language servers
-which can be useful for debugging.
+|:LspInfo| provides an overview which can be useful for debugging.
 
 Note that it will not report any configuration changes applied in
 `on_new_config`.
@@ -511,7 +504,7 @@ Highlights                                                *lspconfig-highlight*
 
 WARNING: The `require('lspconfig.ui.windows')` API was removed.
 LspInfo is provided by a healthcheck instead: >vim
-    :checkhealth lspconfig
+    :checkhealth vim.lsp
 <
 
 ==============================================================================

--- a/lua/lspconfig/health.lua
+++ b/lua/lspconfig/health.lua
@@ -323,6 +323,12 @@ local function check_lspdocs(buf_clients, other_matching_configs)
 end
 
 function M.check()
+  if vim.fn.has('nvim-0.11') == 1 then
+    vim.deprecate(':checkhealth lspconfig', ':checkhealth vim.lsp', '0.12', 'nvim-lspconfig', false)
+    vim.cmd [[checkhealth vim.lsp]]
+    return
+  end
+
   -- XXX: create "q" mapping until :checkhealth has this feature in Nvim stable.
   vim.cmd [[nnoremap <buffer> q <c-w>q]]
 

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -65,7 +65,7 @@ end
 
 -- Called from plugin/lspconfig.vim because it requires knowing that the last
 -- script in scriptnames to be executed is lspconfig.
-api.nvim_create_user_command('LspInfo', ':che lspconfig', { desc = 'Deprecated alias to `:che lspconfig`' })
+api.nvim_create_user_command('LspInfo', ':checkhealth vim.lsp', { desc = 'Alias to `:checkhealth vim.lsp`' })
 
 api.nvim_create_user_command('LspStart', function(info)
   local server_name = string.len(info.args) > 0 and info.args or nil


### PR DESCRIPTION
Problem:
`:checkhealth lspconfig` has no benefits vs `:checkhealth vim.lsp`.

Solution:
- on Nvim 0.11+, `:LspInfo` is an alias to `:checkhealth vim.lsp` instead of `:checkhealth lspconfig`.
- `lua/lspconfig/health.lua` will be removed in a few months.


fix #3453
fix #3509