### PR TITLE
refactor: replace all instances of vim.loop with vim.uv

### DIFF
--- a/.github/ci/run_sanitizer.sh
+++ b/.github/ci/run_sanitizer.sh
@@ -22,12 +22,3 @@ if git diff --pickaxe-all -U0 -G "${SEARCH_PATTERN}" "${REF_BRANCH}" "${PR_BRANC
   echo 'Do not use deprecated util functions: '"${SEARCH_PATTERN}"
   exit 1
 fi
-
-SEARCH_PATTERN='(vim\.uv)'
-
-if git diff --pickaxe-all -U0 -G "${SEARCH_PATTERN}" "${REF_BRANCH}" "${PR_BRANCH}" -- '*.lua' | grep -Ev '\.lua$' | grep -E "^\+.*${SEARCH_PATTERN}" ; then
-  echo
-  echo 'Do not use modules that are too new: '"${SEARCH_PATTERN}"
-  echo 'Consult README to check the minimum supported neovim version.'
-  exit 1
-fi

--- a/doc/configs.md
+++ b/doc/configs.md
@@ -6279,7 +6279,7 @@ require'lspconfig'.lua_ls.setup {
   on_init = function(client)
     if client.workspace_folders then
       local path = client.workspace_folders[1].name
-      if path ~= vim.fn.stdpath('config') and (vim.loop.fs_stat(path..'/.luarc.json') or vim.loop.fs_stat(path..'/.luarc.jsonc')) then
+      if path ~= vim.fn.stdpath('config') and (vim.uv.fs_stat(path..'/.luarc.json') or vim.uv.fs_stat(path..'/.luarc.jsonc')) then
         return
       end
     end

--- a/doc/configs.txt
+++ b/doc/configs.txt
@@ -5757,7 +5757,7 @@ require'lspconfig'.lua_ls.setup {
   on_init = function(client)
     if client.workspace_folders then
       local path = client.workspace_folders[1].name
-      if path ~= vim.fn.stdpath('config') and (vim.loop.fs_stat(path..'/.luarc.json') or vim.loop.fs_stat(path..'/.luarc.jsonc')) then
+      if path ~= vim.fn.stdpath('config') and (vim.uv.fs_stat(path..'/.luarc.json') or vim.uv.fs_stat(path..'/.luarc.jsonc')) then
         return
       end
     end

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -98,7 +98,7 @@ function configs.__newindex(t, config_name, config_def)
         return
       end
 
-      local pwd = vim.loop.cwd()
+      local pwd = vim.uv.cwd()
 
       async.run(function()
         local root_dir

--- a/lua/lspconfig/configs/angularls.lua
+++ b/lua/lspconfig/configs/angularls.lua
@@ -17,7 +17,7 @@ local function get_angular_core_version(root_dir)
   end
 
   local package_json = project_root .. '/package.json'
-  if not vim.loop.fs_stat(package_json) then
+  if not vim.uv.fs_stat(package_json) then
     return ''
   end
 

--- a/lua/lspconfig/configs/eslint.lua
+++ b/lua/lspconfig/configs/eslint.lua
@@ -125,7 +125,7 @@ return {
       -- Support Yarn2 (PnP) projects
       local pnp_cjs = new_root_dir .. '/.pnp.cjs'
       local pnp_js = new_root_dir .. '/.pnp.js'
-      if vim.loop.fs_stat(pnp_cjs) or vim.loop.fs_stat(pnp_js) then
+      if vim.uv.fs_stat(pnp_cjs) or vim.uv.fs_stat(pnp_js) then
         config.cmd = vim.list_extend({ 'yarn', 'exec' }, config.cmd)
       end
     end,

--- a/lua/lspconfig/configs/fennel_ls.lua
+++ b/lua/lspconfig/configs/fennel_ls.lua
@@ -7,7 +7,7 @@ return {
     root_dir = function(dir)
       local has_fls_project_cfg = function(path)
         local fnlpath = vim.fs.joinpath(path, 'flsproject.fnl')
-        return (vim.loop.fs_stat(fnlpath) or {}).type == 'file'
+        return (vim.uv.fs_stat(fnlpath) or {}).type == 'file'
       end
       return util.search_ancestors(dir, has_fls_project_cfg) or vim.fs.root(0, '.git')
     end,

--- a/lua/lspconfig/configs/foam_ls.lua
+++ b/lua/lspconfig/configs/foam_ls.lua
@@ -6,7 +6,7 @@ return {
     filetypes = { 'foam', 'OpenFOAM' },
     root_dir = function(fname)
       return util.search_ancestors(fname, function(path)
-        if vim.loop.fs_stat(path .. '/system/controlDict') then
+        if vim.uv.fs_stat(path .. '/system/controlDict') then
           return path
         end
       end)

--- a/lua/lspconfig/configs/gitlab_ci_ls.lua
+++ b/lua/lspconfig/configs/gitlab_ci_ls.lua
@@ -1,6 +1,6 @@
 local util = require 'lspconfig.util'
 
-local cache_dir = vim.loop.os_homedir() .. '/.cache/gitlab-ci-ls/'
+local cache_dir = vim.uv.os_homedir() .. '/.cache/gitlab-ci-ls/'
 return {
   default_config = {
     cmd = { 'gitlab-ci-ls' },

--- a/lua/lspconfig/configs/intelephense.lua
+++ b/lua/lspconfig/configs/intelephense.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'intelephense', '--stdio' },
     filetypes = { 'php' },
     root_dir = function(pattern)
-      local cwd = vim.loop.cwd()
+      local cwd = vim.uv.cwd()
       local root = util.root_pattern('composer.json', '.git')(pattern)
 
       -- prefer cwd if root is a descendant

--- a/lua/lspconfig/configs/jdtls.lua
+++ b/lua/lspconfig/configs/jdtls.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 local handlers = require 'vim.lsp.handlers'
 
 local env = {
-  HOME = vim.loop.os_homedir(),
+  HOME = vim.uv.os_homedir(),
   XDG_CACHE_HOME = os.getenv 'XDG_CACHE_HOME',
   JDTLS_JVM_ARGS = os.getenv 'JDTLS_JVM_ARGS',
 }

--- a/lua/lspconfig/configs/julials.lua
+++ b/lua/lspconfig/configs/julials.lua
@@ -22,7 +22,7 @@ local function activate_env(path)
     path = vim.fs.normalize(vim.fn.fnamemodify(vim.fn.expand(path), ':p'))
     local found_env = false
     for _, project_file in ipairs(root_files) do
-      local file = vim.loop.fs_stat(vim.fs.joinpath(path, project_file))
+      local file = vim.uv.fs_stat(vim.fs.joinpath(path, project_file))
       if file and file.type then
         found_env = true
         break

--- a/lua/lspconfig/configs/lua_ls.lua
+++ b/lua/lspconfig/configs/lua_ls.lua
@@ -38,7 +38,7 @@ require'lspconfig'.lua_ls.setup {
   on_init = function(client)
     if client.workspace_folders then
       local path = client.workspace_folders[1].name
-      if path ~= vim.fn.stdpath('config') and (vim.loop.fs_stat(path..'/.luarc.json') or vim.loop.fs_stat(path..'/.luarc.jsonc')) then
+      if path ~= vim.fn.stdpath('config') and (vim.uv.fs_stat(path..'/.luarc.json') or vim.uv.fs_stat(path..'/.luarc.jsonc')) then
         return
       end
     end

--- a/lua/lspconfig/configs/phan.lua
+++ b/lua/lspconfig/configs/phan.lua
@@ -19,7 +19,7 @@ return {
     filetypes = { 'php' },
     single_file_support = true,
     root_dir = function(pattern)
-      local cwd = vim.loop.cwd()
+      local cwd = vim.uv.cwd()
       local root = util.root_pattern('composer.json', '.git')(pattern)
 
       -- prefer cwd if root is a descendant

--- a/lua/lspconfig/configs/phpactor.lua
+++ b/lua/lspconfig/configs/phpactor.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'phpactor', 'language-server' },
     filetypes = { 'php' },
     root_dir = function(pattern)
-      local cwd = vim.loop.cwd()
+      local cwd = vim.uv.cwd()
       local root = util.root_pattern('composer.json', '.git', '.phpactor.json', '.phpactor.yml')(pattern)
 
       -- prefer cwd if root is a descendant

--- a/lua/lspconfig/configs/r_language_server.lua
+++ b/lua/lspconfig/configs/r_language_server.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'R', '--no-echo', '-e', 'languageserver::run()' },
     filetypes = { 'r', 'rmd', 'quarto' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1]) or vim.loop.os_homedir()
+      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1]) or vim.uv.os_homedir()
     end,
     log_level = vim.lsp.protocol.MessageType.Warning,
   },

--- a/lua/lspconfig/configs/relay_lsp.lua
+++ b/lua/lspconfig/configs/relay_lsp.lua
@@ -36,7 +36,7 @@ return {
       if config.path_to_config then
         config.path_to_config = vim.fs.normalize(config.path_to_config)
         local path_to_config = table.concat({ root_dir, config.path_to_config }, '/')
-        if vim.loop.fs_stat(path_to_config) then
+        if vim.uv.fs_stat(path_to_config) then
           vim.list_extend(config.cmd, { config.path_to_config })
           vim.list_extend(compiler_cmd, { config.path_to_config })
         else

--- a/lua/lspconfig/configs/rnix.lua
+++ b/lua/lspconfig/configs/rnix.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'rnix-lsp' },
     filetypes = { 'nix' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1]) or vim.loop.os_homedir()
+      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1]) or vim.uv.os_homedir()
     end,
     settings = {},
     init_options = {},

