### PR TITLE
fix(astro): using vim.fs.jointhpath concat path

### DIFF
--- a/lsp/astro.lua
+++ b/lsp/astro.lua
@@ -1,6 +1,6 @@
 local function get_typescript_server_path(root_dir)
   local project_root = vim.fs.dirname(vim.fs.find('node_modules', { path = root_dir, upward = true })[1])
-  return project_root and (project_root .. '/node_modules/typescript/lib') or ''
+  return project_root and vim.fs.joinpath(project_root, 'node_modules', 'typescript', 'lib') or ''
 end
 
 ---@brief


### PR DESCRIPTION
Problem: hardcord path symbol in get_typescript_server_path

Solution: using vim.fs.joinpath to concat path