### PR TITLE
fix(tailwindcss): add fallback for tailwind v4

### DIFF
--- a/lsp/tailwindcss.lua
+++ b/lsp/tailwindcss.lua
@@ -123,6 +123,8 @@ return {
       'theme/static_src/tailwind.config.mjs',
       'theme/static_src/tailwind.config.ts',
       'theme/static_src/postcss.config.js',
+      -- Fallback for tailwind v4, where tailwind.config.* is not required anymore
+      '.git',
     }
     local fname = vim.api.nvim_buf_get_name(bufnr)
     root_files = util.insert_package_json(root_files, 'tailwindcss', fname)


### PR DESCRIPTION
Since tailwind v4 it is not required to have a tailwind.config.* in the project 1. The current configuration is preventing the LSP to attach to the configured file types in cases when no tailwind.config.* or none of the other markers (package.json etc.) is present. This commit fixes this limitation by providing .git as a fallback and by documenting this limitation.

fixes #3979 