### PR TITLE
feat(atlas): update doc support for `atlas-rule` filetype

### DIFF
--- a/lsp/atlas.lua
+++ b/lsp/atlas.lua
@@ -2,19 +2,22 @@
 ---
 --- https://github.com/ariga/atlas
 ---
---- Language server for Atlas config and scheme files.
+--- Language server for Atlas config and schema files.
 ---
 --- You may also need to configure the filetype for *.hcl files:
 ---
---- `autocmd BufNewFile,BufRead atlas.hcl set filetype=atlas-config`
---- `autocmd BufNewFile,BufRead *.my.hcl set filetype=atlas-schema-mysql`
---- `autocmd BufNewFile,BufRead *.pg.hcl set filetype=atlas-schema-postgresql`
---- `autocmd BufNewFile,BufRead *.lt.hcl set filetype=atlas-schema-sqlite`
---- `autocmd BufNewFile,BufRead *.ch.hcl set filetype=atlas-schema-clickhouse`
---- `autocmd BufNewFile,BufRead *.ms.hcl set filetype=atlas-schema-mssql`
---- `autocmd BufNewFile,BufRead *.rs.hcl set filetype=atlas-schema-redshift`
---- `autocmd BufNewFile,BufRead *.test.hcl set filetype=atlas-test`
---- `autocmd BufNewFile,BufRead *.plan.hcl set filetype=atlas-plan`
+--- ```vim
+--- autocmd BufNewFile,BufRead atlas.hcl set filetype=atlas-config
+--- autocmd BufNewFile,BufRead *.my.hcl set filetype=atlas-schema-mysql
+--- autocmd BufNewFile,BufRead *.pg.hcl set filetype=atlas-schema-postgresql
+--- autocmd BufNewFile,BufRead *.lt.hcl set filetype=atlas-schema-sqlite
+--- autocmd BufNewFile,BufRead *.ch.hcl set filetype=atlas-schema-clickhouse
+--- autocmd BufNewFile,BufRead *.ms.hcl set filetype=atlas-schema-mssql
+--- autocmd BufNewFile,BufRead *.rs.hcl set filetype=atlas-schema-redshift
+--- autocmd BufNewFile,BufRead *.test.hcl set filetype=atlas-test
+--- autocmd BufNewFile,BufRead *.plan.hcl set filetype=atlas-plan
+--- autocmd BufNewFile,BufRead *.rule.hcl set filetype=atlas-rule
+--- ```
 ---
 --- or
 ---
@@ -32,6 +35,7 @@
 ---     ['.*/*.rs.hcl'] = 'atlas-schema-redshift',
 ---     ['.*/*.test.hcl'] = 'atlas-test',
 ---     ['.*/*.plan.hcl'] = 'atlas-plan',
+---     ['.*/*.rule.hcl'] = 'atlas-rule',
 ---   },
 --- })
 --- ```
@@ -48,6 +52,7 @@
 --- vim.treesitter.language.register('hcl', 'atlas-schema-redshift')
 --- vim.treesitter.language.register('hcl', 'atlas-test')
 --- vim.treesitter.language.register('hcl', 'atlas-plan')
+--- vim.treesitter.language.register('hcl', 'atlas-rule')
 --- ```
 ---
 return {


### PR DESCRIPTION
Following #3539, this PR adds a new `atlas-rule` file type.

Note: only the documentation needs to be updated