### PR TITLE
feat(lua_ls): add rootPath to workspace.library

### DIFF
--- a/lsp/lua_ls.lua
+++ b/lsp/lua_ls.lua
@@ -65,4 +65,14 @@ return {
     'selene.yml',
     '.git',
   },
+  settings = {
+    Lua = {
+      workspace = {
+        library = {},
+      },
+    },
+  },
+  before_init = function(init_params, config)
+    table.insert(config.settings.Lua.workspace.library, init_params.rootPath)
+  end,
 }


### PR DESCRIPTION
This seems to make it possible to jump to any lua file under rootPath, regardless of directory structure.

I'm a noob in this area, please let me know if there's anything strange.