### PR TITLE
fix: add pylyzer dependency info (erg) (#3433)

### DIFF
--- a/lsp/pylyzer.lua
+++ b/lsp/pylyzer.lua
@@ -5,8 +5,7 @@
 --- `pylyzer`, a fast static code analyzer & language server for Python.
 ---
 --- `pylyzer` requires Erg as dependency, and finds it via `ERG_PATH` environment variable.
---- In the default config `ERG_PATH` is set to `~/.erg`, as shown in the `on_new_config` function.
---- Add a `on_new_config` on your own if you want to change it.
+--- This config sets `ERG_PATH="~/.erg"`. Set `cmd_env` if you want to change it.
 --- To install Erg, simply extract tarball/zip from [Erg releases](https://github.com/erg-lang/erg/releases/latest)
 --- to the the path where you want to install it, e.g. `~/.erg`.
 return {

--- a/lsp/pylyzer.lua
+++ b/lsp/pylyzer.lua
@@ -3,6 +3,12 @@
 --- https://github.com/mtshiba/pylyzer
 ---
 --- `pylyzer`, a fast static code analyzer & language server for Python.
+---
+--- `pylyzer` requires Erg as dependency, and finds it via `ERG_PATH` environment variable.
+--- In the default config `ERG_PATH` is set to `~/.erg`, as shown in the `on_new_config` function.
+--- Add a `on_new_config` on your own if you want to change it.
+--- To install Erg, simply extract tarball/zip from [Erg releases](https://github.com/erg-lang/erg/releases/latest)
+--- to the the path where you want to install it, e.g. `~/.erg`.
 return {
   cmd = { 'pylyzer', '--server' },
   filetypes = { 'python' },
@@ -22,4 +28,7 @@ return {
       checkOnType = false,
     },
   },
+  on_new_config = function(new_config, _)
+    new_config.cmd_env.ERG_PATH = vim.fs.joinpath(vim.uv.os_homedir(), '/.erg')
+  end,
 }

--- a/lsp/pylyzer.lua
+++ b/lsp/pylyzer.lua
@@ -28,7 +28,7 @@ return {
       checkOnType = false,
     },
   },
-  on_new_config = function(new_config, _)
-    new_config.cmd_env.ERG_PATH = vim.fs.joinpath(vim.uv.os_homedir(), '/.erg')
-  end,
+  cmd_env = {
+    ERG_PATH = vim.env.ERG_PATH or vim.fs.joinpath(vim.uv.os_homedir(), '.erg'),
+  },
 }


### PR DESCRIPTION
Pylyzer requires Erg as dependency. This info is missing in default config and doc.