### PR TITLE
feat(zls): add `vim.lsp.config` support

### DIFF
--- a/lsp/zls.lua
+++ b/lsp/zls.lua
@@ -1,0 +1,11 @@
+---@brief
+-- https://github.com/zigtools/zls
+--
+-- Zig LSP implementation + Zig Language Server
+
+return {
+  cmd = { 'zls' },
+  filetypes = { 'zig', 'zir' },
+  root_markers = { 'zls.json', 'build.zig', '.git' },
+  workspace_required = false,
+}


### PR DESCRIPTION
Disclaimer: i'm a zig newb and i'm not up to speed on the planned direction for `nvim` and `vim.lsp.config`. Would appreciate some review to make sure i'm not overlooking  anything. This does seem to work fine in my limited testing though i.e. making sure the lsp starts up in some random projects and the functionality works, and that `checkhealth vim.lsp` looks fine.

Includes the following changes from the legacy config:
- Use `root_markers` instead of `root_dir` 
  - This removes the dependency on `util`
- Remove `on_new_config`
  - I wasn't sure what/if to replace this. I took a look at what was done for `omnisharp`, which was listed in #3705 and has been ported/merged and it doesn't appear to have an equivalent there so I am assuming it's fine to leave this out
- Replace `single_file_support = true` with `workspace_required = false`