### PR TITLE
feat(tailwindcss): map elixir and heex ft to phoenix-heex

### DIFF
--- a/lsp/tailwindcss.lua
+++ b/lsp/tailwindcss.lua
@@ -86,9 +86,11 @@ return {
       },
       includeLanguages = {
         eelixir = 'html-eex',
+        elixir = 'phoenix-heex',
         eruby = 'erb',
-        templ = 'html',
+        heex = 'phoenix-heex',
         htmlangular = 'html',
+        templ = 'html',
       },
     },
   },


### PR DESCRIPTION
tailwind-intellisense won't activate unless the filetype is detected as an HTML-based file. Elixir `.ex` files can have `~H` sigils with HEEX syntax inside or `~E` sigils with eelixir syntax inside. It's also typical to have `.html.heex` files entirely of HEEX syntax. Both of these are recognized in Elixir's treesitter injections.scm

tailwind-intellisense recognized html languages:
https://github.com/tailwindlabs/tailwindcss-intellisense/blob/db9768908e5f192a4ee9792eb640bf93caa89242/packages/tailwindcss-language-service/src/util/languages.ts#L3

nvim-treesitter heex support:
https://github.com/nvim-treesitter/nvim-treesitter/blob/066fd6505377e3fd4aa219e61ce94c2b8bdb0b79/queries/heex/highlights.scm

nvim-treesitter heex sigil injection:
https://github.com/nvim-treesitter/nvim-treesitter/blob/066fd6505377e3fd4aa219e61ce94c2b8bdb0b79/queries/elixir/injections.scm#L34C1-L39C36

nvim-treesitter eex sigil injection:
https://github.com/nvim-treesitter/nvim-treesitter/blob/066fd6505377e3fd4aa219e61ce94c2b8bdb0b79/queries/elixir/injections.scm#L34-L39