### PR TITLE
Support for non-conventional `package.json5`

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -46,14 +46,13 @@ end
 
 function M.insert_package_json(config_files, field, fname)
   local path = vim.fn.fnamemodify(fname, ':h')
-  local root_with_package = vim.fs.dirname(vim.fs.find('package.json', { path = path, upward = true })[1])
+  local root_with_package = vim.fs.find({ 'package.json', 'package.json5' }, { path = path, upward = true })[1]
 
   if root_with_package then
     -- only add package.json if it contains field parameter
-    local path_sep = iswin and '\\' or '/'
-    for line in io.lines(root_with_package .. path_sep .. 'package.json') do
+    for line in io.lines(root_with_package) do
       if line:find(field) then
-        config_files[#config_files + 1] = 'package.json'
+        config_files[#config_files + 1] = vim.fs.basename(root_with_package)
         break
       end
     end


### PR DESCRIPTION
This is to address a recent issue (see #3710), with root detection failing when running a `pcakage.json5`.

I've modified `insert_package_json` to support `package.json5`.  While this has worked in my case with `tailwind-language-server`, whether this change should be upstreamed is up to maintainer's discretion.

Much thanks.