### PR TITLE
Fix the 'cmd' setting for the 'jsonls' LSP server

### DIFF
--- a/lua/lspconfig/configs/jsonls.lua
+++ b/lua/lspconfig/configs/jsonls.lua
@@ -1,6 +1,6 @@
 return {
   default_config = {
-    cmd = { 'vscode-json-language-server', '--stdio' },
+    cmd = { 'vscode-json-languageserver', '--stdio' },
     filetypes = { 'json', 'jsonc' },
     init_options = {
       provideFormatter = true,


### PR DESCRIPTION
I encountered a bug with the default `jsonls` LSP server config. Perhaps I was missing something, but this change fixed my issue.

Before, the default `cmd` for `jsonls` was this:

```lua
    cmd = { 'vscode-json-language-server', '--stdio' },
```
This caused a bug where the LSP server was not loaded. I changed it to this (removed a dash):

```lua
    cmd = { 'vscode-json-languageserver', '--stdio' },
```

This change fixed the problem and enabled the LSP server to be attached.