--- a/lua/lspconfig/configs/smarty_ls.lua
+++ b/lua/lspconfig/configs/smarty_ls.lua
@@ -5,7 +5,7 @@ return {
     cmd = { 'smarty-language-server', '--stdio' },
     filetypes = { 'smarty' },
     root_dir = function(pattern)
-      local cwd = vim.loop.cwd()
+      local cwd = vim.uv.cwd()
       local root = util.root_pattern('composer.json', '.git')(pattern)
 
       -- prefer cwd if root is a descendant

--- a/lua/lspconfig/configs/turtle_ls.lua
+++ b/lua/lspconfig/configs/turtle_ls.lua
@@ -15,7 +15,7 @@ if bin_path == nil then
   end
   for _, p in ipairs(paths) do
     local candidate = table.concat({ p, bin_name }, '/')
-    if (vim.loop.fs_stat(candidate) or {}).type == 'file' then
+    if (vim.uv.fs_stat(candidate) or {}).type == 'file' then
       full_path = candidate
       break
     end

--- a/lua/lspconfig/configs/vdmj.lua
+++ b/lua/lspconfig/configs/vdmj.lua
@@ -2,7 +2,7 @@ local util = require 'lspconfig.util'
 
 local function get_default_mavenrepo()
   local repo = vim.env.HOME .. '/.m2/repository/dk/au/ece/vdmj'
-  if vim.loop.fs_stat(repo) then
+  if vim.uv.fs_stat(repo) then
     return repo
   else
     return vim.env.HOME .. '/.m2/repository/com/fujitsu'
@@ -22,7 +22,7 @@ local function get_latest_installed_version(repo)
   local sort = vim.fn.sort
 
   local subdirs = function(file)
-    local stat = vim.loop.fs_stat(table.concat({ path, file }, '/'))
+    local stat = vim.uv.fs_stat(table.concat({ path, file }, '/'))
     return stat.type == 'directory' and 1 or 0
   end
 

--- a/lua/lspconfig/health.lua
+++ b/lua/lspconfig/health.lua
@@ -190,12 +190,12 @@ local function make_client_info(client, fname)
   local client_info, info_lines = make_info(client)
 
   local workspace_folders = client.workspace_folders
-  fname = vim.fs.normalize(vim.loop.fs_realpath(fname) or fn.fnamemodify(fn.resolve(fname), ':p'))
+  fname = vim.fs.normalize(vim.uv.fs_realpath(fname) or fn.fnamemodify(fn.resolve(fname), ':p'))
 
   if workspace_folders then
     for _, schema in ipairs(workspace_folders) do
       local matched = true
-      local root_dir = vim.loop.fs_realpath(schema.name)
+      local root_dir = vim.uv.fs_realpath(schema.name)
       if root_dir == nil or fname:sub(1, root_dir:len()) ~= root_dir then
         matched = false
       end

--- a/lua/lspconfig/manager.lua
+++ b/lua/lspconfig/manager.lua
@@ -115,7 +115,7 @@ function M:_start_client(bufnr, new_config, root_dir, single_file, silent)
 
   -- Launch the server in the root directory used internally by lspconfig, if otherwise unset
   -- also check that the path exist
-  if not new_config.cmd_cwd and vim.loop.fs_realpath(root_dir) then
+  if not new_config.cmd_cwd and vim.uv.fs_realpath(root_dir) then
     new_config.cmd_cwd = root_dir
   end
 
@@ -202,7 +202,7 @@ function M:try_add(bufnr, project_root, silent)
 
   local get_root_dir = self.config.root_dir
 
-  local pwd = assert(vim.loop.cwd())
+  local pwd = assert(vim.uv.cwd())
 
   async.run(function()
     local root_dir

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -3,7 +3,7 @@ local api = vim.api
 local lsp = vim.lsp
 local nvim_eleven = vim.fn.has 'nvim-0.11' == 1
 
-local iswin = vim.loop.os_uname().version:match 'Windows'
+local iswin = vim.uv.os_uname().version:match 'Windows'
 
 local M = { path = {} }
 
@@ -103,7 +103,7 @@ function M.root_pattern(...)
     for _, pattern in ipairs(patterns) do
       local match = M.search_ancestors(startpath, function(path)
         for _, p in ipairs(vim.fn.glob(table.concat({ escape_wildcards(path), pattern }, '/'), true, true)) do
-          if vim.loop.fs_stat(p) then
+          if vim.uv.fs_stat(p) then
             return path
           end
         end
@@ -194,7 +194,7 @@ end
 
 -- Traverse the path calling cb along the way.
 local function traverse_parents(path, cb)
-  path = vim.loop.fs_realpath(path)
+  path = vim.uv.fs_realpath(path)
   local dir = path
   -- Just in case our algo is buggy, don't infinite loop.
   for _ = 1, 100 do
@@ -245,11 +245,11 @@ function M.path.is_dir(filename)
   return vim.fn.isdirectory(filename) == 1
 end
 
---- @deprecated use `(vim.loop.fs_stat(path) or {}).type == 'file'` instead
+--- @deprecated use `(vim.uv.fs_stat(path) or {}).type == 'file'` instead
 --- @param path string
 --- @return boolean
 function M.path.is_file(path)
-  return (vim.loop.fs_stat(path) or {}).type == 'file'
+  return (vim.uv.fs_stat(path) or {}).type == 'file'
 end
 
 --- @deprecated use `vim.fs.dirname` instead
@@ -258,11 +258,11 @@ M.path.dirname = vim.fs.dirname
 --- @deprecated use `vim.fs.normalize` instead
 M.path.sanitize = vim.fs.normalize
 
---- @deprecated use `vim.loop.fs_stat` instead
+--- @deprecated use `vim.uv.fs_stat` instead
 --- @param filename string
 --- @return string|false
 function M.path.exists(filename)
-  local stat = vim.loop.fs_stat(filename)
+  local stat = vim.uv.fs_stat(filename)
   return stat and stat.type or false
 end
 

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -97,7 +97,7 @@ api.nvim_create_user_command('LspRestart', function(info)
       detach_clients[client.name] = { client, lsp.get_buffers_by_client_id(client.id) }
     end
   end
-  local timer = assert(vim.loop.new_timer())
+  local timer = assert(vim.uv.new_timer())
   timer:start(
     500,
     100,

--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -57,7 +57,7 @@ local function make_section(indentlvl, sep, parts)
 end
 
 local function readfile(path)
-  assert((vim.loop.fs_stat(path) or {}).type == 'file')
+  assert((vim.uv.fs_stat(path) or {}).type == 'file')
   return io.open(path):read '*a'
 end
 
@@ -182,7 +182,7 @@ local function make_lsp_sections(is_markdown)
       })
 
       if docs then
-        local tempdir = os.getenv 'DOCGEN_TEMPDIR' or vim.loop.fs_mkdtemp '/tmp/nvim-lspconfig.XXXXXX'
+        local tempdir = os.getenv 'DOCGEN_TEMPDIR' or vim.uv.fs_mkdtemp '/tmp/nvim-lspconfig.XXXXXX'
         local preamble_parts = make_parts {
           function()
             if docs.description and #docs.description > 0 then
@@ -192,10 +192,10 @@ local function make_lsp_sections(is_markdown)
           function()
             local package_json_name = table.concat({ tempdir, config_name .. '.package.json' }, '/')
             if docs.package_json then
-              if not ((vim.loop.fs_stat(package_json_name) or {}).type == 'file') then
+              if not ((vim.uv.fs_stat(package_json_name) or {}).type == 'file') then
                 os.execute(string.format('curl -v -L -o %q %q', package_json_name, docs.package_json))
               end
-              if not ((vim.loop.fs_stat(package_json_name) or {}).type == 'file') then
+              if not ((vim.uv.fs_stat(package_json_name) or {}).type == 'file') then
                 print(string.format('Failed to download package.json for %q at %q', config_name, docs.package_json))
                 os.exit(1)
                 return


### PR DESCRIPTION
I noticed #3483 is about supporting 0.9, and the main branch now requires 0.10. This is a rote find-replace of `vim.loop`, so please judge it harshly.

See: https://github.com/neovim/neovim/blob/v0.10.0/runtime/doc/deprecated.txt#L55