### PR TITLE
fix: improve path escaping in wildcard function

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -124,7 +124,7 @@ local function escape_wildcards(path)
   -- - Shell special characters: ` ' " ; | & < >
   -- - Whitespace: %s (spaces, tabs, etc.)
   -- The gsub function replaces any matches with the same character preceded by a backslash
-  return path:gsub('([%[%]%?%*%$%(%)%^%%%.%+%-%~\\`\'";|&<>%s])', '\\%1')
+  return path:gsub('([' .. vim.pesc('[]?*$()^%.+-~') .. '\\`\'";|&<>%s])', '\\%1')
 end
 
 function M.root_pattern(...)

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -117,7 +117,14 @@ function M.search_ancestors(startpath, func)
 end
 
 local function escape_wildcards(path)
-  return path:gsub('([%[%]%?%*])', '\\%1')
+  -- Escape all potentially problematic special characters
+  -- Covers:
+  -- - Wildcards and pattern matching: [ ] ? * $ ( ) ^ % . + - ~
+  -- - Escape character: \
+  -- - Shell special characters: ` ' " ; | & < >
+  -- - Whitespace: %s (spaces, tabs, etc.)
+  -- The gsub function replaces any matches with the same character preceded by a backslash
+  return path:gsub('([%[%]%?%*%$%(%)%^%%%.%+%-%~\\`\'";|&<>%s])', '\\%1')
 end
 
 function M.root_pattern(...)


### PR DESCRIPTION
The escape_wildcards function was enhanced to handle a broader range of special characters that could cause issues when used in pattern matching. This includes additional wildcards, pattern matching characters, shell special characters, the escape character itself, and whitespace.

I faced this issue when I work on React Router and Tanstack 	Router.
They adapt file-based routing, and they use special characters like `$` as filename.
https://reactrouter.com/how-to/file-route-conventions#optional-segments

Before this fix, it takes like 15 seconds to open files like `foo.$.ts`, but this fixes!