### PR TITLE
fix(vue_ls): missing config table, suspress message

### DIFF
--- a/lsp/vue_ls.lua
+++ b/lsp/vue_ls.lua
@@ -22,6 +22,11 @@ return {
   cmd = { 'vue-language-server', '--stdio' },
   filetypes = { 'vue' },
   root_markers = { 'package.json' },
+  init_options = {
+    typescript = {
+      tsdk = '',
+    }
+  },
   on_init = function(client)
     client.handlers['tsserver/request'] = function(_, result, context)
       local clients = vim.lsp.get_clients({ bufnr = context.bufnr, name = 'vtsls' })


### PR DESCRIPTION
Update vue_ls.lua
Fix nil table error/message:
Added init_options table to suppress error message. So no additional config override is necessary. 

```lua
LSP[vue_ls]: Error BEFORE_INIT_CALLBACK_ERROR: ".../mason-lspconfig.nvim/lua/mason-lspconfig/lsp/vue_ls.lua:8: attempt to index field 'init_options' (a nil value)"
```
