### PR TITLE
fix(svelte): only attach to existing files

### DIFF
--- a/lsp/svelte.lua
+++ b/lsp/svelte.lua
@@ -12,7 +12,14 @@
 return {
   cmd = { 'svelteserver', '--stdio' },
   filetypes = { 'svelte' },
-  root_markers = { 'package.json', '.git' },
+  root_dir = function(bufnr, on_dir)
+    local root_files = { 'package.json', '.git' }
+    local fname = vim.api.nvim_buf_get_name(bufnr)
+    -- Svelte LSP only supports file:// schema. https://github.com/sveltejs/language-tools/issues/2777
+    if vim.uv.fs_stat(fname) ~= nil then
+      on_dir(vim.fs.dirname(vim.fs.find(root_files, { path = fname, upward = true })[1]))
+    end
+  end,
   on_attach = function(client, bufnr)
     vim.api.nvim_buf_create_user_command(bufnr, 'LspMigrateToSvelte5', function()
       client:exec_cmd({


### PR DESCRIPTION
Similar to #3875, but this time I [checked](https://github.com/sveltejs/language-tools/issues/2777), and the server actually doesn't support schemas other than `file://`.