### PR TITLE
fix(clangd): improve indentation of snippets

### DIFF
--- a/lsp/clangd.lua
+++ b/lsp/clangd.lua
@@ -88,4 +88,29 @@ return {
       symbol_info()
     end, { desc = 'Show symbol info' })
   end,
+  on_init = function(client)
+    local request = client.rpc.request
+    function client.rpc.request(method, params, handler, ...)
+      if method ~= 'textDocument/completion' then
+        return request(method, params, handler, ...)
+      end
+      local new_handler = function(...)
+        local err, result = ...
+        if err or not result then
+          return handler(...)
+        end
+        local items = result.items or result
+        for _, item in ipairs(items) do
+          local kind = vim.lsp.protocol.CompletionItemKind
+          if item.kind == kind.Snippet then
+            local text = item.textEdit.newText
+            text = text:gsub('{\n', '{\n\t')
+            item.textEdit.newText = text
+          end
+        end
+        return handler(...)
+      end
+      return request(method, params, new_handler, ...)
+    end
+  end,
 }


### PR DESCRIPTION
`clangd` does not add indentation to to many snippets. That issue has been raised upstream at [clangd](https://github.com/clangd/clangd/issues/828). The issue was closed, stating that this is working as intended. This issue has also been raised at [LuaSnip](https://github.com/L3MON4D3/LuaSnip/issues/477), where @L3MON4D3 suggested intercepting and fixing the snippets provided by the language server.

I have been using this interception code for about two years now and it has worked well for me so far. Now that `vim.lsp.config` is out, I thought it would be worthwhile to bring it up here. 

### Before
```c
if (statement) {
expression
} else {
expression
}
```

### After
```c
if (statement) {
    expression
} else {
    expression
}
```

### Related
- https://github.com/L3MON4D3/LuaSnip/issues/477
- https://github.com/clangd/clangd/issues/828
- https://github.com/L3MON4D3/LuaSnip/wiki/Misc#improve-language-server-snippets