### PR TITLE
feat(clangd): remove proto filetype support, reverting (#2125)

### DIFF
--- a/lsp/clangd.lua
+++ b/lsp/clangd.lua
@@ -62,7 +62,7 @@ end
 
 return {
   cmd = { 'clangd' },
-  filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda', 'proto' },
+  filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda' },
   root_markers = {
     '.clangd',
     '.clang-tidy',


### PR DESCRIPTION
The corresponding post was made in 2022, but we now have rich protobuf language servers and formatters such as
[buf](https://github.com/bufbuild/buf). Buf already has their stuff registered with mason and nonels, so they're already well integrated into the neovim ecosystem. 

There are open hacks to getting around this by explicitly overriding the default settings, but it's more idiomatic to have sensible defaults in the go-to lsp repo. (The current issue is that clangd will attach, fail to parse, then spam the file with bogus error messages). 