### PR TITLE
feat: add php language server 'phptools' from devsense

### DIFF
--- a/lsp/phptools.lua
+++ b/lsp/phptools.lua
@@ -18,6 +18,7 @@
 --- }
 --- ```
 
+---@type vim.lsp.Config
 return {
   cmd = { 'devsense-php-ls', '--stdio' },
   filetypes = { 'php' },


### PR DESCRIPTION
This pull request adds support for [`devsense-php-ls`](https://www.npmjs.com/package/devsense-php-ls), the language server used by the [PHP Tools extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=DEVSENSE.phptools-vscode).

This language server offers a comprehensive PHP development experience (within the limits of the LSP protocol), including:

* Laravel IDE features
* Support for PhpStan, Psalm, and other PHPDoc annotations
* Code completion
* Inlay hints
* Code diagnostics
* Code navigation
* Code folding
* And more