### PR TITLE
feat(glint): add vim.lsp.config support

### DIFF
--- a/lsp/glint.lua
+++ b/lsp/glint.lua
@@ -1,0 +1,63 @@
+---@brief
+---
+--- https://github.com/typed-ember/glint
+--- https://typed-ember.gitbook.io/glint/
+--- `glint-language-server` is installed when adding `@glint/core` to your project's devDependencies:
+---
+--- ```sh
+--- npm install @glint/core --save-dev
+--- yarn add -D @glint/core
+---
+--- This configuration uses the local installation of `glint-language-server`
+--- (found in the `node_modules` directory of your project).
+---
+--- To use a global installation of `glint-language-server`,
+--- set the `init_options.glint.useGlobal` to `true`.
+---
+--- vim.lsp.config('glint', {
+---   init_options = {
+---     glint = {
+---       useGlobal = true,
+---     },
+---   },
+--- })
+
+return {
+  cmd = { 'glint-language-server' },
+  init_options = {
+    glint = {
+      useGlobal = false,
+    },
+  },
+  before_init = function(_, config)
+    if config.init_options.glint.useGlobal then
+      return
+    end
+
+    local root_dir = config.root_dir
+    if not root_dir then
+      error('No root directory found for glint')
+    end
+    config.cmd = {
+      'exec',
+      root_dir .. '/node_modules/.bin/glint-language-server',
+    }
+  end,
+  filetypes = {
+    'html.handlebars',
+    'handlebars',
+    'typescript',
+    'typescript.glimmer',
+    'javascript',
+    'javascript.glimmer',
+  },
+  root_markers = {
+    '.glintrc.yml',
+    '.glintrc',
+    '.glintrc.json',
+    '.glintrc.js',
+    'glint.config.js',
+    'package.json',
+  },
+  workspace_required = true,
+}


### PR DESCRIPTION
Saw this one was still missing in the list in #3705.

I tested it by creating a new ember ts project -> `ember new my-typescript-app --typescript`
then adding glint to that project -> `npm install --save-dev @glint/core`

Per default we use the project local glint-language-server, but the user can also choose to use a globally installed version.

Based on [lua/lspconfig/configs/glint.lua](https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/configs/glint.lua)