### PR TITLE
fix(eslint): require workspace instead of checking root dir for `nil` value

### DIFF
--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -44,6 +44,7 @@ return {
     'svelte',
     'astro',
   },
+  workspace_required = true,
   on_attach = function(client)
     vim.api.nvim_buf_create_user_command(0, 'LspEslintFixAll', function()
       local bufnr = vim.api.nvim_get_current_buf()
@@ -79,10 +80,7 @@ return {
 
     local fname = vim.api.nvim_buf_get_name(bufnr)
     root_file_patterns = util.insert_package_json(root_file_patterns, 'eslintConfig', fname)
-    local root_dir = vim.fs.dirname(vim.fs.find(root_file_patterns, { path = fname, upward = true })[1])
-    if root_dir then
-      on_dir(root_dir)
-    end
+    on_dir(vim.fs.dirname(vim.fs.find(root_file_patterns, { path = fname, upward = true })[1]))
   end,
   -- Refer to https://github.com/Microsoft/vscode-eslint#settings-options for documentation.
   settings = {


### PR DESCRIPTION
This PR requires a workspace to be present for the ESLint LSP to attach, replacing the previous behavior of checking whether the root directory is `nil` (introduced in https://github.com/neovim/nvim-lspconfig/pull/3800).
End users can override this behavior by setting the `workspace_required = false` option.
It's generally better not to enable any JS/TS-related LSP globally, as developers tend to prefer different tools (e.g., ESLint, Biome, Oxlint).