### PR TITLE
feat(helm_ls,yamlls): support custom filetype for helm-ls

### DIFF
--- a/lsp/helm_ls.lua
+++ b/lsp/helm_ls.lua
@@ -11,7 +11,7 @@
 --- If need Helm file highlight use [vim-helm](https://github.com/towolf/vim-helm) plugin.
 return {
   cmd = { 'helm_ls', 'serve' },
-  filetypes = { 'helm' },
+  filetypes = { 'helm', 'yaml.helm-values' },
   root_markers = { 'Chart.yaml' },
   capabilities = {
     workspace = {

--- a/lsp/yamlls.lua
+++ b/lsp/yamlls.lua
@@ -60,7 +60,7 @@
 --- ```
 return {
   cmd = { 'yaml-language-server', '--stdio' },
-  filetypes = { 'yaml', 'yaml.docker-compose', 'yaml.gitlab' },
+  filetypes = { 'yaml', 'yaml.docker-compose', 'yaml.gitlab', 'yaml.helm-values' },
   root_markers = { '.git' },
   settings = {
     -- https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting


### PR DESCRIPTION
this adds config for starting helm_ls and yamlls with the new filetype yaml.helm-values that will be added to the neovim helm_ls extension by https://github.com/qvalentin/helm-ls.nvim/pull/8

Files of this type should have both yamlls and helm-ls running. This is required because helm-ls now supports editing values.yaml files but should only be active for certain yaml files.