### PR TITLE
fix(tailwindcss): only attach to existing files

### DIFF
--- a/lsp/tailwindcss.lua
+++ b/lsp/tailwindcss.lua
@@ -132,8 +132,10 @@ return {
       'app/assets/tailwind/application.css',
     }
     local fname = vim.api.nvim_buf_get_name(bufnr)
-    root_files = util.insert_package_json(root_files, 'tailwindcss', fname)
-    root_files = util.root_markers_with_field(root_files, { 'mix.lock' }, 'tailwind', fname)
-    on_dir(vim.fs.dirname(vim.fs.find(root_files, { path = fname, upward = true })[1]))
+    if vim.uv.fs_stat(fname) ~= nil then
+      root_files = util.insert_package_json(root_files, 'tailwindcss', fname)
+      root_files = util.root_markers_with_field(root_files, { 'mix.lock' }, 'tailwind', fname)
+      on_dir(vim.fs.dirname(vim.fs.find(root_files, { path = fname, upward = true })[1]))
+    end
   end,
 }


### PR DESCRIPTION
The tailwind LSP behaves poorly when attaching to "virtual" buffers. I've noticed that it gets stuck with 100% CPU usage when using the "virtual buffers" from [diffview](https://github.com/sindrets/diffview.nvim) (i.e., via `:DiffviewOpen`).

I thought about reporting this issue upstream (tailwind), but I decided to first open a PR here to get some thoughts. There's a related [issue](https://github.com/neovim/neovim/issues/32074) on neovim, and I understand that the current method to handle conditional attaching is using the `root_dir` function, but so far I haven't seen any configs using this trick, so I'm not sure if it's welcome here.