### PR TITLE
fix(vue_ls): prevent memory leak

### DIFF
--- a/lsp/vue_ls.lua
+++ b/lsp/vue_ls.lua
@@ -41,7 +41,8 @@ return {
           payload,
         },
       }, { bufnr = context.bufnr }, function(_, r)
-        local response_data = { { id, r.body } }
+        local response = r and r.body or nil
+        local response_data = { { id, response } }
         ---@diagnostic disable-next-line: param-type-mismatch
         client:notify('tsserver/response', response_data)
       end)


### PR DESCRIPTION
On the `vue_ls` side, there's a hash table to track the requests sent, and will remove the item when response received. Thus if `r` is `nil` (e.g. when the tsserver plugin is not correctly setup) the table will keep growing and allocating memory unless kill the lsp, this pr make sure to always send the response back even there's an error.

I did not add a `vim.notify` when the payload is empty as in some plugins it's okay to be nil e.g. `diffview.nvim`. If things not working for the user they can always troubleshoot themselves, but if you think there should be error or warning level notify (ideally `r` should always exist, so either error or warning makes sense), just let me know.