### PR TITLE
fix: restore :LspStart/LspStop behaviour without arguments

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -112,9 +112,7 @@ if vim.version.ge(vim.version(), { 0, 11, 2 }) then
       end
     end
 
-    for _, name in ipairs(servers) do
-      vim.lsp.enable(name)
-    end
+    vim.lsp.enable(servers)
   end, {
     desc = 'Enable and launch a language server',
     nargs = '?',


### PR DESCRIPTION
### Description

After the refactoring in e4d1c8b for Neovim 0.11.2 these commands now require an argument.

This restores the previous behaviour where `:LspStart` defaults to enabling all servers matching the filetype of the current buffer, and `:LspStop` defaults to disabling all servers attached to the current buffer.

### Context

- https://github.com/neovim/nvim-lspconfig/pull/3734
- https://github.com/neovim/neovim/discussions/33978
- https://github.com/neovim/neovim/issues/28479#issuecomment-2941615809

fix #3892
