### PR TITLE
fix(emmet_ls, emmet_language_server): standardized configs across both emmet lsps

### DIFF
--- a/lsp/emmet_language_server.lua
+++ b/lsp/emmet_language_server.lua
@@ -9,17 +9,21 @@
 return {
   cmd = { 'emmet-language-server', '--stdio' },
   filetypes = {
+    'astro',
     'css',
     'eruby',
     'html',
+    'htmlangular',
     'htmldjango',
     'javascriptreact',
     'less',
     'pug',
     'sass',
     'scss',
+    'svelte',
+    'templ',
     'typescriptreact',
-    'htmlangular',
+    'vue',
   },
   root_markers = { '.git' },
 }

--- a/lsp/emmet_ls.lua
+++ b/lsp/emmet_ls.lua
@@ -13,6 +13,7 @@ return {
     'css',
     'eruby',
     'html',
+    'htmlangular',
     'htmldjango',
     'javascriptreact',
     'less',
@@ -20,9 +21,9 @@ return {
     'sass',
     'scss',
     'svelte',
+    'templ',
     'typescriptreact',
     'vue',
-    'htmlangular',
   },
   root_markers = { '.git' },
 }


### PR DESCRIPTION
Problem:
Both emmet LSPs had different configs despite being intended to target the same filetypes, both also lacked the 'templ' filetype

Solution:
Copy configs from one LSP to the other, add the 'templ' file extension to both LSPs