### PR TITLE
feat(biome): use project local bin if available

### DIFF
--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -10,7 +10,14 @@
 local util = require 'lspconfig.util'
 
 return {
-  cmd = { 'biome', 'lsp-proxy' },
+  cmd = function(dispatchers, config)
+    local cmd = 'biome'
+    local local_cmd = config.root_dir and config.root_dir .. '/node_modules/.bin/biome'
+    if local_cmd and vim.fn.executable(local_cmd) == 1 then
+      cmd = local_cmd
+    end
+    return vim.lsp.rpc.start({ cmd, 'lsp-proxy' }, dispatchers)
+  end,
   filetypes = {
     'astro',
     'css',


### PR DESCRIPTION
Problem: users may have a different version of biome installed in a project, compared to the global installation.

Solution: use project local binary if available.

Note: I used `vim.system({ ... }):wait()` to check if the binary is executable. LMK if using `vim.fn.executable` is preferred.

This PR is inspired by the release of biome v2, which introduced some breaking changes.