### PR TITLE
fix(configs): remove utils in config with globs as markers

### DIFF
--- a/lsp/ada_ls.lua
+++ b/lsp/ada_ls.lua
@@ -18,13 +18,18 @@
 --- })
 --- ```
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'ada_language_server' },
   filetypes = { 'ada' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('Makefile', '.git', 'alire.toml', '*.gpr', '*.adc')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { 'Makefile', '.git', 'alire.toml', '*.gpr', '*.adc' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
 }

--- a/lsp/agda_ls.lua
+++ b/lsp/agda_ls.lua
@@ -4,13 +4,18 @@
 ---
 --- Language Server for Agda.
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'als' },
   filetypes = { 'agda' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('.git', '*.agda-lib')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '.git', '*.agda-lib' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
 }

--- a/lsp/arduino_language_server.lua
+++ b/lsp/arduino_language_server.lua
@@ -68,13 +68,12 @@
 --- Note that an upstream bug makes keywords in some cases become undefined by the language server.
 --- Ref: https://github.com/arduino/arduino-ide/issues/159
 
-local util = require 'lspconfig.util'
-
 return {
   filetypes = { 'arduino' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('*.ino')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      return vim.glob.to_lpeg('*.ino'):match(name) ~= nil
+    end))
   end,
   cmd = {
     'arduino-language-server',

--- a/lsp/autotools_ls.lua
+++ b/lsp/autotools_ls.lua
@@ -9,15 +9,19 @@
 ---
 --- Language server for autoconf, automake and make using tree sitter in python.
 
-local util = require 'lspconfig.util'
-
 local root_files = { 'configure.ac', 'Makefile', 'Makefile.am', '*.mk' }
 
 return {
   cmd = { 'autotools-language-server' },
   filetypes = { 'config', 'automake', 'make' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern(unpack(root_files))(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      for _, pattern in ipairs(root_files) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
 }

--- a/lsp/csharp_ls.lua
+++ b/lsp/csharp_ls.lua
@@ -8,13 +8,18 @@
 ---
 --- The preferred way to install csharp-ls is with `dotnet tool install --global csharp-ls`.
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'csharp-ls' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern '*.sln'(fname) or util.root_pattern '*.csproj'(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '*.sln', '*.csproj' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
   filetypes = { 'cs' },
   init_options = {

--- a/lsp/fsautocomplete.lua
+++ b/lsp/fsautocomplete.lua
@@ -17,13 +17,18 @@
 --- This is automatically done by plugins such as [PhilT/vim-fsharp](https://github.com/PhilT/vim-fsharp), [fsharp/vim-fsharp](https://github.com/fsharp/vim-fsharp), and [adelarsq/neofsharp.vim](https://github.com/adelarsq/neofsharp.vim).
 ---
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'fsautocomplete', '--adaptive-lsp-server-enabled' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('*.sln', '*.fsproj', '.git')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '*.sln', '*.fsproj', '.git' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
   filetypes = { 'fsharp' },
   init_options = {

--- a/lsp/fsharp_language_server.lua
+++ b/lsp/fsharp_language_server.lua
@@ -13,13 +13,18 @@
 ---
 --- `autocmd BufNewFile,BufRead *.fs,*.fsx,*.fsi set filetype=fsharp`
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'dotnet', 'FSharpLanguageServer.dll' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('*.sln', '*.fsproj', '.git')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '*.sln', '*.fsproj', '.git' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
   filetypes = { 'fsharp' },
   init_options = {

--- a/lsp/gitlab_ci_ls.lua
+++ b/lsp/gitlab_ci_ls.lua
@@ -7,16 +7,21 @@
 --- `gitlab-ci-ls` can be installed via cargo:
 --- cargo install gitlab-ci-ls
 
-local util = require 'lspconfig.util'
-
 local cache_dir = vim.uv.os_homedir() .. '/.cache/gitlab-ci-ls/'
 
 return {
   cmd = { 'gitlab-ci-ls' },
   filetypes = { 'yaml.gitlab' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('.gitlab*', '.git')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '.gitlab*', '.git' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
   init_options = {
     cache_path = cache_dir,

--- a/lsp/graphql.lua
+++ b/lsp/graphql.lua
@@ -10,13 +10,18 @@
 ---
 --- Note that you must also have [the graphql package](https://github.com/graphql/graphql-js) installed within your project and create a [GraphQL config file](https://the-guild.dev/graphql/config/docs).
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'graphql-lsp', 'server', '-m', 'stream' },
   filetypes = { 'graphql', 'typescriptreact', 'javascriptreact' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('.graphqlrc*', '.graphql.config.*', 'graphql.config.*')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '.graphqlrc*', '.graphql.config.*', 'graphql.config.*' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
 }

--- a/lsp/hls.lua
+++ b/lsp/hls.lua
@@ -12,14 +12,19 @@
 --- })
 --- ```
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'haskell-language-server-wrapper', '--lsp' },
   filetypes = { 'haskell', 'lhaskell' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('hie.yaml', 'stack.yaml', 'cabal.project', '*.cabal', 'package.yaml')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { 'hie.yaml', 'stack.yaml', 'cabal.project', '*.cabal', 'package.yaml' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
   settings = {
     haskell = {

--- a/lsp/idris2_lsp.lua
+++ b/lsp/idris2_lsp.lua
@@ -29,13 +29,12 @@
 --- latest commit on the `master` branch, and set a reminder to check the Idris2-Lsp
 --- repo for the release of a compatible versioned branch.
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'idris2-lsp' },
   filetypes = { 'idris2' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern '*.ipkg'(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      return vim.glob.to_lpeg('*.ipkg'):match(name) ~= nil
+    end))
   end,
 }

--- a/lsp/msbuild_project_tools_server.lua
+++ b/lsp/msbuild_project_tools_server.lua
@@ -33,13 +33,19 @@
 --- ```
 
 local host_dll_name = 'MSBuildProjectTools.LanguageServer.Host.dll'
-local util = require 'lspconfig.util'
 
 return {
   filetypes = { 'msbuild' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('*.sln', '*.slnx', '*.*proj', '.git')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '*.sln', '*.slnx', '*.*proj', '.git' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
   init_options = {},
   cmd = { 'dotnet', host_dll_name },

--- a/lsp/nim_langserver.lua
+++ b/lsp/nim_langserver.lua
@@ -8,15 +8,18 @@
 --- nimble install nimlangserver
 --- ```
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'nimlangserver' },
   filetypes = { 'nim' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(
-      util.root_pattern '*.nimble'(fname) or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
-    )
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '*.nimble', '.git' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
 }

--- a/lsp/nimls.lua
+++ b/lsp/nimls.lua
@@ -8,15 +8,18 @@
 --- nimble install nimlsp
 --- ```
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'nimlsp' },
   filetypes = { 'nim' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(
-      util.root_pattern '*.nimble'(fname) or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
-    )
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '*.nimble', '.git' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
 }

--- a/lsp/nomad_lsp.lua
+++ b/lsp/nomad_lsp.lua
@@ -16,7 +16,6 @@
 ---
 --- Description of your jobs should be written in `.nomad` files for the LSP client to configure the server's `root_dir` configuration option.
 
-local util = require 'lspconfig.util'
 local bin_name = 'nomad-lsp'
 
 if vim.fn.has 'win32' == 1 then
@@ -27,7 +26,8 @@ return {
   cmd = { bin_name },
   filetypes = { 'hcl.nomad', 'nomad' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern '*.nomad'(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      return vim.glob.to_lpeg('*.nomad'):match(name) ~= nil
+    end))
   end,
 }

--- a/lsp/ocamlls.lua
+++ b/lsp/ocamlls.lua
@@ -7,13 +7,18 @@
 --- npm install -g ocaml-language-server
 --- ```
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'ocaml-language-server', '--stdio' },
   filetypes = { 'ocaml', 'reason' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('*.opam', 'esy.json', 'package.json')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '*.opam', 'esy.json', 'package.json' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
 }

