### PR TITLE
fix(postgres_lsp): re-enable single file support

### DIFF
--- a/lua/lspconfig/configs/postgres_lsp.lua
+++ b/lua/lspconfig/configs/postgres_lsp.lua
@@ -5,7 +5,7 @@ return {
       'sql',
     },
     root_dir = vim.fs.root(0, { 'postgrestools.jsonc' }),
-    single_file_support = false,
+    single_file_support = true,
   },
   docs = {
     description = [[


### PR DESCRIPTION
Do not require a `postgrestools.jsonc` file in the root directory for single file support.

Fixes #3672.