### PR TITLE
fix(pyright): command :LspPyrightOrganizeImports fails

### DIFF
--- a/.github/ci/lint.sh
+++ b/.github/ci/lint.sh
@@ -53,7 +53,7 @@ _check_lsp_cmd_prefix() {
 
 # Enforce client:exec_cmd().
 _check_exec_cmd() {
-  local exclude='eslint'
+  local exclude='eslint\|pyright\|basedpyright'
   if git grep -P 'workspace.executeCommand' -- 'lsp/*.lua' | grep -v "$exclude"  ; then
     _fail 'Use client:exec_cmd() instead of calling request("workspace/executeCommand") directly. Example: lsp/pyright.lua'
   fi

--- a/lsp/basedpyright.lua
+++ b/lsp/basedpyright.lua
@@ -48,7 +48,9 @@ return {
         arguments = { vim.uri_from_bufnr(bufnr) },
       }
 
-      -- cannot use client:exec_cmd() as it will fail due to the LSP command not being advertised by the server
+      -- Using client.request(() directly because this is a private command (not
+      -- advertised via capabilities), which client:exec_cmd() refuses to call.
+      -- https://github.com/neovim/neovim/blob/c333d64663d3b6e0dd9aa440e433d346af4a3d81/runtime/lua/vim/lsp/client.lua#L1024-L1030
       client.request('workspace/executeCommand', params, nil, bufnr)
     end, {
       desc = 'Organize Imports',

--- a/lsp/basedpyright.lua
+++ b/lsp/basedpyright.lua
@@ -43,10 +43,13 @@ return {
   },
   on_attach = function(client, bufnr)
     vim.api.nvim_buf_create_user_command(bufnr, 'LspPyrightOrganizeImports', function()
-      client:exec_cmd({
+      local params = {
         command = 'basedpyright.organizeimports',
         arguments = { vim.uri_from_bufnr(bufnr) },
-      })
+      }
+
+      -- cannot use client:exec_cmd() as it will fail due to the LSP command not being advertised by the server
+      client.request('workspace/executeCommand', params, nil, bufnr)
     end, {
       desc = 'Organize Imports',
     })

--- a/lsp/basedpyright.lua
+++ b/lsp/basedpyright.lua
@@ -48,8 +48,8 @@ return {
         arguments = { vim.uri_from_bufnr(bufnr) },
       }
 
-      -- Using client.request(() directly because this is a private command (not
-      -- advertised via capabilities), which client:exec_cmd() refuses to call.
+      -- Using client.request() directly because "basedpyright.organizeimports" is private
+      -- (not advertised via capabilities), which client:exec_cmd() refuses to call.
       -- https://github.com/neovim/neovim/blob/c333d64663d3b6e0dd9aa440e433d346af4a3d81/runtime/lua/vim/lsp/client.lua#L1024-L1030
       client.request('workspace/executeCommand', params, nil, bufnr)
     end, {

--- a/lsp/pyright.lua
+++ b/lsp/pyright.lua
@@ -48,7 +48,9 @@ return {
         arguments = { vim.uri_from_bufnr(bufnr) },
       }
 
-      -- cannot use client:exec_cmd() as it will fail due to the LSP command not being advertised by the server
+      -- Using client.request() directly because "pyright.organizeimports" is private
+      -- (not advertised via capabilities), which client:exec_cmd() refuses to call.
+      -- https://github.com/neovim/neovim/blob/c333d64663d3b6e0dd9aa440e433d346af4a3d81/runtime/lua/vim/lsp/client.lua#L1024-L1030
       client.request('workspace/executeCommand', params, nil, bufnr)
     end, {
       desc = 'Organize Imports',

--- a/lsp/pyright.lua
+++ b/lsp/pyright.lua
@@ -43,10 +43,13 @@ return {
   },
   on_attach = function(client, bufnr)
     vim.api.nvim_buf_create_user_command(bufnr, 'LspPyrightOrganizeImports', function()
-      client:exec_cmd({
+      local params = {
         command = 'pyright.organizeimports',
         arguments = { vim.uri_from_bufnr(bufnr) },
-      })
+      }
+
+      -- cannot use client:exec_cmd() as it will fail due to the LSP command not being advertised by the server
+      client.request('workspace/executeCommand', params, nil, bufnr)
     end, {
       desc = 'Organize Imports',
     })


### PR DESCRIPTION
Fix error raised when running `:LspPyrightOrganizeImports` :

```
Language server `pyright` does not support command `pyright.organizeimports`. This command may require a client extension.
```