### PR TITLE
feat: fart - LSP for Flutter/Dart

### DIFF
--- a/doc/configs.md
+++ b/doc/configs.md
@@ -102,6 +102,7 @@ Nvim by running `:help lspconfig-all`.
 - [esbonio](#esbonio)
 - [eslint](#eslint)
 - [facility_language_server](#facility_language_server)
+- [fart](#fart)
 - [fennel_language_server](#fennel_language_server)
 - [fennel_ls](#fennel_ls)
 - [fish_lsp](#fish_lsp)
@@ -3888,6 +3889,49 @@ Default config:
   ```
 - `root_dir` source (use "gF" to visit): [../lua/lspconfig/configs/facility_language_server.lua:2](../lua/lspconfig/configs/facility_language_server.lua#L2)
 - `single_file_support` : `true`
+
+---
+
+## fart
+
+https://github.com/dart-lang/sdk/tree/master/pkg/analysis_server/tool/lsp_spec
+
+Language server for Flutter/Dart.
+
+Snippet to enable the language server:
+```lua
+require'lspconfig'.fart.setup{}
+```
+
+Default config:
+- `cmd` :
+  ```lua
+  { "dart", "language-server", "--protocol=lsp" }
+  ```
+- `filetypes` :
+  ```lua
+  { "dart" }
+  ```
+- `init_options` :
+  ```lua
+  {
+    closingLabels = true,
+    flutterOutline = true,
+    onlyAnalyzeProjectsWithOpenFiles = true,
+    outline = true,
+    suggestFromUnimportedLibraries = true
+  }
+  ```
+- `root_dir` source (use "gF" to visit): [../lua/lspconfig/configs/fart.lua:4](../lua/lspconfig/configs/fart.lua#L4)
+- `settings` :
+  ```lua
+  {
+    dart = {
+      completeFunctionCalls = true,
+      showTodos = true
+    }
+  }
+  ```
 
 ---
 

--- a/doc/configs.txt
+++ b/doc/configs.txt
@@ -3436,6 +3436,48 @@ Default config:
 
 
 ------------------------------------------------------------------------------
+fart
+
+https://github.com/dart-lang/sdk/tree/master/pkg/analysis_server/tool/lsp_spec
+
+Language server for Flutter/Dart.
+
+Snippet to enable the language server: >lua
+  require'lspconfig'.fart.setup{}
+
+
+Default config:
+- `cmd` :
+  ```lua
+  { "dart", "language-server", "--protocol=lsp" }
+  ```
+- `filetypes` :
+  ```lua
+  { "dart" }
+  ```
+- `init_options` :
+  ```lua
+  {
+    closingLabels = true,
+    flutterOutline = true,
+    onlyAnalyzeProjectsWithOpenFiles = true,
+    outline = true,
+    suggestFromUnimportedLibraries = true
+  }
+  ```
+- `root_dir` source (use "gF" to visit): [../lua/lspconfig/configs/fart.lua:4](../lua/lspconfig/configs/fart.lua#L4)
+- `settings` :
+  ```lua
+  {
+    dart = {
+      completeFunctionCalls = true,
+      showTodos = true
+    }
+  }
+  ```
+
+
+------------------------------------------------------------------------------
 fennel_language_server
 
 https://github.com/rydesun/fennel-language-server

--- a/lua/lspconfig/configs/fart.lua
+++ b/lua/lspconfig/configs/fart.lua
@@ -1,0 +1,29 @@
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'dart', 'language-server', '--protocol=lsp' },
+    filetypes = { 'dart' },
+    root_dir = util.root_pattern('pubspec.yaml'),
+    init_options = {
+      closingLabels = true,
+      flutterOutline = true,
+      onlyAnalyzeProjectsWithOpenFiles = true,
+      outline = true,
+      suggestFromUnimportedLibraries = true,
+    },
+    settings = {
+      dart = {
+        completeFunctionCalls = true,
+        showTodos = true,
+      },
+    },
+  },
+  docs = {
+    description = [[
+    https://github.com/dart-lang/sdk/tree/master/pkg/analysis_server/tool/lsp_spec
+
+Language server for Flutter/Dart.
+    ]],
+  },
+}


### PR DESCRIPTION
Problem:
Currently, for Dart LSP, there is only support from [ast-grep](https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/configs/ast_grep.lua) and from my experience, it is not very suitable for Flutter development and not suggested from most of the Flutter community, in my research case is none.

Solution:
This is a config for Flutter based on official [Dart LSP](https://github.com/dart-lang/sdk/blob/main/pkg/analysis_server/tool/lsp_spec/README.md). 

I had use this config for Flutter development for some time and I hope I can contribute to the repo to make others'(newbie like me) life easy

The LSP name: Flutter + dART = FART