### PR TITLE
fix(gopls): schedule vim.notify in on_exit

### DIFF
--- a/lsp/gopls.lua
+++ b/lsp/gopls.lua
@@ -36,7 +36,9 @@ return {
         end
         on_dir(get_root(fname))
       else
-        vim.notify(('[gopls] cmd failed with code %d: %s\n%s'):format(output.code, cmd, output.stderr))
+        vim.schedule(function()
+          vim.notify(('[gopls] cmd failed with code %d: %s\n%s'):format(output.code, cmd, output.stderr))
+        end)
       end
     end)
   end,


### PR DESCRIPTION
fix #3841

This fixes the following error

> E5560: nvim_echo must not be called in a fast event context

when gopls fails.

Similar to commit 48f4475 / PR #3793.

PS long term I think it's best to do something like https://github.com/neovim/neovim/pull/21288/commits/a4100e107242f773937f229c3ae84e4112259213 instead.