### PR TITLE
feat(matlab_ls): vim.lsp.config support

### DIFF
--- a/lsp/matlab_ls.lua
+++ b/lsp/matlab_ls.lua
@@ -1,0 +1,21 @@
+---@brief
+---
+--- https://github.com/mathworks/MATLAB-language-server
+---
+--- MATLAB® language server implements the Microsoft® Language Server Protocol for the MATLAB language.
+return {
+  cmd = { 'matlab-language-server', '--stdio' },
+  filetypes = { 'matlab' },
+  root_dir = function(bufnr, on_dir)
+    local root_dir = vim.fs.root(bufnr, '.git')
+    on_dir(root_dir or vim.fn.getcwd())
+  end,
+  settings = {
+    MATLAB = {
+      indexWorkspace = true,
+      installPath = '',
+      matlabConnectionTiming = 'onStart',
+      telemetry = true,
+    },
+  },
+}


### PR DESCRIPTION
Adding a vim.lsp.config option for matlab_ls, as discussed in #3705.

This also brings a couple of improvements compared to the old config:
- Outside of a .git repository, CWD will be passed to the language server as root_dir, replicating normal Matlab behaviour
- indexWorkspace is set to "true" by default