### PR TITLE
feat: pyrefly

### DIFF
--- a/lsp/pyrefly.lua
+++ b/lsp/pyrefly.lua
@@ -1,0 +1,25 @@
+---@brief
+---
+--- https://pyrefly.org/
+---
+---`pyrefly`, a faster Python type checker written in Rust.
+--
+-- `pyrefly` is still in development, so please report any errors to
+-- our issues page at https://github.com/facebook/pyrefly/issues.
+
+return {
+  cmd = { 'pyrefly', 'lsp' },
+  filetypes = { 'python' },
+  root_markers = {
+    'pyrefly.toml',
+    'pyproject.toml',
+    'setup.py',
+    'setup.cfg',
+    'requirements.txt',
+    'Pipfile',
+    '.git',
+  },
+  on_exit = function(code, _, _)
+    vim.notify('Closing Pyrefly LSP exited with code: ' .. code, vim.log.levels.INFO)
+  end,
+}


### PR DESCRIPTION
Hello,

I'm part of the Pyrefly team at Meta, and we're working on a new language server/type checker (called Pyrefly 😄, [website](https://pyrefly.org/), [github](https://github.com/facebook/pyrefly)) to replace our other Python language server, Pyre. Pyre isn't fully ready to be deprecated yet, but we just made our big announcement at PyCon this year, and are excited for users to test it out.

I've been using it in NeoVim so far, and would love to make it easy for others to use. Please let me know if there's anything else you would need from me to get this working!