### PR TITLE
fix(sourcekit): URL & add dynamic reg. for `didChangeWatchedFiles`

### DIFF
--- a/lua/lspconfig/configs/sourcekit.lua
+++ b/lua/lspconfig/configs/sourcekit.lua
@@ -16,6 +16,11 @@ return {
       return t[ftype] or ftype
     end,
     capabilities = {
+      workspace = {
+        didChangeWatchedFiles = {
+          dynamicRegistration = true,
+        },
+      },
       textDocument = {
         diagnostic = {
           dynamicRegistration = true,
@@ -26,7 +31,7 @@ return {
   },
   docs = {
     description = [[
-https://github.com/apple/sourcekit-lsp
+https://github.com/swiftlang/sourcekit-lsp
 
 Language server for Swift and C/C++/Objective-C.
     ]],


### PR DESCRIPTION
1. the URL is outdated, repo owner is now `swiftlang`
2. this guide from `swift.org` recommends to always add `capabilities.workspace.didChangeWatchedFiles.dynamicRegistration = true`. 

I am not a Swift dev—I just wanted to quickly enable the LSP to go through a Swift project—but seeing that it's the official Swift website that recommends this, I assume it does make sense to add it to the default config.