### PR TITLE
fix(golangci_lint_ls): support wrapper script

### DIFF
--- a/lsp/golangci_lint_ls.lua
+++ b/lsp/golangci_lint_ls.lua
@@ -30,14 +30,16 @@ return {
   before_init = function(_, config)
     -- Add support for golangci-lint V1 (in V2 `--out-format=json` was replaced by
     -- `--output.json.path=stdout`).
-    local v1
+    local v1, v2 = false, false
     -- PERF: `golangci-lint version` is very slow (about 0.1 sec) so let's find
     -- version using `go version -m $(which golangci-lint) | grep '^\smod'`.
     if vim.fn.executable 'go' == 1 then
       local exe = vim.fn.exepath 'golangci-lint'
       local version = vim.system({ 'go', 'version', '-m', exe }):wait()
       v1 = string.match(version.stdout, '\tmod\tgithub.com/golangci/golangci%-lint\t')
-    else
+      v2 = string.match(version.stdout, '\tmod\tgithub.com/golangci/golangci%-lint/v2\t')
+    end
+    if not v1 and not v2 then
       local version = vim.system({ 'golangci-lint', 'version' }):wait()
       v1 = string.match(version.stdout, 'version v?1%.')
     end

--- a/lua/lspconfig/configs/golangci_lint_ls.lua
+++ b/lua/lspconfig/configs/golangci_lint_ls.lua
@@ -21,14 +21,16 @@ return {
     before_init = function(_, config)
       -- Add support for golangci-lint V1 (in V2 `--out-format=json` was replaced by
       -- `--output.json.path=stdout`).
-      local v1
+      local v1, v2 = false, false
       -- PERF: `golangci-lint version` is very slow (about 0.1 sec) so let's find
       -- version using `go version -m $(which golangci-lint) | grep '^\smod'`.
       if vim.fn.executable 'go' == 1 then
         local exe = vim.fn.exepath 'golangci-lint'
         local version = vim.system({ 'go', 'version', '-m', exe }):wait()
         v1 = string.match(version.stdout, '\tmod\tgithub.com/golangci/golangci%-lint\t')
-      else
+        v2 = string.match(version.stdout, '\tmod\tgithub.com/golangci/golangci%-lint/v2\t')
+      end
+      if not v1 and not v2 then
         local version = vim.system({ 'golangci-lint', 'version' }):wait()
         v1 = string.match(version.stdout, 'version v?1%.')
       end


### PR DESCRIPTION
Should fix detection of shell wrapper script as explained in https://github.com/neovim/nvim-lspconfig/issues/3863#issuecomment-3151511384.