### PR TITLE
fix(intelephense): change root markers order

### DIFF
--- a/lsp/intelephense.lua
+++ b/lsp/intelephense.lua
@@ -28,5 +28,5 @@
 return {
   cmd = { 'intelephense', '--stdio' },
   filetypes = { 'php' },
-  root_markers = { 'composer.json', '.git' },
+  root_markers = { '.git', 'composer.json' },
 }


### PR DESCRIPTION
See discussion: https://github.com/neovim/nvim-lspconfig/issues/3930#issuecomment-3018465294

Prioritize `.git` above the `composer.json`, as in PHP projects sometimes multiple composer.json files are used. 
Having `composer.json` above `.git` will prioritize the closest `composer.json`, leading into some unintended behavior when having multiple `composer.json` files within your project. 
(i.e. when using module strategy which each their own composer file)
The common strategy is to autoload these files in the root composer.json.

This will also resolve problems similar to this: 477f412973484b4de20ae70c142e28a5790936a5

This solve a bug introduced in fa91d1c

**References:**
Basic usage/placement of a composer.json file:
https://getcomposer.org/doc/01-basic-usage.md#composer-json-project-setup 
> To start using Composer in your project, all you need is a composer.json file. This file describes the dependencies of your project and may contain other metadata as well. It typically should go in the **top-most directory** of your project/VCS repository.

Autoloading strategy:
https://getcomposer.org/doc/01-basic-usage.md#autoloading

[phpactor](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/phpactor.lua) using the same approach for similar reason
