### PR TITLE
refactor: deprecate add_hook_before/after

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -149,28 +149,6 @@ The global defaults for all servers can be overridden by extending the
 <
 
 ==============================================================================
-SETUP HOOK                                                *lspconfig-setup-hook*
-
-`lspconfig` will execute the `on_setup` hook for each setup call to a server after
-validating its configuration, and before attempting to launch the server
-itself. One typical usage is to allow ad-hoc substitution for any
-configuration entry, such as `cmd`.
-
->lua
-  local lspconfig = require 'lspconfig'
-  lspconfig.util.on_setup = lspconfig.util.add_hook_before(lspconfig.util.on_setup, function(config)
-    if some_condition and config.name == "clangd" then
-      local custom_server_prefix = "/my/custom/server/prefix"
-      config.cmd = { custom_server_prefix .. "/bin/clangd" }
-    end
-  end)
-
-
-Note: This is primarily targeted at plugins developers, so make sure to use
-`util.add_hook_before()` as a wrapper instead of overriding the original function
-completely, to void breaking external integrations with lspconfig.
-
-==============================================================================
 SERVER CONFIGS                                        *lspconfig-configurations*
 
 See |lspconfig-all| for the list of provided LSP configurations.

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -34,30 +34,6 @@ function M.validate_bufnr(bufnr)
   return bufnr == 0 and api.nvim_get_current_buf() or bufnr
 end
 
-function M.add_hook_before(func, new_fn)
-  if func then
-    return function(...)
-      -- TODO which result?
-      new_fn(...)
-      return func(...)
-    end
-  else
-    return new_fn
-  end
-end
-
-function M.add_hook_after(func, new_fn)
-  if func then
-    return function(...)
-      -- TODO which result?
-      func(...)
-      return new_fn(...)
-    end
-  else
-    return new_fn
-  end
-end
-
 -- Maps lspconfig-style command options to nvim_create_user_command (i.e. |command-attributes|) option names.
 local opts_aliases = {
   ['description'] = 'desc',
@@ -365,6 +341,32 @@ end
 function M.get_lsp_clients(filter)
   --- @diagnostic disable-next-line:deprecated
   return nvim_eleven and lsp.get_clients(filter) or lsp.get_active_clients(filter)
+end
+
+--- @deprecated Will be removed. Do not use.
+function M.add_hook_before(func, new_fn)
+  if func then
+    return function(...)
+      -- TODO which result?
+      new_fn(...)
+      return func(...)
+    end
+  else
+    return new_fn
+  end
+end
+
+--- @deprecated Will be removed. Do not use.
+function M.add_hook_after(func, new_fn)
+  if func then
+    return function(...)
+      -- TODO which result?
+      func(...)
+      return new_fn(...)
+    end
+  else
+    return new_fn
+  end
 end
 
 return M


### PR DESCRIPTION
These are special-purpose functions that should never have been "public".