### PR TITLE
feat(ts_ls): add _typescript.rename handler

### DIFF
--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -78,4 +78,19 @@ return {
     'typescript.tsx',
   },
   root_markers = { 'tsconfig.json', 'jsconfig.json', 'package.json', '.git' },
+  handlers = {
+    -- handle rename request for certain code actions like extracting functions / types
+    ['_typescript.rename'] = function(_, result, ctx)
+      local client = vim.lsp.get_client_by_id(ctx.client_id)
+      vim.lsp.util.show_document({
+        uri = result.textDocument.uri,
+        range = {
+          start = result.position,
+          ['end'] = result.position,
+        },
+      }, client.offset_encoding)
+      vim.lsp.buf.rename()
+      return vim.NIL
+    end,
+  },
 }


### PR DESCRIPTION
This handler is used when performing certain code actions such as extracting functions or types. The language server asks the editor to prompt for a rename for the newly created function or type.