### PR TITLE
fix(configs): eliminate some usages of root_pattern

### DIFF
--- a/lsp/elmls.lua
+++ b/lsp/elmls.lua
@@ -7,10 +7,7 @@
 --- npm install -g elm elm-test elm-format @elm-tooling/elm-language-server
 --- ```
 
-local util = require 'lspconfig.util'
 local api = vim.api
-
-local elm_root_pattern = util.root_pattern 'elm.json'
 
 return {
   cmd = { 'elm-language-server' },
@@ -20,7 +17,7 @@ return {
     local fname = api.nvim_buf_get_name(bufnr)
     local filetype = api.nvim_buf_get_option(0, 'filetype')
     if filetype == 'elm' or (filetype == 'json' and fname:match 'elm%.json$') then
-      on_dir(elm_root_pattern(fname))
+      on_dir(vim.fs.root(fname, 'elm.json'))
       return
     end
     on_dir(nil)

--- a/lsp/intelephense.lua
+++ b/lsp/intelephense.lua
@@ -25,17 +25,15 @@
 --- }
 --- ```
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'intelephense', '--stdio' },
   filetypes = { 'php' },
   root_dir = function(bufnr, on_dir)
     local fname = vim.api.nvim_buf_get_name(bufnr)
     local cwd = assert(vim.uv.cwd())
-    local root = util.root_pattern('composer.json', '.git')(fname)
+    local root = vim.fs.root(fname, { 'composer.json', '.git' })
 
     -- prefer cwd if root is a descendant
-    on_dir(vim.fs.relpath(cwd, root) and cwd or root)
+    on_dir(root and vim.fs.relpath(cwd, root) and cwd)
   end,
 }

--- a/lsp/kotlin_language_server.lua
+++ b/lsp/kotlin_language_server.lua
@@ -16,10 +16,6 @@
 --- For faster startup, you can setup caching by specifying a storagePath
 --- in the init_options. The default is your home directory.
 
-local util = require 'lspconfig.util'
-
-local bin_name = 'kotlin-language-server'
-
 --- The presence of one of these files indicates a project root directory
 --
 --  These are configuration files for the various build systems supported by
@@ -37,9 +33,9 @@ local root_files = {
 return {
   filetypes = { 'kotlin' },
   root_markers = root_files,
-  cmd = { bin_name }, -- kotlin-language-server
+  cmd = { 'kotlin-language-server' },
   init_options = {
     -- Enables caching and use project root to store cache data.
-    storagePath = util.root_pattern(unpack(root_files))(vim.fn.expand '%:p:h'),
+    storagePath = vim.fs.root(vim.fn.expand '%:p:h', root_files),
   },
 }

--- a/lsp/lean3ls.lua
+++ b/lsp/lean3ls.lua
@@ -14,8 +14,6 @@
 --- that plugin fully handles the setup of the Lean language server,
 --- and you shouldn't set up `lean3ls` both with it and `lspconfig`.
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'lean-language-server', '--stdio', '--', '-M', '4096', '-T', '100000' },
   filetypes = { 'lean3' },
@@ -33,8 +31,7 @@ return {
     end
 
     on_dir(
-      util.root_pattern 'leanpkg.toml'(fname)
-        or util.root_pattern 'leanpkg.path'(fname)
+      vim.fs.root(fname, { 'leanpkg.toml', 'leanpkg.path' })
         or stdlib_dir
         or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
     )

--- a/lsp/phan.lua
+++ b/lsp/phan.lua
@@ -4,8 +4,6 @@
 ---
 --- Installation: https://github.com/phan/phan#getting-started
 
-local util = require 'lspconfig.util'
-
 local cmd = {
   'phan',
   '-m',
@@ -25,9 +23,9 @@ return {
   root_dir = function(bufnr, on_dir)
     local fname = vim.api.nvim_buf_get_name(bufnr)
     local cwd = assert(vim.uv.cwd())
-    local root = util.root_pattern('composer.json', '.git')(fname)
+    local root = vim.fs.root(fname, { 'composer.json', '.git' })
 
     -- prefer cwd if root is a descendant
-    on_dir(vim.fs.relpath(cwd, root) and cwd or root)
+    on_dir(root and vim.fs.relpath(cwd, root) and cwd)
   end,
 }

--- a/lsp/phpactor.lua
+++ b/lsp/phpactor.lua
@@ -4,17 +4,15 @@
 ---
 --- Installation: https://phpactor.readthedocs.io/en/master/usage/standalone.html#global-installation
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'phpactor', 'language-server' },
   filetypes = { 'php' },
   root_dir = function(bufnr, on_dir)
     local fname = vim.api.nvim_buf_get_name(bufnr)
     local cwd = assert(vim.uv.cwd())
-    local root = util.root_pattern('composer.json', '.git', '.phpactor.json', '.phpactor.yml')(fname)
+    local root = vim.fs.root(fname, { 'composer.json', '.git', '.phpactor.json', '.phpactor.yml' })
 
     -- prefer cwd if root is a descendant
-    on_dir(vim.fs.relpath(cwd, root) and cwd or root)
+    on_dir(root and vim.fs.relpath(cwd, root) and cwd)
   end,
 }

