### PR TITLE
fix(svelte): use augroup to avoid creating multiple autocmds 

### DIFF
--- a/lsp/svelte.lua
+++ b/lsp/svelte.lua
@@ -25,7 +25,7 @@ return {
     -- See https://github.com/sveltejs/language-tools/issues/2008
     vim.api.nvim_create_autocmd('BufWritePost', {
       pattern = { '*.js', '*.ts' },
-      buffer = bufnr,
+      group = vim.api.nvim_create_augroup('svelte_js_ts_file_watch', {}),
       callback = function(ctx)
         -- internal API to sync changes that have not yet been saved to the file system
         client:notify('$/onDidChangeTsOrJsFile', { uri = ctx.match })


### PR DESCRIPTION
Follow up: https://github.com/neovim/nvim-lspconfig/pull/3958

As it turns out, we can't use both `buffer` and `pattern` in the same autocmd. And even if we could set the buffer, it is not necessarily the one the server is attaching to.

By removing the `buffer` we are creating a new autocmd every time the buffer attaches. The ideal solution would be to guard against that, but I'm not sure if that would be the best approach (I imagine there are some augroup shenanigans?).