### PR TITLE
docs(rescriptls): register didChangeWatchedFiles hook

### DIFF
--- a/doc/configs.md
+++ b/doc/configs.md
@@ -9284,6 +9284,19 @@ Default config:
   {}
   ```
 
+Detect file changes:
+While using @rescript/language-server >= 1.63.0 you have to detect file changes by registering the `didChangeWatchedFiles` hook.
+
+```
+capabilities = {
+    workspace = {
+        didChangeWatchedFiles = {
+            dynamicRegistration = true,
+        },
+    },
+}
+``` 
+
 ---
 
 ## rls


### PR DESCRIPTION
Using the newest language server for rescript doesn't detect file changes by itself anymore. So you have to register to the `didChangeWatchedFiles` hook.

I added this information to the configs.md, since the newest version is not yet released as stable but is required for the newest beta version of rescript.

When it will be released, we should add the capabilities to the default config.

For reference:
https://github.com/rescript-lang/rescript-vscode/blob/master/CHANGELOG.md
https://forum.rescript-lang.org/t/ann-rescript-12-beta-release-call-for-testing/6238/10