### PR TITLE
fix(rust_analyzer): nvim_echo must not be called in a fast event context

### DIFF
--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -96,7 +96,9 @@ return {
 
         on_dir(cargo_workspace_root or cargo_crate_dir)
       else
-        vim.notify(('[rust_analyzer] cmd failed with code %d: %s\n%s'):format(output.code, cmd, output.stderr))
+        vim.schedule(function()
+          vim.notify(('[rust_analyzer] cmd failed with code %d: %s\n%s'):format(output.code, cmd, output.stderr))
+        end)
       end
     end)
   end,


### PR DESCRIPTION
Fix `E5560: nvim_echo must not be called in a fast event context`