### PR TITLE
docs(matlab_ls): add installPath requirement comment

### DIFF
--- a/lsp/matlab_ls.lua
+++ b/lsp/matlab_ls.lua
@@ -13,7 +13,7 @@ return {
   settings = {
     MATLAB = {
       indexWorkspace = true,
-      installPath = '',
+      installPath = '', -- NOTE: Set this to your MATLAB installation path.
       matlabConnectionTiming = 'onStart',
       telemetry = true,
     },

--- a/lsp/matlab_ls.lua
+++ b/lsp/matlab_ls.lua
@@ -4,8 +4,7 @@
 ---
 --- MATLAB® language server implements the Microsoft® Language Server Protocol for the MATLAB language.
 ---
---- Make sure to set `MATLAB.installPath` to your MATLAB path:
---- E.g.: 
+--- Make sure to set `MATLAB.installPath` to your MATLAB path, e.g.:
 --- ```lua
 -- settings = {
 --   MATLAB = {

--- a/lsp/matlab_ls.lua
+++ b/lsp/matlab_ls.lua
@@ -6,13 +6,13 @@
 ---
 --- Make sure to set `MATLAB.installPath` to your MATLAB path, e.g.:
 --- ```lua
--- settings = {
---   MATLAB = {
---     ...
---     installPath = '/usr/local/MATLAB/R2023a', 
---     ...
---   },
--- },
+--- settings = {
+---   MATLAB = {
+---     ...
+---     installPath = '/usr/local/MATLAB/R2023a', 
+---     ...
+---   },
+--- },
 --- ```
 return {
   cmd = { 'matlab-language-server', '--stdio' },

--- a/lsp/matlab_ls.lua
+++ b/lsp/matlab_ls.lua
@@ -3,6 +3,18 @@
 --- https://github.com/mathworks/MATLAB-language-server
 ---
 --- MATLAB® language server implements the Microsoft® Language Server Protocol for the MATLAB language.
+---
+--- Make sure to set `MATLAB.installPath` to your MATLAB path:
+--- E.g.: 
+--- ```lua
+-- settings = {
+--   MATLAB = {
+--     ...
+--     installPath = '/usr/local/MATLAB/R2023a', 
+--     ...
+--   },
+-- },
+--- ```
 return {
   cmd = { 'matlab-language-server', '--stdio' },
   filetypes = { 'matlab' },

--- a/lsp/matlab_ls.lua
+++ b/lsp/matlab_ls.lua
@@ -9,7 +9,7 @@
 --- settings = {
 ---   MATLAB = {
 ---     ...
----     installPath = '/usr/local/MATLAB/R2023a', 
+---     installPath = '/usr/local/MATLAB/R2023a',
 ---     ...
 ---   },
 --- },


### PR DESCRIPTION
Problem:
No clear documentation about requirement to set `installPath`. Leaving `installPath` empty causes the language server to fail silently (it attaches, but does not provide any features).

Solution:
Add documentation in `matlab_ls.lua`.