### PR TITLE
fix(gh_actions_ls): use `root_dir` and add `init_options`

### DIFF
--- a/lsp/gh_actions_ls.lua
+++ b/lsp/gh_actions_ls.lua
@@ -15,14 +15,21 @@
 --- ```
 return {
   cmd = { 'gh-actions-language-server', '--stdio' },
-  -- the `root_markers` with `workspace_required` prevent attaching to every yaml file
   filetypes = { 'yaml' },
-  root_markers = {
-    '.github/workflows',
-    '.forgejo/workflows',
-    '.gitea/workflows',
-  },
-  workspace_required = true,
+
+  -- `root_dir` ensures that the LSP does not attach to all yaml files
+  root_dir = function(bufnr, on_dir)
+    local parent = vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr))
+    if
+      vim.endswith(parent, '/.github/workflows')
+      or vim.endswith(parent, '/.forgejo/workflows')
+      or vim.endswith(parent, '/.gitea/workflows')
+    then
+      on_dir(parent)
+    end
+  end,
+
+  init_options = {}, -- needs to be present https://github.com/neovim/nvim-lspconfig/pull/3713#issuecomment-2857394868
   capabilities = {
     workspace = {
       didChangeWorkspaceFolders = {


### PR DESCRIPTION
1. Replace `root_markers` and `workspace_required = true` with a `root_dir` function that checks the file is located in the correct location. This prevents some edge cases where the LSP would still attach to non-workflow files. This also makes unnecessary to use a `yaml.github` filetype, [as the readme of the lsp describes](https://github.com/lttb/gh-actions-language-server?tab=readme-ov-file#add-yamlgithub-filetype-detection).
2. add an empty `init_options` table, since such a table is apparently needed by the LSP: https://github.com/neovim/nvim-lspconfig/pull/3713#issuecomment-2857394868