### PR TITLE
fix: improve typescript server path search for ts dependents lsp

### DIFF
--- a/lsp/astro.lua
+++ b/lsp/astro.lua
@@ -8,8 +8,15 @@
 --- ```
 
 local function get_typescript_server_path(root_dir)
-  local project_root = vim.fs.dirname(vim.fs.find('node_modules', { path = root_dir, upward = true })[1])
-  return project_root and vim.fs.joinpath(project_root, 'node_modules', 'typescript', 'lib') or ''
+  local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
+  for _, project_root in ipairs(project_roots) do
+    local typescript_path = project_root .. '/typescript'
+    local stat = vim.loop.fs_stat(typescript_path)
+    if stat and stat.type == 'directory' then
+      return typescript_path .. '/lib'
+    end
+  end
+  return ''
 end
 
 return {

--- a/lsp/astro.lua
+++ b/lsp/astro.lua
@@ -7,17 +7,7 @@
 --- npm install -g @astrojs/language-server
 --- ```
 
-local function get_typescript_server_path(root_dir)
-  local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
-  for _, project_root in ipairs(project_roots) do
-    local typescript_path = project_root .. '/typescript'
-    local stat = vim.loop.fs_stat(typescript_path)
-    if stat and stat.type == 'directory' then
-      return typescript_path .. '/lib'
-    end
-  end
-  return ''
-end
+local util = require 'lspconfig.util'
 
 return {
   cmd = { 'astro-ls', '--stdio' },
@@ -28,7 +18,7 @@ return {
   },
   before_init = function(_, config)
     if config.init_options and config.init_options.typescript and not config.init_options.typescript.tsdk then
-      config.init_options.typescript.tsdk = get_typescript_server_path(config.root_dir)
+      config.init_options.typescript.tsdk = util.get_typescript_server_path(config.root_dir)
     end
   end,
 }

--- a/lsp/mdx_analyzer.lua
+++ b/lsp/mdx_analyzer.lua
@@ -3,17 +3,7 @@
 ---
 --- `mdx-analyzer`, a language server for MDX
 
-local function get_typescript_server_path(root_dir)
-  local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
-  for _, project_root in ipairs(project_roots) do
-    local typescript_path = project_root .. '/typescript'
-    local stat = vim.loop.fs_stat(typescript_path)
-    if stat and stat.type == 'directory' then
-      return typescript_path .. '/lib'
-    end
-  end
-  return ''
-end
+local util = require 'lspconfig.util'
 
 return {
   cmd = { 'mdx-language-server', '--stdio' },
@@ -25,7 +15,7 @@ return {
   },
   before_init = function(_, config)
     if config.init_options and config.init_options.typescript and not config.init_options.typescript.tsdk then
-      config.init_options.typescript.tsdk = get_typescript_server_path(config.root_dir)
+      config.init_options.typescript.tsdk = util.get_typescript_server_path(config.root_dir)
     end
   end,
 }

--- a/lsp/mdx_analyzer.lua
+++ b/lsp/mdx_analyzer.lua
@@ -4,8 +4,15 @@
 --- `mdx-analyzer`, a language server for MDX
 
 local function get_typescript_server_path(root_dir)