--- a/lsp/ocamllsp.lua
+++ b/lsp/ocamllsp.lua
@@ -9,8 +9,6 @@
 --- opam install ocaml-lsp-server
 --- ```
 
-local util = require 'lspconfig.util'
-
 local language_id_of = {
   menhir = 'ocaml.menhir',
   ocaml = 'ocaml',
@@ -28,8 +26,15 @@ return {
   cmd = { 'ocamllsp' },
   filetypes = { 'ocaml', 'menhir', 'ocamlinterface', 'ocamllex', 'reason', 'dune' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('*.opam', 'esy.json', 'package.json', '.git', 'dune-project', 'dune-workspace')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '*.opam', 'esy.json', 'package.json', '.git', 'dune-project', 'dune-workspace' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
   get_language_id = get_language_id,
 }

--- a/lsp/ols.lua
+++ b/lsp/ols.lua
@@ -4,13 +4,18 @@
 ---
 --- `Odin Language Server`.
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'ols' },
   filetypes = { 'odin' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('ols.json', '.git', '*.odin')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { 'ols.json', '.git', '*.odin' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
 }

--- a/lsp/pasls.lua
+++ b/lsp/pasls.lua
@@ -15,13 +15,18 @@
 --- export FPCTARGETCPU='x86_64'          # Target CPU for cross compiling.
 --- ```
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'pasls' },
   filetypes = { 'pascal' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('*.lpi', '*.lpk', '.git')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '*.lpi', '*.lpk', '.git' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
 }

