### PR TITLE
fix(sqls): install instructions

### DIFF
--- a/doc/configs.md
+++ b/doc/configs.md
@@ -10113,7 +10113,7 @@ vim.lsp.config('sqls', {
   ...
 })
 ```
-Sqls can be installed via `go get github.com/sqls-server/sqls`. Instructions for compiling Sqls from the source can be found at [sqls-server/sqls](https://github.com/sqls-server/sqls).
+Sqls can be installed via `go install github.com/sqls-server/sqls@latest`. Instructions for compiling Sqls from the source can be found at [sqls-server/sqls](https://github.com/sqls-server/sqls).
 
 Snippet to enable the language server:
 ```lua

--- a/doc/configs.txt
+++ b/doc/configs.txt
@@ -9506,7 +9506,7 @@ vim.lsp.config('sqls', {
   ...
 })
 ```
-Sqls can be installed via `go get github.com/sqls-server/sqls`. Instructions for compiling Sqls from the source can be found at [sqls-server/sqls](https://github.com/sqls-server/sqls).
+Sqls can be installed via `go install github.com/sqls-server/sqls@latest`. Instructions for compiling Sqls from the source can be found at [sqls-server/sqls](https://github.com/sqls-server/sqls).
 
 Snippet to enable the language server: >lua
   vim.lsp.enable('sqls')


### PR DESCRIPTION
Problem:
Outdated installation instructions for sqls by using `go get ...`

Solution:
The new working method is `go install ...`
I had to put `@latest` as the package version because the package has not yet reached v1.0, which means it is stable in Go land.
