### PR TITLE
Add Postcss for Django

### DIFF
--- a/lsp/tailwindcss.lua
+++ b/lsp/tailwindcss.lua
@@ -127,6 +127,7 @@ return {
       'theme/static_src/tailwind.config.cjs',
       'theme/static_src/tailwind.config.mjs',
       'theme/static_src/tailwind.config.ts',
+      'theme/static_src/postcss.config.js',
       -- Rails
       'app/assets/stylesheets/application.tailwind.css',
       'app/assets/tailwind/application.css',


### PR DESCRIPTION
The new `django-tailwind` package comes with the Tailwind CSS 4 by default, which migrated to the `postcss.config.js`.

Add the `theme/static_src/postcss.config.js`.