### PR TITLE
fix(powershell_es): update LogLevel to Information

### DIFF
--- a/lsp/powershell_es.lua
+++ b/lsp/powershell_es.lua
@@ -44,7 +44,7 @@ return {
     local shell = vim.lsp.config.powershell_es.shell or 'pwsh'
 
     local command_fmt =
-      [[& '%s/PowerShellEditorServices/Start-EditorServices.ps1' -BundledModulesPath '%s' -LogPath '%s/powershell_es.log' -SessionDetailsPath '%s/powershell_es.session.json' -FeatureFlags @() -AdditionalModules @() -HostName nvim -HostProfileId 0 -HostVersion 1.0.0 -Stdio -LogLevel Normal]]
+      [[& '%s/PowerShellEditorServices/Start-EditorServices.ps1' -BundledModulesPath '%s' -LogPath '%s/powershell_es.log' -SessionDetailsPath '%s/powershell_es.session.json' -FeatureFlags @() -AdditionalModules @() -HostName nvim -HostProfileId 0 -HostVersion 1.0.0 -Stdio -LogLevel Information]]
     local command = command_fmt:format(bundle_path, bundle_path, temp_path, temp_path)
     local cmd = { shell, '-NoLogo', '-NoProfile', '-Command', command }
 


### PR DESCRIPTION
LogLevel `Normal` of PowerShellEditorServices has been removed by the commit https://github.com/PowerShell/PowerShellEditorServices/commit/d9de5bd8b1ed624a687d701fa2616e5991db2e2c
The corresponding value after the change is `Information = 2`.
