### PR TITLE
fix(unocss): add `workspace_required` to `true`

### DIFF
--- a/lsp/unocss.lua
+++ b/lsp/unocss.lua
@@ -34,5 +34,6 @@ return {
     'rescript',
     'rust',
   },
+  workspace_required = true,
   root_markers = { 'unocss.config.js', 'unocss.config.ts', 'uno.config.js', 'uno.config.ts' },
 }


### PR DESCRIPTION
unocss is a css utility library similar to tailwind which requires configuration files and the package to be installed to work with. 
Otherwise it will throw an error:
> Error executing vim.schedule lua callback: /usr/local/share/nvim/runtime/lua/vim/lsp/client.lua:551: RPC[Error] code_name = InternalError, message = "Request initialize failed with message: Cannot read properties of null (reading '0')"
stack traceback:
	[C]: in function 'assert'
	/usr/local/share/nvim/runtime/lua/vim/lsp/client.lua:551: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>

Thus set `workspace_required ` to `true`.