### PR TITLE
feat(gh_actions_ls): add `vim.lsp.config` support

### DIFF
--- a/lsp/gh_actions_ls.lua
+++ b/lsp/gh_actions_ls.lua
@@ -1,0 +1,31 @@
+---@brief
+-- https://github.com/lttb/gh-actions-language-server
+--
+-- Language server for GitHub Actions.
+--
+-- The projects [forgejo](https://forgejo.org/) and [gitea](https://about.gitea.com/)
+-- design their actions to be as compatible to github as possible
+-- with only [a few differences](https://docs.gitea.com/usage/actions/comparison#unsupported-workflows-syntax) between the systems.
+-- The `gh_actions_ls` is therefore enabled for those `yaml` files as well.
+--
+-- The `gh-actions-language-server` can be installed via `npm`:
+--
+-- ```sh
+-- npm install -g gh-actions-language-server
+-- ```
+return {
+  cmd = { 'gh-actions-language-server', '--stdio' },
+  filetypes = { 'yaml' }, -- the `root_markers` prevent attaching to every yaml file
+  root_markers = {
+    '.github/workflows',
+    '.forgejo/workflows',
+    '.gitea/workflows',
+  },
+  capabilities = {
+    workspace = {
+      didChangeWorkspaceFolders = {
+        dynamicRegistration = true,
+      },
+    },
+  },
+}


### PR DESCRIPTION
`gh_actions_ls` is missing in the `lsp` folder, likely due to it using a workaround with single file support to prevent it from attaching to every yaml file, even though it should only attach to certain yaml files, without defining an extra `yaml.github` filetype (see #3558).

Using `.github/workflows` and co as `root_markers` however prevents this issue, allowing us to use the LSP like a regular LSP without it attaching to unrelated yaml files. Thus, there is no anymore problem using `git_actions_ls` with `vim.lsp.config`.

cc @disrupted 