### PR TITLE
fix: support :LspRestart without arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Most of the time, the reason for failure is present in the logs.
 * `:LspInfo` (alias to `:checkhealth vim.lsp`) shows the status of active and configured language servers.
 * `:LspStart <config_name>` Start the requested server name. Will only successfully start if the command detects a root directory matching the current config.
 * `:LspStop [<client_id_or_name> ...]` Stops the given server(s). Defaults to stopping all servers active on the current buffer. To force stop add `++force`
-* `:LspRestart [<client_id_or_name> ...]` Restarts the given client(s), and attempts to reattach to all previously attached buffers.
+* `:LspRestart [<client_id_or_name> ...]` Restarts the given client(s), and attempts to reattach to all previously attached buffers. Defaults to restarting all active servers.
 
 ## Contributions
 

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -93,7 +93,8 @@ servers: >vim
 
 :LspRestart [client_id] or [config_name] ...                     *:LspRestart*
 Restarts the clients with the given client-ids or config names, and attempts
-to reattach to all previously attached buffers.
+to reattach to all previously attached buffers. Defaults to restarting all
+active servers.
 
 ==============================================================================
 SERVER CONFIGS                                        *lspconfig-configurations*


### PR DESCRIPTION
### Description

Problem:
After the refactoring in e4d1c8b for Neovim 0.11.2 this command now requires an argument.

Solution:
Restore the previous behaviour where `:LspRestart` defaults to restarting all active servers.

### Context

- Follow-up to https://github.com/neovim/nvim-lspconfig/pull/3890
- Fixes https://github.com/neovim/nvim-lspconfig/issues/3892