### PR TITLE
fix(eslint): only call `on_dir` when root directory is found

### DIFF
--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -80,7 +80,11 @@ return {
 
     local fname = vim.api.nvim_buf_get_name(bufnr)
     root_file_patterns = util.insert_package_json(root_file_patterns, 'eslintConfig', fname)
-    on_dir(vim.fs.dirname(vim.fs.find(root_file_patterns, { path = fname, upward = true })[1]))
+    local root_dir = vim.fs.dirname(vim.fs.find(root_file_patterns, { path = fname, upward = true })[1])
+    if not root_dir then
+      return
+    end
+    on_dir(root_dir)
   end,
   -- Refer to https://github.com/Microsoft/vscode-eslint#settings-options for documentation.
   settings = {


### PR DESCRIPTION
Closes #3922 

This fixes "Unable to load ESLint library" errors in JavaScript projects without eslint.

The eslint config was calling `on_dir` unconditionally, but per neovim docs it should only be called when configuration files exist:

> To dynamically decide whether LSP is activated, define a [[lsp-root_dir()](https://neovim.io/doc/user/lsp.html#lsp-root_dir())](https://neovim.io/doc/user/lsp.html#lsp-root_dir()) function which calls on_dir() only when you want that config to activate

Now `on_dir` is only called when a valid root directory is found.