### PR TITLE
feat(eslint): add htmlangular to supported filetypes

### DIFF
--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -46,6 +46,7 @@ return {
     'vue',
     'svelte',
     'astro',
+    'htmlangular',
   },
   workspace_required = true,
   on_attach = function(client, bufnr)


### PR DESCRIPTION
Adds `htmlangular` to eslint's supported filetypes to enable linting for angular template .hml files.