### PR TITLE
fix(powershell_es): update LogLevel to recognized value

### DIFF
--- a/lsp/powershell_es.lua
+++ b/lsp/powershell_es.lua
@@ -44,7 +44,7 @@ return {
     local shell = vim.lsp.config.powershell_es.shell or 'pwsh'
 
     local command_fmt =
-      [[& '%s/PowerShellEditorServices/Start-EditorServices.ps1' -BundledModulesPath '%s' -LogPath '%s/powershell_es.log' -SessionDetailsPath '%s/powershell_es.session.json' -FeatureFlags @() -AdditionalModules @() -HostName nvim -HostProfileId 0 -HostVersion 1.0.0 -Stdio -LogLevel Information]]
+      [[& '%s/PowerShellEditorServices/Start-EditorServices.ps1' -BundledModulesPath '%s' -LogPath '%s/powershell_es.log' -SessionDetailsPath '%s/powershell_es.session.json' -FeatureFlags @() -AdditionalModules @() -HostName nvim -HostProfileId 0 -HostVersion 1.0.0 -Stdio -LogLevel Normal]]
     local command = command_fmt:format(bundle_path, bundle_path, temp_path, temp_path)
     local cmd = { shell, '-NoLogo', '-NoProfile', '-Command', command }
 


### PR DESCRIPTION
Problem:
Powershell Editor Services does not recognize `-LogLevel Information` and this prevents the LSP from starting

Solution:
Revert update to `command_fmt` to use a recognized log level from [Start-EditorServices.ps1](https://github.com/PowerShell/PowerShellEditorServices/blob/3a429eac5544fd7613c281c0814f94ac03fad551/module/PowerShellEditorServices/Start-EditorServices.ps1)