### PR TITLE
fix(eslint): check nil before on_dir

### DIFF
--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -80,7 +80,9 @@ return {
     local fname = vim.api.nvim_buf_get_name(bufnr)
     root_file_patterns = util.insert_package_json(root_file_patterns, 'eslintConfig', fname)
     local root_dir = vim.fs.dirname(vim.fs.find(root_file_patterns, { path = fname, upward = true })[1])
-    on_dir(root_dir)
+    if root_dir then
+      on_dir(root_dir)
+    end
   end,
   -- Refer to https://github.com/Microsoft/vscode-eslint#settings-options for documentation.
   settings = {


### PR DESCRIPTION
i don't know if this fix should be used, but it surely fixed my problem.

if you dont check if it is `nil` before pass it to `on_dir`, the `root_dir`  became useless. or if we should check `nil` inside `on_dir` ? i don't know.

maybe there are more config didn't check `nil` in `root_dir` in `/lsp/*.lua`, but i dont have time to check them carefully.