### PR TITLE
Update ts_ls.lua to include instructions for ember support

### DIFF
--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -32,6 +32,34 @@
 --- Use the `:LspTypescriptSourceAction` command to see "whole file" ("source") code-actions such as:
 --- - organize imports
 --- - remove unused code
+--- 
+--- ### Ember support
+--- 
+--- ```lua
+--- vim.lsp.config('ts_ls',  {
+---   init_options = {
+---     plugins = {
+---       {
+---         name = "@glint/tsserver-plugin",
+---         location = "/your/path/to/@glint/tsserver-plugin",
+---         languages = {"javascript", "typescript", "typescript.glimmer", "javascript.glimmer"},
+---       },
+---     },
+---   },
+---   filetypes = {
+---     "javascript",
+---     "typescript",
+---     "javascript.glimmer",
+---     "typescript.glimmer"
+---   },
+--- })
+--- ```
+--- `location` MUST be defined. If the plugin is installed in `node_modules`,
+--- `location` can have any value.
+---
+--- `languages` must include `typescript.glimmer` and `javascript.glimmer` even if it is listed in `filetypes`.
+---
+--- `filetypes` is extended here to include the gjs and gts filetype names.
 ---
 --- ### Vue support
 ---

--- a/lua/lspconfig/configs/ts_ls.lua
+++ b/lua/lspconfig/configs/ts_ls.lua
@@ -70,43 +70,7 @@ require'lspconfig'.ts_ls.setup{
     "vue",
   },
 }
-
--- You must make sure volar is setup
--- e.g. require'lspconfig'.volar.setup{}
--- See volar's section for more information
 ```
-
-`location` MUST be defined. If the plugin is installed in `node_modules`,
-`location` can have any value.
-
-`languages` must include `vue` even if it is listed in `filetypes`.
-
-`filetypes` is extended here to include Vue SFC.
-
-### Ember support
-
-```lua
-require'lspconfig'.ts_ls.setup{
-  init_options = {
-    plugins = {
-      {
-        name = "@glint/tsserver-plugin",
-        location = "/your/path/to/@glint/tsserver-plugin",
-        languages = {"javascript", "typescript", "typescript.glimmer", "javascript.glimmer"},
-      },
-    },
-  },
-  filetypes = {
-    "javascript",
-    "typescript",
-    "javascript.glimmer",
-    "typescript.glimmer"
-  },
-}
-```
-
-`location` MUST be defined. If the plugin is installed in `node_modules`,
-`location` can have any value.
 ]],
   },
 }

--- a/lua/lspconfig/configs/ts_ls.lua
+++ b/lua/lspconfig/configs/ts_ls.lua
@@ -103,10 +103,6 @@ require'lspconfig'.ts_ls.setup{
     "typescript.glimmer"
   },
 }
-
--- You must make sure volar is setup
--- e.g. require'lspconfig'.volar.setup{}
--- See volar's section for more information
 ```
 
 `location` MUST be defined. If the plugin is installed in `node_modules`,

