### PR TITLE
feat(biome): `vim.lsp.config` support, with `workspace_required` and proper `root_dir`

### DIFF
--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -1,0 +1,36 @@
+---@brief
+-- https://biomejs.dev
+--
+-- Toolchain of the web. [Successor of Rome](https://biomejs.dev/blog/annoucing-biome).
+--
+-- ```sh
+-- npm install [-g] @biomejs/biome
+-- ```
+
+local util = require 'lspconfig.util'
+
+return {
+  cmd = { 'biome', 'lsp-proxy' },
+  filetypes = {
+    'astro',
+    'css',
+    'graphql',
+    'javascript',
+    'javascriptreact',
+    'json',
+    'jsonc',
+    'svelte',
+    'typescript',
+    'typescript.tsx',
+    'typescriptreact',
+    'vue',
+  },
+  workspace_required = true,
+  root_dir = function(bufnr, on_dir)
+    local fname = vim.api.nvim_buf_get_name(bufnr)
+    local root_files = { 'biome.json', 'biome.jsonc' }
+    root_files = util.insert_package_json(root_files, 'biome', fname)
+    local root_dir = vim.fs.dirname(vim.fs.find(root_files, { path = fname, upward = true })[1])
+    on_dir(root_dir)
+  end,
+}


### PR DESCRIPTION
Follow up to #3718. Re-adds `lsp/biome.lua` correctly with `workspace_required = true` (though this will only start to work from 0.11.1 on, or on nightly.)

Now also with the `root_dir` func checking for biome being in the package.json (cc @maximtrp).



