### PR TITLE
fix(golangci-lint): disable stats in json output

### DIFF
--- a/lua/lspconfig/configs/golangci_lint_ls.lua
+++ b/lua/lspconfig/configs/golangci_lint_ls.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'golangci-lint-langserver' },
     filetypes = { 'go', 'gomod' },
     init_options = {
-      command = { 'golangci-lint', 'run', '--output.json.path', 'stdout' },
+      command = { 'golangci-lint', 'run', '--output.json.path=stdout', '--show-stats=false' },
     },
     root_dir = function(fname)
       return util.root_pattern(


### PR DESCRIPTION
Changes from #3662 and #3661 do not work, since the `golangci-lint run` command returns trailing stats info after json output (and language server therefore cannot parse it).

This was already addressed in the [comment](https://github.com/neovim/nvim-lspconfig/pull/3662#issuecomment-2755344532) of #3662, but wasn't fixed there.

Here is an example output from the command without `--show-stats=false` flag:

```
$ golangci-lint run --output.json.path stdout
{
  // valid json here
}
9 issues:
* errcheck: 8
* staticcheck: 1
```

... and here is the output with it:
```
$ golangci-lint run --output.json.path stdout --show-stats=false
{
  // valid json here
}
```

**Also important note**:

The flag needs to be in the form with an equal sign (`--show-stats=false`) and not witout it (`--show-stats false`), since in the latter case, `false` is interpreted as path to lint. I also changed the `--output.json.path` argument into this form, just to be a bit more consistent.