### PR TITLE
fix(doc): Correct `lua_ls` documentation.

### DIFF
--- a/lsp/lua_ls.lua
+++ b/lsp/lua_ls.lua
@@ -17,15 +17,18 @@
 ---   on_init = function(client)
 ---     if client.workspace_folders then
 ---       local path = client.workspace_folders[1].name
----       if path ~= vim.fn.stdpath('config') and (vim.uv.fs_stat(path..'/.luarc.json') or vim.uv.fs_stat(path..'/.luarc.jsonc')) then
+---       if
+---         path ~= vim.fn.stdpath('config')
+---         and (vim.uv.fs_stat(path .. '/.luarc.json') or vim.uv.fs_stat(path .. '/.luarc.jsonc'))
+---       then
 ---         return
 ---       end
 ---     end
 ---
 ---     client.config.settings.Lua = vim.tbl_deep_extend('force', client.config.settings.Lua, {
 ---       runtime = {
----         -- Tell the language server which version of Lua you're using
----         -- (most likely LuaJIT in the case of Neovim)
+---         -- Tell the language server which version of Lua you're using (most
+---         -- likely LuaJIT in the case of Neovim)
 ---         version = 'LuaJIT'
 ---       },
 ---       -- Make the server aware of Neovim runtime files
@@ -33,12 +36,18 @@
 ---         checkThirdParty = false,
 ---         library = {
 ---           vim.env.VIMRUNTIME
----           -- Depending on the usage, you might want to add additional paths here.
----           -- "${3rd}/luv/library"
----           -- "${3rd}/busted/library",
+---           -- Depending on the usage, you might want to add additional paths
+---           -- here.
+---           -- '${3rd}/luv/library'
+---           -- '${3rd}/busted/library'
 ---         }
----         -- or pull in all of 'runtimepath'. NOTE: this is a lot slower and will cause issues when working on your own configuration (see https://github.com/neovim/nvim-lspconfig/issues/3189)
----         -- library = vim.api.nvim_get_runtime_file("", true)
+---         -- Or pull in all of 'runtimepath'.
+---         -- NOTE: this is a lot slower and will cause issues when working on
+---         -- your own configuration.
+---         -- See https://github.com/neovim/nvim-lspconfig/issues/3189
+---         -- library = {
+---         --   vim.api.nvim_get_runtime_file('', true),
+---         -- }
 ---       }
 ---     })
 ---   end,


### PR DESCRIPTION
Correct formatting in `lua_ls` documentation.

- Re indent long lines
- Use quotes consistently
- Organize `runtimepath` section for clarity by splitting `library` in two separate blocks