### PR TITLE
fix(taplo): add Taplo configuration files to root markers

### DIFF
--- a/lsp/taplo.lua
+++ b/lsp/taplo.lua
@@ -11,5 +11,5 @@
 return {
   cmd = { 'taplo', 'lsp', 'stdio' },
   filetypes = { 'toml' },
-  root_markers = { '.git', '.taplo.toml', 'taplo.toml' },
+  root_markers = { '.taplo.toml', 'taplo.toml', '.git'  },
 }

--- a/lsp/taplo.lua
+++ b/lsp/taplo.lua
@@ -11,5 +11,5 @@
 return {
   cmd = { 'taplo', 'lsp', 'stdio' },
   filetypes = { 'toml' },
-  root_markers = { '.git' },
+  root_markers = { '.git', '.taplo.toml', 'taplo.toml' },
 }

--- a/lsp/taplo.lua
+++ b/lsp/taplo.lua
@@ -11,5 +11,5 @@
 return {
   cmd = { 'taplo', 'lsp', 'stdio' },
   filetypes = { 'toml' },
-  root_markers = { '.taplo.toml', 'taplo.toml', '.git'  },
+  root_markers = { '.git', '.taplo.toml', 'taplo.toml' },
 }

--- a/lsp/taplo.lua
+++ b/lsp/taplo.lua
@@ -11,5 +11,5 @@
 return {
   cmd = { 'taplo', 'lsp', 'stdio' },
   filetypes = { 'toml' },
-  root_markers = { '.git', '.taplo.toml', 'taplo.toml' },
+  root_markers = { '.taplo.toml', 'taplo.toml', '.git' },
 }

--- a/lua/lspconfig/configs/taplo.lua
+++ b/lua/lspconfig/configs/taplo.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'taplo', 'lsp', 'stdio' },
     filetypes = { 'toml' },
     root_dir = function(fname)
-      return vim.fs.root(0, { '.taplo.toml', 'taplo.toml', '.git' }),
+      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
     end,
     single_file_support = true,
   },

--- a/lua/lspconfig/configs/taplo.lua
+++ b/lua/lspconfig/configs/taplo.lua
@@ -3,7 +3,7 @@ return {
     cmd = { 'taplo', 'lsp', 'stdio' },
     filetypes = { 'toml' },
     root_dir = function(fname)
-      return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+      return vim.fs.root(0, { '.taplo.toml', 'taplo.toml', '.git' }),
     end,
     single_file_support = true,
   },


### PR DESCRIPTION
According to the [Taplo documentation](https://taplo.tamasfe.dev/configuration/file.html#configuration-file):
> Taplo supports configuration via file, unsurprisingly it uses the TOML format.
> 
> By default, every tool looks for one in the working directory or the root of the workspace by the following names (in precedence order):
> - .taplo.toml
> - taplo.toml

This simply adds those two files to the root directory definition.

Note: the commit message/PR is potentially mischaracterized as `fix` instead of `feat`; I was unsure of which category this falls under. 