### PR TITLE
feat(docker): add docker-language-server

### DIFF
--- a/lsp/docker_language_server.lua
+++ b/lsp/docker_language_server.lua
@@ -8,7 +8,7 @@
 --- ```
 return {
   cmd = { 'docker-language-server', 'start', '--stdio' },
-  filetypes = { 'dockerfile', 'yaml.docker-compose', 'hcl', 'json' },
+  filetypes = { 'dockerfile', 'yaml.docker-compose' },
   root_markers = {
     'Dockerfile',
     'docker-compose.yaml',

--- a/lsp/docker_language_server.lua
+++ b/lsp/docker_language_server.lua
@@ -1,0 +1,23 @@
+---@brief
+---
+--- https://github.com/docker/docker-language-server
+---
+--- `docker-langserver-server` can be installed via `go`:
+--- ```sh
+--- go install github.com/docker/docker-language-server/cmd/docker-language-server@latest
+--- ```
+return {
+  cmd = { 'docker-language-server', 'start', '--stdio' },
+  filetypes = { 'dockerfile', 'yaml.docker-compose', 'hcl', 'json' },
+  root_markers = {
+    'Dockerfile',
+    'docker-compose.yaml',
+    'docker-compose.yml',
+    'compose.yaml',
+    'compose.yml',
+    'docker-bake.json',
+    'docker-bake.hcl',
+    'docker-bake.override.json',
+    'docker-bake.override.hcl',
+  },
+}


### PR DESCRIPTION
Add support for the official [docker language server](https://github.com/docker/docker-language-server).

The official docker language server supports `Dockerfile`s, Docker Compose YAML files, and Bake HCL/JSON files.

I am not sure what is the recommendation/consensus around enabling the language servers on such broad filetypes (e.g. `json`, `hcl`) since they are general purpose configuration/data languages. Happy to remove them and leave it up to users to pass in these filetypes through their customized configs, if they desire.