### PR TITLE
fix(clangd): set offset_encoding correctly

### DIFF
--- a/lsp/clangd.lua
+++ b/lsp/clangd.lua
@@ -57,6 +57,9 @@ local function symbol_info()
   end, bufnr)
 end
 
+---@class ClangdInitializeResult: lsp.InitializeResult
+---@field offsetEncoding? string
+
 return {
   cmd = { 'clangd' },
   filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda', 'proto' },
@@ -77,6 +80,13 @@ return {
     },
     offsetEncoding = { 'utf-8', 'utf-16' },
   },
+  ---@param client vim.lsp.Client
+  ---@param init_result ClangdInitializeResult
+  on_init = function(client, init_result)
+    if init_result.offsetEncoding then
+      client.offset_encoding = init_result.offsetEncoding
+    end
+  end,
   on_attach = function()
     vim.api.nvim_buf_create_user_command(0, 'LspClangdSwitchSourceHeader', function()
       switch_source_header(0)


### PR DESCRIPTION
Problem:
Neovim's native `Client:initialize` implementation does not support clangd's [utf8 offsets extension](https://clangd.llvm.org/extensions#utf-8-offsets), resulting in an inconsistency in `offsetEncoding` between clangd and Neovim when using `vim.lsp.config`.

Solution:
Add a custom `on_init` to set the `offset_encoding` correctly.

Fix https://github.com/neovim/neovim/issues/34203