-  local project_root = vim.fs.dirname(vim.fs.find('node_modules', { path = root_dir, upward = true })[1])
-  return project_root and vim.fs.joinpath(project_root, 'node_modules', 'typescript', 'lib') or ''
+  local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
+  for _, project_root in ipairs(project_roots) do
+    local typescript_path = project_root .. '/typescript'
+    local stat = vim.loop.fs_stat(typescript_path)
+    if stat and stat.type == 'directory' then
+      return typescript_path .. '/lib'
+    end
+  end
+  return ''
 end
 
 return {

--- a/lsp/volar.lua
+++ b/lsp/volar.lua
@@ -74,8 +74,15 @@
 --- ```
 
 local function get_typescript_server_path(root_dir)
-  local project_root = vim.fs.dirname(vim.fs.find('node_modules', { path = root_dir, upward = true })[1])
-  return project_root and vim.fs.joinpath(project_root, 'node_modules', 'typescript', 'lib') or ''
+  local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
+  for _, project_root in ipairs(project_roots) do
+    local typescript_path = project_root .. '/typescript'
+    local stat = vim.loop.fs_stat(typescript_path)
+    if stat and stat.type == 'directory' then
+      return typescript_path .. '/lib'
+    end
+  end
+  return ''
 end
 
 -- https://github.com/vuejs/language-tools/blob/master/packages/language-server/lib/types.ts

--- a/lsp/volar.lua
+++ b/lsp/volar.lua
@@ -73,17 +73,7 @@
 --- })
 --- ```
 
-local function get_typescript_server_path(root_dir)
-  local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
-  for _, project_root in ipairs(project_roots) do
-    local typescript_path = project_root .. '/typescript'
-    local stat = vim.loop.fs_stat(typescript_path)
-    if stat and stat.type == 'directory' then
-      return typescript_path .. '/lib'
-    end
-  end
-  return ''
-end
+local util = require 'lspconfig.util'
 
 -- https://github.com/vuejs/language-tools/blob/master/packages/language-server/lib/types.ts
 local volar_init_options = {
@@ -99,7 +89,7 @@ return {
   init_options = volar_init_options,
   before_init = function(_, config)
     if config.init_options and config.init_options.typescript and config.init_options.typescript.tsdk == '' then
-      config.init_options.typescript.tsdk = get_typescript_server_path(config.root_dir)
+      config.init_options.typescript.tsdk = util.get_typescript_server_path(config.root_dir)
     end
   end,
 }

--- a/lua/lspconfig/configs/astro.lua
+++ b/lua/lspconfig/configs/astro.lua
@@ -1,8 +1,15 @@
 local util = require 'lspconfig.util'
 
 local function get_typescript_server_path(root_dir)
-  local project_root = vim.fs.dirname(vim.fs.find('node_modules', { path = root_dir, upward = true })[1])
-  return project_root and (project_root .. '/node_modules/typescript/lib') or ''
+  local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
+  for _, project_root in ipairs(project_roots) do
+    local typescript_path = project_root .. '/typescript'
+    local stat = vim.loop.fs_stat(typescript_path)
+    if stat and stat.type == 'directory' then
+      return typescript_path .. '/lib'
+    end
+  end
+  return ''
 end
 
 return {

--- a/lua/lspconfig/configs/astro.lua
+++ b/lua/lspconfig/configs/astro.lua
@@ -1,17 +1,5 @@
 local util = require 'lspconfig.util'
 
-local function get_typescript_server_path(root_dir)
-  local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
-  for _, project_root in ipairs(project_roots) do
-    local typescript_path = project_root .. '/typescript'
-    local stat = vim.loop.fs_stat(typescript_path)
-    if stat and stat.type == 'directory' then
-      return typescript_path .. '/lib'
-    end
-  end
-  return ''
-end
-
 return {
   default_config = {
     cmd = { 'astro-ls', '--stdio' },
@@ -22,7 +10,7 @@ return {
     },
     on_new_config = function(new_config, new_root_dir)
       if vim.tbl_get(new_config.init_options, 'typescript') and not new_config.init_options.typescript.tsdk then
-        new_config.init_options.typescript.tsdk = get_typescript_server_path(new_root_dir)
+        new_config.init_options.typescript.tsdk = util.get_typescript_server_path(new_root_dir)
       end
     end,
   },

--- a/lua/lspconfig/configs/mdx_analyzer.lua
+++ b/lua/lspconfig/configs/mdx_analyzer.lua
@@ -1,17 +1,5 @@
 local util = require 'lspconfig.util'
 
-local function get_typescript_server_path(root_dir)
-  local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
-  for _, project_root in ipairs(project_roots) do
-    local typescript_path = project_root .. '/typescript'
-    local stat = vim.loop.fs_stat(typescript_path)
-    if stat and stat.type == 'directory' then
-      return typescript_path .. '/lib'
-    end
-  end
-  return ''
-end
-
 return {
   default_config = {
     cmd = { 'mdx-language-server', '--stdio' },
@@ -24,7 +12,7 @@ return {
     },
     on_new_config = function(new_config, new_root_dir)
       if vim.tbl_get(new_config.init_options, 'typescript') and not new_config.init_options.typescript.tsdk then
-        new_config.init_options.typescript.tsdk = get_typescript_server_path(new_root_dir)
+        new_config.init_options.typescript.tsdk = util.get_typescript_server_path(new_root_dir)
       end
     end,
   },

--- a/lua/lspconfig/configs/mdx_analyzer.lua
+++ b/lua/lspconfig/configs/mdx_analyzer.lua
@@ -1,8 +1,15 @@
 local util = require 'lspconfig.util'
 
 local function get_typescript_server_path(root_dir)
-  local project_root = vim.fs.dirname(vim.fs.find('node_modules', { path = root_dir, upward = true })[1])
-  return project_root and (project_root .. '/node_modules/typescript/lib') or ''
+  local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
+  for _, project_root in ipairs(project_roots) do
+    local typescript_path = project_root .. '/typescript'
+    local stat = vim.loop.fs_stat(typescript_path)
+    if stat and stat.type == 'directory' then
+      return typescript_path .. '/lib'
+    end
+  end
+  return ''
 end
 
 return {

--- a/lua/lspconfig/configs/volar.lua
+++ b/lua/lspconfig/configs/volar.lua
@@ -1,17 +1,5 @@
 local util = require 'lspconfig.util'
 
-local function get_typescript_server_path(root_dir)
-  local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
-  for _, project_root in ipairs(project_roots) do
-    local typescript_path = project_root .. '/typescript'
-    local stat = vim.loop.fs_stat(typescript_path)
-    if stat and stat.type == 'directory' then
-      return typescript_path .. '/lib'
-    end
-  end
-  return ''
-end
-
 -- https://github.com/vuejs/language-tools/blob/master/packages/language-server/lib/types.ts
 local volar_init_options = {
   typescript = {
@@ -31,7 +19,7 @@ return {
         and new_config.init_options.typescript
         and new_config.init_options.typescript.tsdk == ''
       then
-        new_config.init_options.typescript.tsdk = get_typescript_server_path(new_root_dir)
+        new_config.init_options.typescript.tsdk = util.get_typescript_server_path(new_root_dir)
       end
     end,
   },

--- a/lua/lspconfig/configs/volar.lua
+++ b/lua/lspconfig/configs/volar.lua
@@ -1,8 +1,15 @@
 local util = require 'lspconfig.util'
 
 local function get_typescript_server_path(root_dir)
-  local project_root = vim.fs.dirname(vim.fs.find('node_modules', { path = root_dir, upward = true })[1])
-  return project_root and (project_root .. '/node_modules/typescript/lib') or ''
+  local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
+  for _, project_root in ipairs(project_roots) do
+    local typescript_path = project_root .. '/typescript'
+    local stat = vim.loop.fs_stat(typescript_path)
+    if stat and stat.type == 'directory' then
+      return typescript_path .. '/lib'
+    end
+  end
+  return ''
 end
 
 -- https://github.com/vuejs/language-tools/blob/master/packages/language-server/lib/types.ts

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -69,6 +69,18 @@ function M.strip_archive_subpath(path)
   return path
 end
 
+function M.get_typescript_server_path(root_dir)
+  local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
+  for _, project_root in ipairs(project_roots) do
+    local typescript_path = project_root .. '/typescript'
+    local stat = vim.loop.fs_stat(typescript_path)
+    if stat and stat.type == 'directory' then
+      return typescript_path .. '/lib'
+    end
+  end
+  return ''
+end
+
 ---
 ---
 ---


### PR DESCRIPTION
LSPs like `volar` (for VueJS), `astro` or `mdx_analyzer` rely on a path for the Typescript server they should use. But this path is wrongly assumed to be inside `node_modules/typescript/lib` starting from the nearest `package.json` file.

In fact, in case of monorepos / workspaces, with all package managers like `npm`, `yarn` or `pnpm`, some hoisting can take place. This means that the `typescript` node module will get move higher up in the tree to be shared between all projects and avoid duplication. The NodeJS module resolution works like this, by trying to find the module upward in the tree, one directory after another.

Therefore, it can happen a case like this:
```
monorepo-root
 - apps
 > - app-number-one
 >> - node_modules (without typescript)
 >> - package.json
 > - app-number-two
 >> - node_modules (without typescript)
 >> - package.json
 - node_modules (with typescript)
 > - typescript
 - package.json
```

I therefore adapted the Lua algorithm to match the one of NodeJS (and the one of the `ts_ls` server, that does it natively).

> Even if some LSPs like `volar` going towards "hybrid modes" where they don't need to spawn their full TS server (because usually users will spawn it nevertheless for other projects), this is still required and needs to be correctly setup to work on the files they target.

I've also mutualized this logic at one place to avoid de-duplication, but feel free to correct me on that. I've created a simple `typescript.lua` file, imagining that we could have language specific utils for LSPs that need it.