### PR TITLE
feat(tailwindcss): tailwind root_dir rails phoenix

### DIFF
--- a/lsp/tailwindcss.lua
+++ b/lsp/tailwindcss.lua
@@ -117,24 +117,16 @@ return {
       'postcss.config.cjs',
       'postcss.config.mjs',
       'postcss.config.ts',
-      -- Phoenix
-      'assets/tailwind.config.js',
-      'assets/tailwind.config.cjs',
-      'assets/tailwind.config.mjs',
-      'assets/tailwind.config.ts',
       -- Django
       'theme/static_src/tailwind.config.js',
       'theme/static_src/tailwind.config.cjs',
       'theme/static_src/tailwind.config.mjs',
       'theme/static_src/tailwind.config.ts',
       'theme/static_src/postcss.config.js',
-      -- Rails
-      'app/assets/stylesheets/application.tailwind.css',
-      'app/assets/tailwind/application.css',
     }
     local fname = vim.api.nvim_buf_get_name(bufnr)
     root_files = util.insert_package_json(root_files, 'tailwindcss', fname)
-    root_files = util.root_markers_with_field(root_files, { 'mix.lock' }, 'tailwind', fname)
+    root_files = util.root_markers_with_field(root_files, { 'mix.lock', 'Gemfile.lock' }, 'tailwind', fname)
     on_dir(vim.fs.dirname(vim.fs.find(root_files, { path = fname, upward = true })[1]))
   end,
 }


### PR DESCRIPTION
The location of the config in Rails and Phoenix does not represent the root of the project. We can look inside mix.lock and Gemfile.lock for the existence of tailwind, which guarantees that it is the root.