### PR TITLE
feat(async): add `run_job`, a coroutine-less version of `run_command`

### DIFF
--- a/lua/lspconfig/async.lua
+++ b/lua/lspconfig/async.lua
@@ -57,6 +57,47 @@ function M.run_command(cmd)
   return stdout and stdout or nil
 end
 
+---@param cmd string[]
+---@param on_done function(string[]?)
+---@param on_error? function(integer, string[]?)
+function M.run_job(cmd, on_done, on_error)
+  local stdout = {}
+  local stderr = {}
+
+  local jobid = vim.fn.jobstart(cmd, {
+    on_stdout = function(_, data, _)
+      data = table.concat(data, '\n')
+      if #data > 0 then
+        stdout[#stdout + 1] = data
+      end
+    end,
+    on_stderr = function(_, data, _)
+      stderr[#stderr + 1] = table.concat(data, '\n')
+    end,
+    on_exit = function(_, code, _)
+      if code == 0 then
+        on_done(stdout)
+      else
+        if on_error then
+          on_error(code, stderr)
+        else
+          vim.notify(
+            ('[lspconfig] cmd failed with code %d: %s\n%s'):format(code, cmd, table.concat(stderr, '')),
+            vim.log.levels.WARN
+          )
+        end
+      end
+    end,
+    stdout_buffered = true,
+    stderr_buffered = true,
+  })
+
+  if jobid <= 0 then
+    vim.notify(('[lspconfig] unable to run cmd: %s'):format(cmd), vim.log.levels.WARN)
+    return nil
+  end
+end
+
 function M.reenter()
   if vim.in_fast_event() then
     local co = assert(coroutine.running())


### PR DESCRIPTION
Needed for neovim 0.11 port

3 configurations use `async.run_command`, but this function cannot be used outside of a coroutine context. This is a replacement that's made exactly for that

Needed for #3659