### PR TITLE
feat(ts_ls): implement code lens support

### DIFF
--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -97,6 +97,32 @@ return {
       return vim.NIL
     end,
   },
+  commands = {
+    ['editor.action.showReferences'] = function(command, ctx)
+      local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
+      local file_uri, position, references = unpack(command.arguments)
+
+      local quickfix_items = vim.lsp.util.locations_to_items(references, client.offset_encoding)
+      vim.fn.setqflist({}, ' ', {
+        title = command.title,
+        items = quickfix_items,
+        context = {
+          command = command,
+          bufnr = ctx.bufnr,
+        },
+      })
+
+      vim.lsp.util.show_document({
+        uri = file_uri,
+        range = {
+          start = position,
+          ['end'] = position,
+        },
+      }, client.offset_encoding)
+
+      vim.cmd('botright copen')
+    end,
+  },
   on_attach = function(client, bufnr)
     -- ts_ls provides `source.*` code actions that apply to the whole file. These only appear in
     -- `vim.lsp.buf.code_action()` if specified in `context.only`.


### PR DESCRIPTION
Implement the `editor.action.showReferences` client command, which is used by the references and implementation code lenses that TypeScript Language Server provides.[^1]
I've mostly based the implementation on the existing code for `vim.lsp.buf.references()`. The main visible difference is that the latter includes the item being referenced at the top of the list. Although, if desired, this could be emulated by manually inserting the position passed along in the command arguments at the top of the list.

[^1]: https://github.com/typescript-language-server/typescript-language-server?tab=readme-ov-file#code-lenses-textdocumentcodelens