### PR TITLE
fix(biome): error when using non-local biome binary

### DIFF
--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -12,7 +12,7 @@ local util = require 'lspconfig.util'
 return {
   cmd = function(dispatchers, config)
     local cmd = 'biome'
-    local local_cmd = config and config.root_dir and config.root_dir .. '/node_modules/.bin/biome'
+    local local_cmd = (config or {}).root_dir and config.root_dir .. '/node_modules/.bin/biome'
     if local_cmd and vim.fn.executable(local_cmd) == 1 then
       cmd = local_cmd
     end


### PR DESCRIPTION
#3957 introduced using local binaries of biome when available, but results in an error on lsp startup when there is no local installation due to a missing nil-check:

```
...eser/.local/share/nvim/lazy/nvim-lspconfig/lsp/biome.lua:15: attempt to index local 'config' (a nil value)
```