### PR TITLE
Feature: migrate builtin commands

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -67,6 +67,45 @@ end
 -- script in scriptnames to be executed is lspconfig.
 api.nvim_create_user_command('LspInfo', ':checkhealth vim.lsp', { desc = 'Alias to `:checkhealth vim.lsp`' })
 
+if vim.version.ge(vim.version(), { 0, 11, 2 }) then
+  local complete_client = function(arg)
+    return vim
+      .iter(vim.lsp.get_clients())
+      :map(function(client)
+        return client.name
+      end)
+      :filter(function(name)
+        return name:sub(1, #arg) == arg
+      end)
+      :totable()
+  end
+
+  api.nvim_create_user_command('LspRestart', function(info)
+    for _, name in ipairs(info.fargs) do
+      if vim.lsp.config[name] == nil then
+        vim.notify(("Invalid server name '%s'"):format(info.args))
+      else
+        vim.lsp.enable(name, false)
+      end
+    end
+
+    local timer = assert(vim.uv.new_timer())
+    timer:start(500, 0, function()
+      for _, name in ipairs(info.fargs) do
+        vim.schedule_wrap(function(x)
+          vim.lsp.enable(x)
+        end)(name)
+      end
+    end)
+  end, {
+    desc = 'Restart the given client(s)',
+    nargs = '+',
+    complete = complete_client,
+  })
+
+  return
+end
+
 api.nvim_create_user_command('LspStart', function(info)
   local server_name = string.len(info.args) > 0 and info.args or nil
   if server_name then

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -80,6 +80,29 @@ if vim.version.ge(vim.version(), { 0, 11, 2 }) then
       :totable()
   end
 
+  local complete_config = function(arg)
+    return vim
+      .iter(vim.api.nvim_get_runtime_file(('lsp/%s*.lua'):format(arg), true))
+      :map(function(path)
+        local file_name = path:match('[^/]*.lua$')
+        return file_name:sub(0, #file_name - 4)
+      end)
+      :totable()
+  end
+
+  api.nvim_create_user_command('LspStart', function(info)
+    if vim.lsp.config[info.args] == nil then
+      vim.notify(("Invalid server name '%s'"):format(info.args))
+      return
+    end
+
+    vim.lsp.enable(info.args)
+  end, {
+    desc = 'Enable and launch a language server',
+    nargs = '?',
+    complete = complete_config,
+  })
+
   api.nvim_create_user_command('LspRestart', function(info)
     for _, name in ipairs(info.fargs) do
       if vim.lsp.config[name] == nil then

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -103,6 +103,20 @@ if vim.version.ge(vim.version(), { 0, 11, 2 }) then
     complete = complete_client,
   })
 
+  api.nvim_create_user_command('LspStop', function(info)
+    for _, name in ipairs(info.fargs) do
+      if vim.lsp.config[name] == nil then
+        vim.notify(("Invalid server name '%s'"):format(info.args))
+      else
+        vim.lsp.enable(name, false)
+      end
+    end
+  end, {
+    desc = 'Disable and stop the given client(s)',
+    nargs = '+',
+    complete = complete_client,
+  })
+
   return
 end
 


### PR DESCRIPTION
fix #3714
fix #2216

Things to note:

- `LspStart` starts the selected LSP and attaches to every buffer which has the right filetype. Should I only attach it to the current buffer?

- `LspStop` stops the selected LSP.

- `LspRestart` restart the selected LSPs, but I don't get how and why it used a timer.

- Should we add `LspEnable`? Maybe in a future PR.

EDIT:

Should I add checks for neovim 0.11?

Something like:
```lua
  if not has_eleven then
    error('nvim-lspconfig 2.x only supports vim.lsp.config. If you dont want to migrate, pin to nvim-lspconfig 1.x')
  end
```