### PR TITLE
fix(roslyn_ls): use absolute paths when open `.sln` and `.csproj` files

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -131,8 +131,7 @@ return {
       -- try load first solution we find
       for entry, type in fs.dir(root_dir) do
         if type == 'file' and vim.endswith(entry, '.sln') then
-          local fpath = fs.joinpath(root_dir, entry)
-          on_init_sln(client, fpath)
+          on_init_sln(client, fs.joinpath(root_dir, entry))
           return
         end
       end

--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -129,17 +129,19 @@ return {
       local root_dir = client.config.root_dir
 
       -- try load first solution we find
-      for entry, type in vim.fs.dir(root_dir) do
+      for entry, type in fs.dir(root_dir) do
         if type == 'file' and vim.endswith(entry, '.sln') then
-          on_init_sln(client, entry)
+          local fpath = fs.joinpath(root_dir, entry)
+          on_init_sln(client, fpath)
           return
         end
       end
 
       -- if no solution is found load project
-      for entry, type in vim.fs.dir(root_dir) do
+      for entry, type in fs.dir(root_dir) do
         if type == 'file' and vim.endswith(entry, '.csproj') then
-          on_init_project(client, { entry })
+          local fpath = fs.joinpath(root_dir, entry)
+          on_init_project(client, { fpath })
         end
       end
     end,

--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -139,8 +139,7 @@ return {
       -- if no solution is found load project
       for entry, type in fs.dir(root_dir) do
         if type == 'file' and vim.endswith(entry, '.csproj') then
-          local fpath = fs.joinpath(root_dir, entry)
-          on_init_project(client, { fpath })
+          on_init_project(client, { fs.joinpath(root_dir, entry) })
         end
       end
     end,


### PR DESCRIPTION
without this change the roslyn_ls can only operate on the current file and e.g. `gd` do not work properly.