### PR TITLE
fix(configs): execute sanitize_cmd only on windows to speed up WSL

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -24,13 +24,10 @@ local configs = {}
 --- @field root_dir? string|fun(filename: string, bufnr: number)
 --- @field commands? table<string, lspconfig.Config.command>
 
+--- For Windows: calls exepath() to ensure .cmd/.bat (if appropriate) on commands. https://github.com/neovim/nvim-lspconfig/issues/3704
 --- @param cmd any
 local function sanitize_cmd(cmd)
-  -- This function is no longer necessary on unix systems, and is particularly slow in WSL, therefore we can skip the
-  -- execution.
-  -- However in windows this remain necessary as most of the times the LSPs scripts end in .cmd but the default config
-  -- dose not have the .cmd, so if this function is not executed all LSPs will fail to start.
-  -- More details here: https://github.com/neovim/nvim-lspconfig/issues/3704
+  -- exepath() is slow, so avoid it on non-Windows.
   if vim.fn.has('win32') == 0 then
     return
   end

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -26,6 +26,14 @@ local configs = {}
 
 --- @param cmd any
 local function sanitize_cmd(cmd)
+  -- This function is no longer necessary on unix systems, and is particularly slow in WSL, therefore we can skip the
+  -- execution.
+  -- However in windows this remain necessary as most of the times the LSPs scripts end in .cmd but the default config
+  -- dose not have the .cmd, so if this function is not executed all LSPs will fail to start.
+  -- More details here: https://github.com/neovim/nvim-lspconfig/issues/3704
+  if vim.fn.has("win32") == 0 then
+    return
+  end
   if cmd and type(cmd) == 'table' and not vim.tbl_isempty(cmd) then
     local original = cmd[1]
     cmd[1] = vim.fn.exepath(cmd[1])

--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -31,7 +31,7 @@ local function sanitize_cmd(cmd)
   -- However in windows this remain necessary as most of the times the LSPs scripts end in .cmd but the default config
   -- dose not have the .cmd, so if this function is not executed all LSPs will fail to start.
   -- More details here: https://github.com/neovim/nvim-lspconfig/issues/3704
-  if vim.fn.has("win32") == 0 then
+  if vim.fn.has('win32') == 0 then
     return
   end
   if cmd and type(cmd) == 'table' and not vim.tbl_isempty(cmd) then


### PR DESCRIPTION
In this PR I propose a solution to the execution of LSPs being slow in WLS, a fix was already made a few days ago, but that broke LSPs entirely in Windows machines, so it has been reverted.

See [#3704 (comment)](https://github.com/neovim/nvim-lspconfig/issues/3704#issuecomment-2840154346) and [#3704 (comment)](https://github.com/neovim/nvim-lspconfig/issues/3704#issuecomment-2795261951)

fix #3704