### PR TITLE
fix(gopls): prioritise `go.work` over `go.mod`

### DIFF
--- a/lsp/gopls.lua
+++ b/lsp/gopls.lua
@@ -15,7 +15,7 @@ local function get_root(fname)
       return clients[#clients].config.root_dir
     end
   end
-  return vim.fs.root(fname, { 'go.work', 'go.mod', '.git' })
+  return vim.fs.root(fname, 'go.work') or vim.fs.root(fname, 'go.mod') or vim.fs.root(fname, '.git')
 end
 
 return {


### PR DESCRIPTION
The purpose of a `go.work` file is to handle multi-module workspaces. A common such scenario is a monorepo.

This is also how the legacy config works because it's using `lsponfig.util.root_pattern()` which has similar semantics as `root_markers`.