### PR TITLE
fix(nushell): avoid nil root_dir (reapply #3611)

### DIFF
--- a/lsp/nushell.lua
+++ b/lsp/nushell.lua
@@ -6,5 +6,7 @@
 return {
   cmd = { 'nu', '--lsp' },
   filetypes = { 'nu' },
-  root_markers = { '.git' },
+  root_dir = function(bufnr, cb)
+    cb(vim.fs.root(bufnr, { '.git' }) or vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr)))
+  end,
 }


### PR DESCRIPTION
Simplified `lsp/nushell.lua` unfortunately triggered the problem with the lsp server again.