### PR TITLE
feat(svelte): notify LSP of changes in JS/TS files

### DIFF
--- a/lsp/svelte.lua
+++ b/lsp/svelte.lua
@@ -21,6 +21,16 @@ return {
     end
   end,
   on_attach = function(client, bufnr)
+    -- Workaround to trigger reloading JS/TS files
+    -- See https://github.com/sveltejs/language-tools/issues/2008
+    vim.api.nvim_create_autocmd('BufWritePost', {
+      pattern = { '*.js', '*.ts' },
+      buffer = bufnr,
+      callback = function(ctx)
+        -- internal API to sync changes that have not yet been saved to the file system
+        client:notify('$/onDidChangeTsOrJsFile', { uri = ctx.match })
+      end,
+    })
     vim.api.nvim_buf_create_user_command(bufnr, 'LspMigrateToSvelte5', function()
       client:exec_cmd({
         command = 'migrate_to_svelte_5',


### PR DESCRIPTION
The Svelte LSP does not attach to regular JS / TS files. To get notified about changes in these files, it "needs" to send a custom message via `notify`.

The VS Code extension uses the same workaround[^1] and it has been discussed to death how to port it to neovim[^2]. Instead of relying on users finding out about said discussion, it should be included in the default configuration.

[^1]: https://github.com/sveltejs/language-tools/blob/2e2c6c3624f2dd21cbda4d8b4b63e0d4df93152e/packages/svelte-vscode/src/extension.ts#L346
[^2]: https://github.com/sveltejs/language-tools/issues/2008