### PR TITLE
feat(tailwind): add `vim.lsp.config` support

### DIFF
--- a/lsp/tailwindcss.lua
+++ b/lsp/tailwindcss.lua
@@ -1,0 +1,123 @@
+---@brief
+--- https://github.com/tailwindlabs/tailwindcss-intellisense
+---
+--- Tailwind CSS Language Server can be installed via npm:
+---
+--- npm install -g @tailwindcss/language-server
+
+local util = require 'lspconfig.util'
+
+return {
+  cmd = { 'tailwindcss-language-server', '--stdio' },
+  -- filetypes copied and adjusted from tailwindcss-intellisense
+  filetypes = {
+    -- html
+    'aspnetcorerazor',
+    'astro',
+    'astro-markdown',
+    'blade',
+    'clojure',
+    'django-html',
+    'htmldjango',
+    'edge',
+    'eelixir', -- vim ft
+    'elixir',
+    'ejs',
+    'erb',
+    'eruby', -- vim ft
+    'gohtml',
+    'gohtmltmpl',
+    'haml',
+    'handlebars',
+    'hbs',
+    'html',
+    'htmlangular',
+    'html-eex',
+    'heex',
+    'jade',
+    'leaf',
+    'liquid',
+    'markdown',
+    'mdx',
+    'mustache',
+    'njk',
+    'nunjucks',
+    'php',
+    'razor',
+    'slim',
+    'twig',
+    -- css
+    'css',
+    'less',
+    'postcss',
+    'sass',
+    'scss',
+    'stylus',
+    'sugarss',
+    -- js
+    'javascript',
+    'javascriptreact',
+    'reason',
+    'rescript',
+    'typescript',
+    'typescriptreact',
+    -- mixed
+    'vue',
+    'svelte',
+    'templ',
+  },
+  settings = {
+    tailwindCSS = {
+      validate = true,
+      lint = {
+        cssConflict = 'warning',
+        invalidApply = 'error',
+        invalidScreen = 'error',
+        invalidVariant = 'error',
+        invalidConfigPath = 'error',
+        invalidTailwindDirective = 'error',
+        recommendedVariantOrder = 'warning',
+      },
+      classAttributes = {
+        'class',
+        'className',
+        'class:list',
+        'classList',
+        'ngClass',
+      },
+      includeLanguages = {
+        eelixir = 'html-eex',
+        eruby = 'erb',
+        templ = 'html',
+        htmlangular = 'html',
+      },
+    },
+  },
+  before_init = function(_, config)
+    if not config.settings then
+      config.settings = {}
+    end
+    if not config.settings.editor then
+      config.settings.editor = {}
+    end
+    if not config.settings.editor.tabSize then
+      config.settings.editor.tabSize = vim.lsp.util.get_effective_tabstop()
+    end
+  end,
+  root_dir = function(bufnr, on_dir)
+    local root_files = {
+      'tailwind.config.js',
+      'tailwind.config.cjs',
+      'tailwind.config.mjs',
+      'tailwind.config.ts',
+      'postcss.config.js',
+      'postcss.config.cjs',
+      'postcss.config.mjs',
+      'postcss.config.ts',
+    }
+    local fname = vim.api.nvim_buf_get_name(bufnr)
+    root_files = util.insert_package_json(root_files, 'tailwindcss', fname)
+    local root_dir = vim.fs.dirname(vim.fs.find(root_files, { path = fname, upward = true })[1])
+    on_dir(root_dir)
+  end,
+}


### PR DESCRIPTION
Should remove `tailwindcss` from the list in #3705

Tested locally, modifies server settings the same way as it did in pre-0.11 setup, LSP works as expected.