--- a/lsp/pico8_ls.lua
+++ b/lsp/pico8_ls.lua
@@ -4,14 +4,13 @@
 ---
 --- Full language support for the PICO-8 dialect of Lua.
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'pico8-ls', '--stdio' },
   filetypes = { 'p8' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('*.p8')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      return vim.glob.to_lpeg('*.p8'):match(name) ~= nil
+    end))
   end,
   settings = {},
 }

--- a/lsp/regal.lua
+++ b/lsp/regal.lua
@@ -9,13 +9,18 @@
 --- go install github.com/StyraInc/regal@latest
 --- ```
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'regal', 'language-server' },
   filetypes = { 'rego' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern '*.rego'(fname) or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1]))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '*.rego', '.git' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
 }

--- a/lsp/regols.lua
+++ b/lsp/regols.lua
@@ -9,13 +9,18 @@
 --- go install github.com/kitagry/regols@latest
 --- ```
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'regols' },
   filetypes = { 'rego' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern '*.rego'(fname) or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1]))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { '*.rego', '.git' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
 }

--- a/lsp/solc.lua
+++ b/lsp/solc.lua
@@ -4,13 +4,18 @@
 ---
 --- solc is the native language server for the Solidity language.
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'solc', '--lsp' },
   filetypes = { 'solidity' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('hardhat.config.*', '.git')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      local patterns = { 'hardhat.config.*', '.git' }
+      for _, pattern in ipairs(patterns) do
+        if vim.glob.to_lpeg(pattern):match(name) ~= nil then
+          return true
+        end
+      end
+      return false
+    end))
   end,
 }

--- a/lsp/stylelint_lsp.lua
+++ b/lsp/stylelint_lsp.lua
@@ -20,9 +20,7 @@
 --- })
 --- ```
 
-local util = require 'lspconfig.util'
-
-local root_file = {
+local root_markers = {
   '.stylelintrc',
   '.stylelintrc.mjs',
   '.stylelintrc.cjs',
@@ -34,8 +32,6 @@ local root_file = {
   'stylelint.config.cjs',
   'stylelint.config.js',
 }
-
-root_file = util.insert_package_json(root_file, 'stylelint')
 
 return {
   cmd = { 'stylelint-lsp', '--stdio' },
@@ -49,6 +45,21 @@ return {
     'vue',
     'wxss',
   },
-  root_markers = root_file,
+  root_dir = function(bufnr, on_dir)
+    local iswin = vim.uv.os_uname().version:match 'Windows'
+    local package_json_dir = vim.fs.root(bufnr, 'package.json')
+
+    -- Append `package.json` only if contains 'stylelint'
+    if package_json_dir then
+      local path_sep = iswin and '\\' or '/'
+      for line in io.lines(package_json_dir .. path_sep .. 'package.json') do
+        if line:find('stylelint') then
+          root_markers[#root_markers + 1] = 'package.json'
+        end
+      end
+    end
+
+    on_dir(vim.fs.root(bufnr, root_markers))
+  end,
   settings = {},
 }

--- a/lsp/unison.lua
+++ b/lsp/unison.lua
@@ -2,14 +2,13 @@
 ---
 --- https://github.com/unisonweb/unison/blob/trunk/docs/language-server.markdown
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'nc', 'localhost', os.getenv 'UNISON_LSP_PORT' or '5757' },
   filetypes = { 'unison' },
   root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('*.u')(fname))
+    on_dir(vim.fs.root(bufnr, function(name, _)
+      return vim.glob.to_lpeg('*.u'):match(name) ~= nil
+    end))
   end,
   settings = {},
 }


### PR DESCRIPTION
Based on #2079.

The majority of configs which rely on `lspconfig.util` use `util.root_pattern` to match against wildcards. I've opened an issue here https://github.com/neovim/neovim/issues/33444 to discuss about this.

In the meantime I'll remove `lspconfig.util` where it's trivial to do so.