### PR TITLE
feat: add `autopkgtest` file type to `debputy.lua`

### DIFF
--- a/lsp/debputy.lua
+++ b/lsp/debputy.lua
@@ -5,6 +5,6 @@
 --- Language Server for Debian packages.
 return {
   cmd = { 'debputy', 'lsp', 'server' },
-  filetypes = { 'debcontrol', 'debcopyright', 'debchangelog', 'make', 'yaml' },
+  filetypes = { 'debcontrol', 'debcopyright', 'debchangelog', 'autopkgtest', 'make', 'yaml' },
   root_markers = { 'debian' },
 }


### PR DESCRIPTION
The `vim-debian` project added `autopkgtest` as id for the `debian/tests/control`. The `debputy` project supports that file under a different file type ID, but will align with `vim-debian` in the next release of `debputy`.

The `vim-debian` project adding the file type:
 * https://salsa.debian.org/vim-team/vim-debian/-/commit/14776de4f28f82177ef6e2397510d01b266f3b41
 * https://salsa.debian.org/vim-team/vim-debian/-/commit/d6363b31dd8baa75d8a70d63301b808583848214

The `debputy` project aligning on the file type ID:
 * https://salsa.debian.org/vim-team/vim-debian/-/commit/d6363b31dd8baa75d8a70d63301b808583848214