### PR TITLE
feat(biome): add `html` as filetype

### DIFF
--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -15,6 +15,7 @@ return {
     'astro',
     'css',
     'graphql',
+    'html',
     'javascript',
     'javascriptreact',
     'json',


### PR DESCRIPTION
the latest release of biome adds preliminary support for formatting html files: https://biomejs.dev/blog/biome-v2/#html-formatter

Thus, html should be added to the list of filetypes for the biome LSP.