### PR TITLE
feat(ty): Add `ty` lsp config

### DIFF
--- a/lsp/ty.lua
+++ b/lsp/ty.lua
@@ -1,0 +1,12 @@
+---@brief
+---
+--- https://github.com/astral-sh/ty
+---
+--- A Language Server Protocol implementation for ty, an extremely fast Python type checker and language server, written in Rust.
+---
+--- For installation instructions, please refer to the [ty documentation](https://github.com/astral-sh/ty/blob/main/README.md#getting-started).
+return {
+  cmd = { 'ty', 'server' },
+  filetypes = { 'python' },
+  root_markers = { 'ty.toml', 'pyproject.toml', '.git' },
+}


### PR DESCRIPTION
This PR adds the [ty lsp](https://github.com/astral-sh/ty) config. The project is still in early development but meets the criteria for a new config.