### PR TITLE
fix(vue_ls): correctly check if `ts_clients` exist

### DIFF
--- a/lsp/vue_ls.lua
+++ b/lsp/vue_ls.lua
@@ -24,8 +24,13 @@ return {
   root_markers = { 'package.json' },
   on_init = function(client)
     client.handlers['tsserver/request'] = function(_, result, context)
-      local clients = vim.lsp.get_clients({ bufnr = context.bufnr, name = 'ts_ls' })
-        or vim.lsp.get_clients({ bufnr = context.bufnr, name = 'vtsls' })
+      local ts_clients = vim.lsp.get_clients({ bufnr = context.bufnr, name = 'ts_ls' })
+      local vtsls_clients = vim.lsp.get_clients({ bufnr = context.bufnr, name = 'vtsls' })
+      local clients = {}
+
+      vim.list_extend(clients, ts_clients)
+      vim.list_extend(clients, vtsls_clients)
+
       if #clients == 0 then
         vim.notify('Could not find `ts_ls` or `vtsls` lsp client, required by `vue_ls`.', vim.log.levels.ERROR)
         return


### PR DESCRIPTION
Currently, `on_init` tries to use `or` to combine two function calls
that return tables and always returns truthy on the first value (`ts_ls`) because an empty
table is considered truthy in lua causing an error when using `vtsls`.
This properly checks if either `ts_ls` or `vtsls` exists and extends the
`clients` list for proper error handling.
