### PR TITLE
[feat] add OpenTofu language server

### DIFF
--- a/lsp/tofu_ls.lua
+++ b/lsp/tofu_ls.lua
@@ -1,0 +1,9 @@
+---@brief
+---
+--- [OpenTofu Language Server](https://github.com/opentofu/tofu-ls)
+---
+return {
+  cmd = { 'tofu-ls', 'serve' },
+  filetypes = { 'opentofu', 'opentofu-vars' },
+  root_markers = { '.terraform', '.git' },
+}


### PR DESCRIPTION
Add [OpenTofu language server](https://github.com/opentofu/tofu-ls).
[OpenTofu](https://opentofu.org/) is a [FOSS fork of Terraform](https://opentofu.org/blog/the-opentofu-fork-is-now-available/).

- Related  [mason-registry  MR]( https://github.com/mason-org/mason-registry/pull/10233)
- Related [nvim-lint MR](https://github.com/mfussenegger/nvim-lint/pull/801)