### PR TITLE
refactor(glint): use `cmd(…, config)`

### DIFF
--- a/lsp/glint.lua
+++ b/lsp/glint.lua
@@ -22,21 +22,10 @@
 ---   },
 --- })
 
-function get_cmd()
-  local useGlobal = vim.lsp.config.glint.init_options.glint.useGlobal
-  if useGlobal then
-    return { 'glint-language-server' }
-  end
-
-  local root_markers = vim.lsp.config.glint.root_markers
-  local root_dir = vim.fs.root(0, root_markers)
-
-  return { root_dir .. '/node_modules/.bin/glint-language-server' }
-end
-
 return {
-  cmd = function(dispatchers)
-    local cmd = get_cmd()
+  cmd = function(dispatchers, config)
+    local cmd = (config.init_options.glint.useGlobal or not config.root_dir) and { 'glint-language-server' }
+      or { config.root_dir .. '/node_modules/.bin/glint-language-server' }
     return vim.lsp.rpc.start(cmd, dispatchers)
   end,
   init_options = {


### PR DESCRIPTION
Problem:
The glint config `cmd()` gets its config from the currently resolved global config, which may be different than the one for the current client.

Solution:
Since Nvim 0.11.3 https://github.com/neovim/neovim/issues/34547 `cmd()` receives a `config` arg, so use that instead.

Followup to https://github.com/neovim/nvim-lspconfig/pull/3912 @justmejulian 

Note that this requires Nvim 0.11.3