--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -21,8 +21,6 @@
 --- Note: do not set `init_options` for this LS config, it will be automatically populated by the contents of settings["rust-analyzer"] per
 --- https://github.com/rust-lang/rust-analyzer/blob/eb5da56d839ae0a9e9f50774fa3eb78eb0964550/docs/dev/lsp-extensions.md?plain=1#L26.
 
-local util = require 'lspconfig.util'
-
 local function reload_workspace(bufnr)
   local clients = vim.lsp.get_clients { bufnr = bufnr, name = 'rust_analyzer' }
   for _, client in ipairs(clients) do
@@ -64,12 +62,12 @@ return {
       return
     end
 
-    local cargo_crate_dir = util.root_pattern 'Cargo.toml'(fname)
+    local cargo_crate_dir = vim.fs.root(fname, { 'Cargo.toml' })
     local cargo_workspace_root
 
     if cargo_crate_dir == nil then
       on_dir(
-        util.root_pattern 'rust-project.json'(fname)
+        vim.fs.root(fname, { 'rust-project.json' })
           or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
       )
       return

--- a/lsp/smarty_ls.lua
+++ b/lsp/smarty_ls.lua
@@ -10,18 +10,16 @@
 --- npm i -g vscode-smarty-langserver-extracted
 --- ```
 
-local util = require 'lspconfig.util'
-
 return {
   cmd = { 'smarty-language-server', '--stdio' },
   filetypes = { 'smarty' },
   root_dir = function(bufnr, on_dir)
     local fname = vim.api.nvim_buf_get_name(bufnr)
     local cwd = assert(vim.uv.cwd())
-    local root = util.root_pattern('composer.json', '.git')(fname)
+    local root = vim.fs.root(fname, { 'composer.json', '.git' })
 
     -- prefer cwd if root is a descendant
-    on_dir(vim.fs.relpath(cwd, root) and cwd or root)
+    on_dir(root and vim.fs.relpath(cwd, root) and cwd)
   end,
   settings = {
     smarty = {

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -24,6 +24,9 @@ local function escape_wildcards(path)
   return path:gsub('([%[%]%?%*])', '\\%1')
 end
 
+--- Returns a function which matches a filepath against the given glob/wildcard patterns.
+---
+--- Also works with zipfile:/tarfile: buffers (via `strip_archive_subpath`).
 function M.root_pattern(...)
   local patterns = M.tbl_flatten { ... }
   return function(startpath)
@@ -44,6 +47,11 @@ function M.root_pattern(...)
   end
 end
 
+--- Appends package.json-like files to the `config_files` list if `field`
+--- is found in any such file in any ancestor of `fname`.
+---
+--- NOTE: this does a "breadth-first" search, so is broken for multi-project workspaces:
+--- https://github.com/neovim/nvim-lspconfig/issues/3818#issuecomment-2848836794
 function M.insert_package_json(config_files, field, fname)
   local path = vim.fn.fnamemodify(fname, ':h')
   local root_with_package = vim.fs.find({ 'package.json', 'package.json5' }, { path = path, upward = true })[1]


### PR DESCRIPTION
Problem:
`root_pattern` is not necessary for non-glob patterns.

Solution:
Replace non-glob cases with `vim.fs.root()`.

#3768