### PR TITLE
chore: don't accept multiple arguments in :LspStop/LspRestart

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ Most of the time, the reason for failure is present in the logs.
 
 * `:LspInfo` (alias to `:checkhealth vim.lsp`) shows the status of active and configured language servers.
 * `:LspStart <config_name>` Start the requested server name. Will only successfully start if the command detects a root directory matching the current config.
-* `:LspStop [<client_id_or_name> ...]` Stops the given server(s). Defaults to stopping all servers active on the current buffer. To force stop add `++force`
-* `:LspRestart [<client_id_or_name> ...]` Restarts the given client(s), and attempts to reattach to all previously attached buffers. Defaults to restarting all active servers.
+* `:LspStop [<client_id_or_name>]` Stops the given server. Defaults to stopping all servers active on the current buffer. To force stop add `++force`
+* `:LspRestart [<client_id_or_name>]` Restarts the given client, and attempts to reattach to all previously attached buffers. Defaults to restarting all active servers.
 
 ## Contributions
 

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -85,14 +85,14 @@ Launches the requested (configured) client, but only if it successfully
 resolves a root directory. Note: Defaults to all configured servers matching
 the current buffer filetype.
 
-:LspStop [client_id] or [config_name] ...                        *:LspStop*
-Stops the servers with the given client-ids or config names. Defaults to
+:LspStop [client_id] or [config_name]                            *:LspStop*
+Stops the server with the given client-id or config name. Defaults to
 stopping all servers active on the current buffer. To force stop language
 servers: >vim
     :LspStop ++force
 
-:LspRestart [client_id] or [config_name] ...                     *:LspRestart*
-Restarts the clients with the given client-ids or config names, and attempts
+:LspRestart [client_id] or [config_name]                         *:LspRestart*
+Restarts the client with the given client-id or config name, and attempts
 to reattach to all previously attached buffers. Defaults to restarting all
 active servers.
 

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -149,8 +149,8 @@ if vim.version.ge(vim.version(), { 0, 11, 2 }) then
       end
     end)
   end, {
-    desc = 'Restart the given client(s)',
-    nargs = '*',
+    desc = 'Restart the given client',
+    nargs = '?',
     complete = complete_client,
   })
 
@@ -175,8 +175,8 @@ if vim.version.ge(vim.version(), { 0, 11, 2 }) then
       end
     end
   end, {
-    desc = 'Disable and stop the given client(s)',
-    nargs = '*',
+    desc = 'Disable and stop the given client',
+    nargs = '?',
     complete = complete_client,
   })
 


### PR DESCRIPTION
### Description

We don't want to support multiple arguments in the upcoming `:Lsp` multi-command, so remove this now from `:LspStop` and `:LspRestart`.

### Context

- Follow-up from https://github.com/neovim/nvim-lspconfig/pull/3890#discussion_r2132402506