### PR TITLE
fix(omnisharp): update executable name

### DIFF
--- a/lsp/omnisharp.lua
+++ b/lsp/omnisharp.lua
@@ -16,7 +16,7 @@
 
 return {
   cmd = {
-    'OmniSharp',
+    vim.fn.executable('OmniSharp') == 1 and 'OmniSharp' or 'omnisharp',
     '-z', -- https://github.com/OmniSharp/omnisharp-vscode/pull/4300
     '--hostPID',
     tostring(vim.fn.getpid()),


### PR DESCRIPTION
Problem:
The executable name may be in lowercase (e.g., when installed with Mason on Linux) in which case it won't be found.

Solution:
Verify if the name is in PascalCase, and otherwise use lowercase.