### PR TITLE
feat(vectorcode_server): add `vim.lsp.config` support

### DIFF
--- a/lsp/vectorcode_server.lua
+++ b/lsp/vectorcode_server.lua
@@ -1,0 +1,9 @@
+---@brief
+--- https://github.com/Davidyz/VectorCode
+---
+--- A Language Server Protocol implementation for VectorCode, a code repository indexing tool.
+return {
+  cmd = { 'vectorcode-server' },
+  root_dir = vim.fs.root(0, { '.vectorcode', '.git' }),
+  settings = {},
+}


### PR DESCRIPTION
With some recent updates in [vectorcode](https://github.com/Davidyz/VectorCode), the `vectorcode-server` no longer requires being started in a directory with a LSP workspace, so `single_file_support=false` can be removed.

Based on [this comment](https://github.com/neovim/nvim-lspconfig/pull/3659#issuecomment-2776613000) in #3659, it looks like `single_file_support` is the only blocker for the migration of `vectorcode-server` to `vim.lsp.config`, so I'm including the `lsp/vectorcode_server.lua` too. If there's anything else that needs modification, please let me know.