### PR TITLE
docs: Correct install command for pug lsp

### DIFF
--- a/lsp/pug.lua
+++ b/lsp/pug.lua
@@ -4,7 +4,7 @@
 ---
 --- An implementation of the Language Protocol Server for [Pug.js](http://pugjs.org)
 ---
---- PugLSP can be installed via `go get github.com/opa-oz/pug-lsp`, or manually downloaded from [releases page](https://github.com/opa-oz/pug-lsp/releases)
+--- PugLSP can be installed via `go install github.com/opa-oz/pug-lsp@latest`, or manually downloaded from [releases page](https://github.com/opa-oz/pug-lsp/releases)
 return {
   cmd = { 'pug-lsp' },
   filetypes = { 'pug' },

--- a/lua/lspconfig/configs/pug.lua
+++ b/lua/lspconfig/configs/pug.lua
@@ -12,7 +12,7 @@ https://github.com/opa-oz/pug-lsp
 
 An implementation of the Language Protocol Server for [Pug.js](http://pugjs.org)
 
-PugLSP can be installed via `go get github.com/opa-oz/pug-lsp`, or manually downloaded from [releases page](https://github.com/opa-oz/pug-lsp/releases)
+PugLSP can be installed via `go install github.com/opa-oz/pug-lsp@latest`, or manually downloaded from [releases page](https://github.com/opa-oz/pug-lsp/releases)
     ]],
   },
 }


### PR DESCRIPTION
Problem:
Installing the pug lsp using the suggested method (`go get github.com/opa-oz/pug-lsp`) does not work in the latest versions of `go` and instead produces a message the "'go get' is no longer supported outside a module".

Solution:
Change the install command for the pug lsp to the correct command which is `go install github.com/opa-oz/pug-lsp@latest`.