### PR TITLE
fix(gh_actions_ls): add `workspace_required`

### DIFF
--- a/lsp/gh_actions_ls.lua
+++ b/lsp/gh_actions_ls.lua
@@ -15,12 +15,14 @@
 -- ```
 return {
   cmd = { 'gh-actions-language-server', '--stdio' },
-  filetypes = { 'yaml' }, -- the `root_markers` prevent attaching to every yaml file
+  -- the `root_markers` with `workspace_required` prevent attaching to every yaml file
+  filetypes = { 'yaml' },
   root_markers = {
     '.github/workflows',
     '.forgejo/workflows',
     '.gitea/workflows',
   },
+  workspace_required = true,
   capabilities = {
     workspace = {
       didChangeWorkspaceFolders = {


### PR DESCRIPTION
follow up to #3713, fixes https://github.com/neovim/nvim-lspconfig/pull/3713#issuecomment-2801407962

(Note that `workspace_required` requires nightly or the upcoming nvim 0.11.1)