### PR TITLE
feat(typos-lsp): support pyproject.toml and Cargo.toml

### DIFF
--- a/lsp/typos_lsp.lua
+++ b/lsp/typos_lsp.lua
@@ -8,6 +8,6 @@
 -- on GitHub: https://github.com/tekumara/typos-lsp/releases
 return {
   cmd = { 'typos-lsp' },
-  root_markers = { 'typos.toml', '_typos.toml', '.typos.toml' },
+  root_markers = { 'typos.toml', '_typos.toml', '.typos.toml', 'pyproject.toml', 'Cargo.toml' },
   settings = {},
 }

--- a/lua/lspconfig/configs/typos_lsp.lua
+++ b/lua/lspconfig/configs/typos_lsp.lua
@@ -3,7 +3,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'typos-lsp' },
-    root_dir = util.root_pattern('typos.toml', '_typos.toml', '.typos.toml'),
+    root_dir = util.root_pattern('typos.toml', '_typos.toml', '.typos.toml', 'pyproject.toml', 'Cargo.toml'),
     single_file_support = true,
     settings = {},
   },


### PR DESCRIPTION
typos via typos-lsp supports [pyproject.toml and Cargo.toml as config files](https://github.com/crate-ci/typos/blob/a557d1af98a669f0f26f04854a81485f53437a11/docs/reference.md#sources):

> Search parents of specified file / directory for one of typos.toml, _typos.toml, .typos.toml, Cargo.toml, or pyproject.toml

Resolves https://github.com/tekumara/typos-lsp/issues/180