### PR TITLE
fix: some `on_attach` callbacks may create commands in a wrong buffer

### DIFF
--- a/lsp/basedpyright.lua
+++ b/lsp/basedpyright.lua
@@ -50,7 +50,7 @@ return {
       desc = 'Organize Imports',
     })
 
-    vim.api.nvim_buf_create_user_command(0, 'LspPyrightSetPythonPath', set_python_path, {
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspPyrightSetPythonPath', set_python_path, {
       desc = 'Reconfigure basedpyright with the provided python path',
       nargs = 1,
       complete = 'file',

--- a/lsp/ccls.lua
+++ b/lsp/ccls.lua
@@ -44,9 +44,9 @@ return {
   offset_encoding = 'utf-32',
   -- ccls does not support sending a null root directory
   workspace_required = true,
-  on_attach = function(client)
-    vim.api.nvim_buf_create_user_command(0, 'LspCclsSwitchSourceHeader', function()
-      switch_source_header(client, 0)
+  on_attach = function(client, bufnr)
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspCclsSwitchSourceHeader', function()
+      switch_source_header(client, bufnr)
     end, { desc = 'Switch between source/header' })
   end,
 }

--- a/lsp/clangd.lua
+++ b/lsp/clangd.lua
@@ -87,12 +87,12 @@ return {
       client.offset_encoding = init_result.offsetEncoding
     end
   end,
-  on_attach = function()
-    vim.api.nvim_buf_create_user_command(0, 'LspClangdSwitchSourceHeader', function()
-      switch_source_header(0)
+  on_attach = function(_, bufnr)
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspClangdSwitchSourceHeader', function()
+      switch_source_header(bufnr)
     end, { desc = 'Switch between source/header' })
 
-    vim.api.nvim_buf_create_user_command(0, 'LspClangdShowSymbolInfo', function()
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspClangdShowSymbolInfo', function()
       symbol_info()
     end, { desc = 'Show symbol info' })
   end,

--- a/lsp/denols.lua
+++ b/lsp/denols.lua
@@ -93,7 +93,7 @@ return {
     ['textDocument/references'] = denols_handler,
   },
   on_attach = function(client, bufnr)
-    vim.api.nvim_buf_create_user_command(0, 'LspDenolsCache', function()
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspDenolsCache', function()
       client:exec_cmd({
         command = 'deno.cache',
         arguments = { {}, vim.uri_from_bufnr(bufnr) },

--- a/lsp/ds_pinyin_lsp.lua
+++ b/lsp/ds_pinyin_lsp.lua
@@ -55,12 +55,12 @@ return {
     match_long_input = true,
     max_suggest = 15,
   },
-  on_attach = function()
-    vim.api.nvim_buf_create_user_command(0, 'LspDsPinyinCompletionOff', function()
-      ds_pinyin_lsp_off(0)
+  on_attach = function(_, bufnr)
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspDsPinyinCompletionOff', function()
+      ds_pinyin_lsp_off(bufnr)
     end, { desc = 'Turn off the ds-pinyin-lsp completion' })
-    vim.api.nvim_buf_create_user_command(0, 'LspDsPinyinCompletionOn', function()
-      ds_pinyin_lsp_on(0)
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspDsPinyinCompletionOn', function()
+      ds_pinyin_lsp_on(bufnr)
     end, { desc = 'Turn on the ds-pinyin-lsp completion' })
   end,
 }

--- a/lsp/julials.lua
+++ b/lsp/julials.lua
@@ -120,8 +120,8 @@ return {
   cmd = cmd,
   filetypes = { 'julia' },
   root_markers = root_files,
-  on_attach = function()
-    vim.api.nvim_buf_create_user_command(0, 'LspJuliaActivateEnv', activate_env, {
+  on_attach = function(_, bufnr)
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspJuliaActivateEnv', activate_env, {
       desc = 'Activate a Julia environment',
       nargs = '?',
       complete = 'file',

--- a/lsp/markdown_oxide.lua
+++ b/lsp/markdown_oxide.lua
@@ -12,18 +12,18 @@ return {
   root_markers = { '.git', '.obsidian', '.moxide.toml' },
   filetypes = { 'markdown' },
   cmd = { 'markdown-oxide' },
-  on_attach = function()
-    vim.api.nvim_buf_create_user_command(0, 'LspToday', function()
+  on_attach = function(_, bufnr)
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspToday', function()
       vim.lsp.buf.execute_command { command = 'jump', arguments = { 'today' } }
     end, {
       desc = "Open today's daily note",
     })
-    vim.api.nvim_buf_create_user_command(0, 'LspTomorrow', function()
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspTomorrow', function()
       vim.lsp.buf.execute_command { command = 'jump', arguments = { 'tomorrow' } }
     end, {
       desc = "Open tomorrow's daily note",
     })
-    vim.api.nvim_buf_create_user_command(0, 'LspYesterday', function()
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspYesterday', function()
       vim.lsp.buf.execute_command { command = 'jump', arguments = { 'yesterday' } }
     end, {
       desc = "Open yesterday's daily note",

--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -111,9 +111,9 @@ return {
       init_params.initializationOptions = config.settings['rust-analyzer']
     end
   end,
-  on_attach = function()
-    vim.api.nvim_buf_create_user_command(0, 'LspCargoReload', function()
-      reload_workspace(0)
+  on_attach = function(_, bufnr)
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspCargoReload', function()
+      reload_workspace(bufnr)
     end, { desc = 'Reload current cargo workspace' })
   end,
 }

--- a/lsp/svlangserver.lua
+++ b/lsp/svlangserver.lua
@@ -34,11 +34,11 @@ return {
       includeIndexing = { '*.{v,vh,sv,svh}', '**/*.{v,vh,sv,svh}' },
     },
   },
-  on_attach = function()
-    vim.api.nvim_buf_create_user_command(0, 'LspSvlangserverBuildIndex', build_index, {
+  on_attach = function(_, bufnr)
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspSvlangserverBuildIndex', build_index, {
       desc = 'Instructs language server to rerun indexing',
     })
-    vim.api.nvim_buf_create_user_command(0, 'LspSvlangserverReportHierarchy', report_hierarchy, {
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspSvlangserverReportHierarchy', report_hierarchy, {
       desc = 'Generates hierarchy for the given module',
     })
   end,

--- a/lsp/texlab.lua
+++ b/lsp/texlab.lua
@@ -192,29 +192,29 @@ return {
       formatterLineLength = 80,
     },
   },
-  on_attach = function()
-    vim.api.nvim_buf_create_user_command(0, 'LspTexlabBuild', client_with_fn(buf_build), {
+  on_attach = function(_, buf)
+    vim.api.nvim_buf_create_user_command(buf, 'LspTexlabBuild', client_with_fn(buf_build), {
       desc = 'Build the current buffer',
     })
-    vim.api.nvim_buf_create_user_command(0, 'LspTexlabForward', client_with_fn(buf_search), {
+    vim.api.nvim_buf_create_user_command(buf, 'LspTexlabForward', client_with_fn(buf_search), {
       desc = 'Forward search from current position',
     })
-    vim.api.nvim_buf_create_user_command(0, 'LspTexlabCancelBuild', client_with_fn(buf_cancel_build), {
+    vim.api.nvim_buf_create_user_command(buf, 'LspTexlabCancelBuild', client_with_fn(buf_cancel_build), {
       desc = 'Cancel the current build',
     })
-    vim.api.nvim_buf_create_user_command(0, 'LspTexlabDependencyGraph', client_with_fn(dependency_graph), {
+    vim.api.nvim_buf_create_user_command(buf, 'LspTexlabDependencyGraph', client_with_fn(dependency_graph), {
       desc = 'Show the dependency graph',
     })
-    vim.api.nvim_buf_create_user_command(0, 'LspTexlabCleanArtifacts', client_with_fn(command_factory('Artifacts')), {
+    vim.api.nvim_buf_create_user_command(buf, 'LspTexlabCleanArtifacts', client_with_fn(command_factory('Artifacts')), {
       desc = 'Clean the artifacts',
     })
-    vim.api.nvim_buf_create_user_command(0, 'LspTexlabCleanAuxiliary', client_with_fn(command_factory('Auxiliary')), {
+    vim.api.nvim_buf_create_user_command(buf, 'LspTexlabCleanAuxiliary', client_with_fn(command_factory('Auxiliary')), {
       desc = 'Clean the auxiliary files',
     })
-    vim.api.nvim_buf_create_user_command(0, 'LspTexlabFindEnvironments', client_with_fn(buf_find_envs), {
+    vim.api.nvim_buf_create_user_command(buf, 'LspTexlabFindEnvironments', client_with_fn(buf_find_envs), {
       desc = 'Find the environments at current position',
     })
-    vim.api.nvim_buf_create_user_command(0, 'LspTexlabChangeEnvironment', client_with_fn(buf_change_env), {
+    vim.api.nvim_buf_create_user_command(buf, 'LspTexlabChangeEnvironment', client_with_fn(buf_change_env), {
       desc = 'Change the environment at current position',
     })
   end,

--- a/lsp/tinymist.lua
+++ b/lsp/tinymist.lua
@@ -69,7 +69,7 @@ return {
       'tinymist.getDocumentMetrics',
     } do
       local cmd_func, cmd_name, cmd_desc = create_tinymist_command(command, client, bufnr)
-      vim.api.nvim_buf_create_user_command(0, cmd_name, cmd_func, { nargs = 0, desc = cmd_desc })
+      vim.api.nvim_buf_create_user_command(bufnr, cmd_name, cmd_func, { nargs = 0, desc = cmd_desc })
     end
   end,
 }

--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -97,10 +97,10 @@ return {
       return vim.NIL
     end,
   },
-  on_attach = function(client)
+  on_attach = function(client, bufnr)
     -- ts_ls provides `source.*` code actions that apply to the whole file. These only appear in
     -- `vim.lsp.buf.code_action()` if specified in `context.only`.
-    vim.api.nvim_buf_create_user_command(0, 'LspTypescriptSourceAction', function()
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspTypescriptSourceAction', function()
       local source_actions = vim.tbl_filter(function(action)
         return vim.startswith(action, 'source.')
       end, client.server_capabilities.codeActionProvider.codeActionKinds)

--- a/lsp/zk.lua
+++ b/lsp/zk.lua
@@ -26,8 +26,8 @@ return {
       desc = 'ZkIndex',
     })
 
-    vim.api.nvim_buf_create_user_command(0, 'LspZkList', function()
-      local bufpath = vim.api.nvim_buf_get_name(0)
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspZkList', function()
+      local bufpath = vim.api.nvim_buf_get_name(bufnr)
       local root = find_zk_root(bufpath)
 
       client:exec_cmd({

--- a/lua/lspconfig/configs/tinymist.lua
+++ b/lua/lspconfig/configs/tinymist.lua
@@ -50,7 +50,7 @@ return {
       return vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
     end,
     single_file_support = true,
-    on_attach = function(_)
+    on_attach = function(_, bufnr)
       for _, command in ipairs {
         'tinymist.exportSvg',
         'tinymist.exportPng',
@@ -66,7 +66,7 @@ return {
         'tinymist.getDocumentMetrics',
       } do
         local cmd_func, cmd_name, cmd_desc = create_tinymist_command(command)
-        vim.api.nvim_create_user_command(cmd_name, cmd_func, { nargs = 0, desc = cmd_desc })
+        vim.api.nvim_buf_create_user_command(bufnr, cmd_name, cmd_func, { nargs = 0, desc = cmd_desc })
       end
     end,
   },


### PR DESCRIPTION
This is a super simple fix, which addresses the bug that if a server is attached to a buffer other than the current one by means of `vim.lsp.buf_attach_client`, then the Language Server-related commands may be created in the current buffer, and not in the one the server has been attached to.

P. S. Does it need to be documented somewhere explicitly that the `on_attach` callback may not always be run within the context of the target buffer? There is an example of writing such a callback in `CONTRIBUTING.md` that correctly uses the `bufnr` passed in as the 2nd parameter, is this enough?