### PR TITLE
feat(biome): add `vim.lsp.config` support

### DIFF
--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -1,0 +1,27 @@
+---@brief
+-- https://biomejs.dev
+--
+-- Toolchain of the web. [Successor of Rome](https://biomejs.dev/blog/annoucing-biome).
+--
+-- ```sh
+-- npm install [-g] @biomejs/biome
+-- ```
+
+return {
+  cmd = { 'biome', 'lsp-proxy' },
+  filetypes = {
+    'astro',
+    'css',
+    'graphql',
+    'javascript',
+    'javascriptreact',
+    'json',
+    'jsonc',
+    'svelte',
+    'typescript',
+    'typescript.tsx',
+    'typescriptreact',
+    'vue',
+  },
+  root_markers = { 'biome.json', 'biome.jsonc' },
+}


### PR DESCRIPTION
Another one to check off the list at #3705.

`single_file_support = false` was introduced in PR #2984. 

As far as I can tell, it is not relevant anymore: when using `vim.lsp.config`'s `root_markers`, the LSP is simply not attached when the root marker is not found, so the problem that #2984 was solving does not occur.