### PR TITLE
feat(pyright): added bypass for marker check for small single python files

### DIFF
--- a/lua/lspconfig/configs/pyright.lua
+++ b/lua/lspconfig/configs/pyright.lua
@@ -45,7 +45,12 @@ return {
     cmd = { 'pyright-langserver', '--stdio' },
     filetypes = { 'python' },
     root_dir = function(fname)
-      return util.root_pattern(unpack(root_files))(fname)
+      local home = vim.loop.os_homedir()
+      local root = util.root_pattern(unpack(root_files))(fname)
+      if root == nil or (root == home and vim.fn.fnamemodify(fname, ':h') ~= home) then
+        root = vim.fn.fnamemodify(fname, ':h')
+      end
+      return root
     end,
     single_file_support = true,
     settings = {


### PR DESCRIPTION
I was constantly running into issues where if I have a folder with a single python file for a quick test, and the pyright lsp starts searching for root_marker files.

It spikes the memory usage upto ~4gigs and throws the error as below.
```[ERROR][2025-06-23 13:35:08] ...p/_transport.lua:36 "rpc" "pyright-langserver" "stderr" "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory\n----- Native stack trace -----\n\n"```

And it was a small python file called test.py with just a print statment.
Hence created a small check where it checks for marker and if not found use the current directory as root directory instead of ~ .

