### PR TITLE
fix(phpactor): root markers precedence

### DIFF
--- a/lsp/phpactor.lua
+++ b/lsp/phpactor.lua
@@ -7,6 +7,6 @@
 return {
   cmd = { 'phpactor', 'language-server' },
   filetypes = { 'php' },
-  root_markers = { 'composer.json', '.git', '.phpactor.json', '.phpactor.yml' },
+  root_markers = { '.git', 'composer.json', '.phpactor.json', '.phpactor.yml' },
   workspace_required = true,
 }


### PR DESCRIPTION
Hello!

This fixes the precedence of root markers for phpactor. When opening a vendor file, a new lsp workspace was being created in the context of the vendor directory, which causes failures because there's no vendor/ directory in the workspace root and therefor the lsp cannot find any of the symbols.

Thanks!