### PR TITLE
fix(eslint): LspEslintFixAll not running sync

### DIFF
--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -48,12 +48,9 @@ return {
     'astro',
   },
   workspace_required = true,
-  on_attach = function(client)
+  on_attach = function(client, bufnr)
     vim.api.nvim_buf_create_user_command(0, 'LspEslintFixAll', function()
-      local bufnr = vim.api.nvim_get_current_buf()
-
-      client:exec_cmd({
-        title = 'Fix all Eslint errors for current buffer',
+      client:request_sync('workspace/executeCommand', {
         command = 'eslint.applyAllFixes',
         arguments = {
           {
@@ -61,7 +58,7 @@ return {
             version = lsp.util.buf_versions[bufnr],
           },
         },
-      }, { bufnr = bufnr })
+      }, nil, bufnr)
     end, {})
   end,
   -- https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats


### PR DESCRIPTION
This fixes the problem described [here](https://github.com/neovim/nvim-lspconfig/issues/3837#issuecomment-2901107052). The new `LspEslintFixAll` writes the changes after save.