### PR TITLE
fix(texlab): Improve root detection for Latexmk projects

### DIFF
--- a/lsp/texlab.lua
+++ b/lsp/texlab.lua
@@ -164,7 +164,7 @@ end
 return {
   cmd = { 'texlab' },
   filetypes = { 'tex', 'plaintex', 'bib' },
-  root_markers = { '.git', '.latexmkrc', '.texlabroot', 'texlabroot', 'Tectonic.toml' },
+  root_markers = { '.git', '.latexmkrc', 'latexmkrc', '.texlabroot', 'texlabroot', 'Tectonic.toml' },
   settings = {
     texlab = {
       rootDirectory = nil,


### PR DESCRIPTION
# Problem:

The root directory of Latexmk-based projects is not detected when the local configuration file is called `latexmkrc` (without leading `.`).

# Solution:

Both `.latexmkrc` and `latexmkrc` are valid names for [local Latexmk configuration files][1]. Add `latexmk` to the list of possible root markers.

[1]: https://mgeier.github.io/latexmk.html#local-configuration-files