### PR TITLE
Revert "fix: improve path escaping in wildcard function"

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -93,14 +93,7 @@ function M.search_ancestors(startpath, func)
 end
 
 local function escape_wildcards(path)
-  -- Escape all potentially problematic special characters
-  -- Covers:
-  -- - Wildcards and pattern matching: [ ] ? * $ ( ) ^ % . + - ~
-  -- - Escape character: \
-  -- - Shell special characters: ` ' " ; | & < >
-  -- - Whitespace: %s (spaces, tabs, etc.)
-  -- The gsub function replaces any matches with the same character preceded by a backslash
-  return path:gsub('([' .. vim.pesc('[]?*$()^%.+-~') .. '\\`\'";|&<>%s])', '\\%1')
+  return path:gsub('([%[%]%?%*])', '\\%1')
 end
 
 function M.root_pattern(...)


### PR DESCRIPTION
Reverts neovim/nvim-lspconfig#3690

see https://github.com/neovim/nvim-lspconfig/pull/3690#issuecomment-2805154318