### PR TITLE
fix(vue_ls): throwing errors in tsserverRequest

### DIFF
--- a/lsp/vue_ls.lua
+++ b/lsp/vue_ls.lua
@@ -41,7 +41,7 @@ return {
           payload,
         },
       }, { bufnr = context.bufnr }, function(_, r)
-        local response_data = { { id, r.body } }
+        local response_data = { { id, r and r.body } }
         ---@diagnostic disable-next-line: param-type-mismatch
         client:notify('tsserver/response', response_data)
       end)


### PR DESCRIPTION
Hi, I would sporadically get nil reference errors with the vue_ls/vtsls integration, when the response from the typescript server is empty. This just adds a simple guard, so that the vue_ls config no longer tries to access a field on nil responses.

So far this did not have any adverse effects that I noticed.