### PR TITLE
feat(vespa_ls): Add vespa_ls config

### DIFF
--- a/lsp/vespa_ls.lua
+++ b/lsp/vespa_ls.lua
@@ -1,0 +1,37 @@
+---@brief
+---
+--- https://github.com/vespa-engine/vespa/tree/master/integration/schema-language-server
+---
+--- Vespa Language Server provides LSP features such as completion, diagnostics,
+--- and go-to-definition for Vespa schema files (`.sd`), profile files (`.profile`),
+--- and YQL query files (`.yql`).
+---
+--- This language server requires Java 17 or higher. You can build the jar from source.
+---
+--- You can override the default command by manually configuring it like this:
+---
+--- ```lua
+--- vim.lsp.config('vespa_ls', {
+---   cmd = { 'java', '-jar', '/path/to/vespa-language-server.jar' },
+--- })
+--- ```
+---
+--- The project root is determined based on the presence of a `.git` directory.
+---
+--- To make Neovim recognize the proper filetypes, add the following setting in `init.lua`:
+---
+---     vim.filetype.add {
+---       extension = {
+---         profile = 'sd',
+---         sd = 'sd',
+---         yql = 'yql',
+---       },
+---     }
+
+return {
+  cmd = { 'java', '-jar', 'vespa-language-server.jar' },
+  filetypes = { 'sd', 'profile', 'yql' },
+  root_markers = {
+    '.git',
+  },
+}


### PR DESCRIPTION
### Summary

This PR adds initial support for the [Vespa schema language server](https://github.com/vespa-engine/vespa/tree/master/integration/schema-language-server), which provides LSP features such as completion, diagnostics, and go-to-definition for the following Vespa filetypes:

- Vespa schema files (`.sd`)
- Profile files (`.profile`)
- YQL query files (`.yql`)

### Details

- Supported filetypes: `sd`, `profile`, `yql`
- Root directory is determined by the presence of a `.git` directory
- Since these extensions are not natively recognized by Neovim, filetypes must be manually added using `vim.filetype.add`

### Example filetype configuration

```lua
vim.filetype.add {
  extension = {
    profile = 'sd',
    sd = 'sd',
    yql = 'yql',
  },
}
