### PR TITLE
fix(readme): update vim.lsp.config anchor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ View [all configs](doc/configs.md) or `:help lspconfig-all` from Nvim.
 5. Run `:checkhealth lsp` to see the status or to troubleshoot.
 
 Read `:help lspconfig` for details. Read `:help lspconfig-all` for the full list of server-specific details.
-For servers not on your `$PATH` (e.g., `jdtls`, `elixirls`), you must manually set the `cmd` parameter, see [vim.lsp.config](#vim.lsp.config).
+For servers not on your `$PATH` (e.g., `jdtls`, `elixirls`), you must manually set the `cmd` parameter, see [vim.lsp.config](#vimlspconfig).
 
 ## Configuration
 
@@ -83,7 +83,7 @@ See [`:h lsp-buf`][lsp-buf] for details on other LSP functions.
 
 Extra settings can be specified for each LSP server:
 
-- Nvim 0.11+ (see [vim.lsp.config](#vim.lsp.config))
+- Nvim 0.11+ (see [vim.lsp.config](#vimlspconfig))
   ```lua
   vim.lsp.config('rust_analyzer', {
     -- Server-specific settings. See `:help lsp-quickstart`


### PR DESCRIPTION
Problem:
Some anchor links were defined as #vim.lsp.config which doesn't work

Solution:
Fix anchor link to #vimlspconfig