### PR TITLE
docs(eslint): update on_attach example

### DIFF
--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -9,14 +9,17 @@
 --- npm i -g vscode-langservers-extracted
 --- ```
 ---
---- `vscode-eslint-language-server` provides an `EslintFixAll` command that can be used to format a document on save:
+--- The default `on_attach` config provides the `LspEslintFixAll` command that can be used to format a document on save:
 --- ```lua
---- vim.lsp.config('eslint', {
----   --- ...
+--- local base_on_attach = vim.lsp.config.eslint.on_attach
+--- vim.lsp.config("eslint", {
 ---   on_attach = function(client, bufnr)
+---     if not base_on_attach then return end
+---
+---     base_on_attach(client, bufnr)
 ---     vim.api.nvim_create_autocmd("BufWritePre", {
 ---       buffer = bufnr,
----       command = "EslintFixAll",
+---       command = "LspEslintFixAll",
 ---     })
 ---   end,
 --- })


### PR DESCRIPTION
This change updates the `eslint` docs `on_attach` example that no longer works. Addresses https://github.com/neovim/nvim-lspconfig/issues/3837.

Issue https://github.com/neovim/neovim/issues/33577 is still open, and the example may need further updates in the future.