### PR TITLE
add missing lua/lspconfig/configs/ty.lua

### DIFF
--- a/lua/lspconfig/configs/ty.lua
+++ b/lua/lspconfig/configs/ty.lua
@@ -1,0 +1,20 @@
+-- lua/lspconfig/configs/ty.lua
+
+local util = require 'lspconfig.util'
+
+return {
+  default_config = {
+    cmd = { 'ty', 'server' },
+    filetypes = { 'python' },
+    root_dir = function(fname)
+      return util.root_pattern('ty.toml', 'pyproject.toml', '.git')(fname)
+    end,
+  },
+  docs = {
+    description = [[
+https://github.com/astral-sh/ty
+`ty`, a static type checker and language server for python.
+The language server can be installed with `uv`: `uv tool install ty`
+]],
+  },
+}


### PR DESCRIPTION
I see that configs under `lua/lspconfig/configs` are deprecated, but without it, we hit this error when trying to setup the server
```lua
require('lspconfig').ty.setup({})
```
![image](https://github.com/user-attachments/assets/a4e8b591-4472-42f9-a56a-ae0bd2af1788)

This file is missing as mentioned [here](https://github.com/neovim/nvim-lspconfig/pull/3842#issuecomment-2875235725)


Adding this file fixes it.

Info:
![image](https://github.com/user-attachments/assets/a4636cd9-c81f-43e9-b8b2-ccc0bb792113)


Any idea on how to solve it if not adding the file?

maybe related #3705 