--- a/lua/lspconfig/configs/ts_ls.lua
+++ b/lua/lspconfig/configs/ts_ls.lua
@@ -75,6 +75,7 @@ require'lspconfig'.ts_ls.setup{
 -- e.g. require'lspconfig'.volar.setup{}
 -- See volar's section for more information
 ```
+
 `location` MUST be defined. If the plugin is installed in `node_modules`,
 `location` can have any value.
 

--- a/lua/lspconfig/configs/ts_ls.lua
+++ b/lua/lspconfig/configs/ts_ls.lua
@@ -82,6 +82,35 @@ require'lspconfig'.ts_ls.setup{
 `languages` must include `vue` even if it is listed in `filetypes`.
 
 `filetypes` is extended here to include Vue SFC.
+
+### Ember support
+
+```lua
+require'lspconfig'.ts_ls.setup{
+  init_options = {
+    plugins = {
+      {
+        name = "@glint/tsserver-plugin",
+        location = "/your/path/to/@glint/tsserver-plugin",
+        languages = {"javascript", "typescript", "typescript.glimmer", "javascript.glimmer"},
+      },
+    },
+  },
+  filetypes = {
+    "javascript",
+    "typescript",
+    "javascript.glimmer",
+    "typescript.glimmer"
+  },
+}
+
+-- You must make sure volar is setup
+-- e.g. require'lspconfig'.volar.setup{}
+-- See volar's section for more information
+```
+
+`location` MUST be defined. If the plugin is installed in `node_modules`,
+`location` can have any value.
 ]],
   },
 }

--- a/lua/lspconfig/configs/ts_ls.lua
+++ b/lua/lspconfig/configs/ts_ls.lua
@@ -70,7 +70,15 @@ require'lspconfig'.ts_ls.setup{
     "vue",
   },
 }
+
+-- You must make sure volar is setup
+-- e.g. require'lspconfig'.volar.setup{}
+-- See volar's section for more information
 ```
+`location` MUST be defined. If the plugin is installed in `node_modules`,
+`location` can have any value.
+`languages` must include `vue` even if it is listed in `filetypes`.
+`filetypes` is extended here to include Vue SFC.    
 ]],
   },
 }

--- a/lua/lspconfig/configs/ts_ls.lua
+++ b/lua/lspconfig/configs/ts_ls.lua
@@ -77,8 +77,10 @@ require'lspconfig'.ts_ls.setup{
 ```
 `location` MUST be defined. If the plugin is installed in `node_modules`,
 `location` can have any value.
+
 `languages` must include `vue` even if it is listed in `filetypes`.
-`filetypes` is extended here to include Vue SFC.    
+
+`filetypes` is extended here to include Vue SFC.
 ]],
   },
 }


### PR DESCRIPTION
idk if we just want instructions here? because we can do a lot better with the `on_new_config` hook.

Here is what I do in my own configs:
```lua
    if (serverName == 'ts_ls') then
      local filetypes = {
        'typescript',
        'javascript',
        'typescript.glimmer',
        'javascript.glimmer',
        'typescript.tsx',
        'javascript.jsx',
        'html.handlebars',
        'handlebars',
      }
      server.setup({
        -- filetypes MUST include our custom filetypes for all variants of TS that we might want to use
        -- else the server won't boot and on_new_config won't get called, so we can't conditionally
        -- configure the init_options based on our project
        filetypes = filetypes,
        root_dir = utils.is_ts_project,
        capabilities = capabilities,
        -- This allows us to switch types of TSServers based on the open file.
        -- We don't always need the @glint/tsserver-plugin -- for example, in backend projects.
        on_new_config = function(new_config, new_root_dir)
          local info = utils.read_nearest_ts_config(new_root_dir)
          local glintPlugin = new_root_dir .. "node_modules/@glint/tsserver-plugin"

          if new_config.init_options then
            new_config.init_options.tsdk = get_typescript_server_path(new_root_dir)
            new_config.init_options.requestForwardingCommand = "forwardingTsRequest"


            if (info.isGlintPlugin) then
              new_config.init_options.plugins = {
                {
                  name = "@glint/tsserver-plugin",
                  location = glintPlugin,
                  languages = filetypes,
                  enableForWorkspaceTypeScriptVersions = true,
                  configNamespace = "typescript"
                }
              }
              print(glintPlugin)
            end
          end
        end,
        init_options = {
          tsserver = { logVerbosity = 'verbose', trace = "verbose" },
          preferences = {
            disableAutomaticTypingAcquisition = true,
            importModuleSpecifierPreference = "relative",
            importModuleSpecifierEnding = "minimal",
          },
          plugins = {}
        },
        settings = mySettings[serverName],
        on_attach = function(client, bufnr)
          keymap(bufnr)
          conditional_features(client, bufnr)
        end
      })
```


this allows automatic swapping of the tsplugins based on package.json, tsconfig.json, and/or node_modules contents