### PR TITLE
fix: update configs to 0.11+

### DIFF
--- a/lsp/clangd.lua
+++ b/lsp/clangd.lua
@@ -12,14 +12,15 @@
 ---   specified as compile_commands.json, see https://clangd.llvm.org/installation#compile_commandsjson
 
 -- https://clangd.llvm.org/extensions.html#switch-between-sourceheader
-local function switch_source_header(bufnr)
+local function switch_source_header(bufnr, client)
   local method_name = 'textDocument/switchSourceHeader'
-  local client = vim.lsp.get_clients({ bufnr = bufnr, name = 'clangd' })[1]
-  if not client then
+  ---@diagnostic disable-next-line:param-type-mismatch
+  if not client or not client:supports_method(method_name) then
     return vim.notify(('method %s is not supported by any servers active on the current buffer'):format(method_name))
   end
   local params = vim.lsp.util.make_text_document_params(bufnr)
-  client.request(method_name, params, function(err, result)
+  ---@diagnostic disable-next-line:param-type-mismatch
+  client:request(method_name, params, function(err, result)
     if err then
       error(tostring(err))
     end
@@ -31,17 +32,18 @@ local function switch_source_header(bufnr)
   end, bufnr)
 end
 
-local function symbol_info()
-  local bufnr = vim.api.nvim_get_current_buf()
-  local clangd_client = vim.lsp.get_clients({ bufnr = bufnr, name = 'clangd' })[1]
-  if not clangd_client or not clangd_client.supports_method 'textDocument/symbolInfo' then
+local function symbol_info(bufnr, client)
+  local method_name = 'textDocument/symbolInfo'
+  ---@diagnostic disable-next-line:param-type-mismatch
+  if not client or not client:supports_method(method_name) then
     return vim.notify('Clangd client not found', vim.log.levels.ERROR)
   end
   local win = vim.api.nvim_get_current_win()
-  local params = vim.lsp.util.make_position_params(win, clangd_client.offset_encoding)
-  clangd_client.request('textDocument/symbolInfo', params, function(err, res)
+  local params = vim.lsp.util.make_position_params(win, client.offset_encoding)
+  ---@diagnostic disable-next-line:param-type-mismatch
+  client:request(method_name, params, function(err, res)
     if err or #res == 0 then
-      -- Clangd always returns an error, there is not reason to parse it
+      -- Clangd always returns an error, there is no reason to parse it
       return
     end
     local container = string.format('container: %s', res[1].containerName) ---@type string
@@ -51,7 +53,6 @@ local function symbol_info()
       width = math.max(string.len(name), string.len(container)),
       focusable = false,
       focus = false,
-      border = 'single',
       title = 'Symbol Info',
     })
   end, bufnr)
@@ -87,13 +88,15 @@ return {
       client.offset_encoding = init_result.offsetEncoding
     end
   end,
-  on_attach = function(_, bufnr)
+  ---@param client vim.lsp.Client
+  ---@param bufnr integer
+  on_attach = function(client, bufnr)
     vim.api.nvim_buf_create_user_command(bufnr, 'LspClangdSwitchSourceHeader', function()
-      switch_source_header(bufnr)
+      switch_source_header(bufnr, client)
     end, { desc = 'Switch between source/header' })
 
     vim.api.nvim_buf_create_user_command(bufnr, 'LspClangdShowSymbolInfo', function()
-      symbol_info()
+      symbol_info(bufnr, client)
     end, { desc = 'Show symbol info' })
   end,
 }

--- a/lsp/denols.lua
+++ b/lsp/denols.lua
@@ -41,7 +41,7 @@ local function virtual_text_document(uri, client)
       uri = uri,
     },
   }
-  local result = client.request_sync('deno/virtualTextDocument', params)
+  local result = client:request_sync('deno/virtualTextDocument', params)
   virtual_text_document_handler(uri, result, client)
 end
 
@@ -100,7 +100,7 @@ return {
       }, { bufnr = bufnr }, function(err, _result, ctx)
         if err then
           local uri = ctx.params.arguments[2]
-          vim.api.nvim_err_writeln('cache command failed for ' .. vim.uri_to_fname(uri))
+          vim.notify('cache command failed for' .. vim.uri_to_fname(uri), vim.log.levels.ERROR)
         end
       end)
     end, {

--- a/lsp/elmls.lua
+++ b/lsp/elmls.lua
@@ -15,7 +15,7 @@ return {
   filetypes = { 'elm' },
   root_dir = function(bufnr, on_dir)
     local fname = api.nvim_buf_get_name(bufnr)
-    local filetype = api.nvim_buf_get_option(0, 'filetype')
+    local filetype = vim.bo[bufnr].filetype
     if filetype == 'elm' or (filetype == 'json' and fname:match 'elm%.json$') then
       on_dir(vim.fs.root(fname, 'elm.json'))
       return

--- a/lsp/markdown_oxide.lua
+++ b/lsp/markdown_oxide.lua
@@ -8,25 +8,29 @@
 --- Inspired by and compatible with Obsidian.
 ---
 --- Check the readme to see how to properly setup.
+
+---@param client vim.lsp.Client
+---@param bufnr integer
+---@param cmd string
+local function command_factory(client, bufnr, cmd)
+  return client:exec_cmd({
+    title = ('Markdown-Oxide-%s'):format(cmd),
+    command = 'jump',
+    arguments = { cmd },
+  }, { bufnr = bufnr })
+end
+
 return {
   root_markers = { '.git', '.obsidian', '.moxide.toml' },
   filetypes = { 'markdown' },
   cmd = { 'markdown-oxide' },
-  on_attach = function(_, bufnr)
-    vim.api.nvim_buf_create_user_command(bufnr, 'LspToday', function()
-      vim.lsp.buf.execute_command { command = 'jump', arguments = { 'today' } }
-    end, {
-      desc = "Open today's daily note",
-    })
-    vim.api.nvim_buf_create_user_command(bufnr, 'LspTomorrow', function()
-      vim.lsp.buf.execute_command { command = 'jump', arguments = { 'tomorrow' } }
-    end, {
-      desc = "Open tomorrow's daily note",
-    })
-    vim.api.nvim_buf_create_user_command(bufnr, 'LspYesterday', function()
-      vim.lsp.buf.execute_command { command = 'jump', arguments = { 'yesterday' } }
-    end, {
-      desc = "Open yesterday's daily note",
-    })
+  on_attach = function(client, bufnr)
+    for _, cmd in ipairs({ 'today', 'tomorrow', 'yesterday' }) do
+      vim.api.nvim_buf_create_user_command(bufnr, 'Lsp' .. ('%s'):format(cmd:gsub('^%l', string.upper)), function()
+        command_factory(client, bufnr, cmd)
+      end, {
+        desc = ('Open %s daily note'):format(cmd),
+      })
+    end
   end,
 }

--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -25,7 +25,8 @@ local function reload_workspace(bufnr)
   local clients = vim.lsp.get_clients { bufnr = bufnr, name = 'rust_analyzer' }
   for _, client in ipairs(clients) do
     vim.notify 'Reloading Cargo Workspace'
-    client.request('rust-analyzer/reloadWorkspace', nil, function(err)
+    ---@diagnostic disable-next-line:param-type-mismatch
+    client:request('rust-analyzer/reloadWorkspace', nil, function(err)
       if err then
         error(tostring(err))
       end

--- a/lsp/svlangserver.lua
+++ b/lsp/svlangserver.lua
@@ -10,21 +10,6 @@
 --- $ npm install -g @imc-trading/svlangserver
 --- ```
 
-local function build_index()
-  local params = {
-    command = 'systemverilog.build_index',
-  }
-  vim.lsp.buf.execute_command(params)
-end
-
-local function report_hierarchy()
-  local params = {
-    command = 'systemverilog.report_hierarchy',
-    arguments = { vim.fn.expand '<cword>' },
-  }
-  vim.lsp.buf.execute_command(params)
-end
-
 return {
   cmd = { 'svlangserver' },
   filetypes = { 'verilog', 'systemverilog' },
@@ -34,11 +19,24 @@ return {
       includeIndexing = { '*.{v,vh,sv,svh}', '**/*.{v,vh,sv,svh}' },
     },
   },
-  on_attach = function(_, bufnr)
-    vim.api.nvim_buf_create_user_command(bufnr, 'LspSvlangserverBuildIndex', build_index, {
+  ---@param client vim.lsp.Client
+  ---@param bufnr integer
+  on_attach = function(client, bufnr)
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspSvlangserverBuildIndex', function()
+      client:exec_cmd({
+        title = 'Build Index',
+        command = 'systemverilog.build_index',
+      }, { bufnr = bufnr })
+    end, {
       desc = 'Instructs language server to rerun indexing',
     })
-    vim.api.nvim_buf_create_user_command(bufnr, 'LspSvlangserverReportHierarchy', report_hierarchy, {
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspSvlangserverReportHierarchy', function()
+      client:exec_cmd({
+        title = 'Build Index',
+        command = 'systemverilog.build_index',
+        arguments = { vim.fn.expand '<cword>' },
+      }, { bufnr = bufnr })
+    end, {
       desc = 'Generates hierarchy for the given module',
     })
   end,

--- a/lsp/tinymist.lua
+++ b/lsp/tinymist.lua
@@ -11,6 +11,8 @@
 --- `LspTinymistGetDocumentMetrics`.
 
 ---@param command_name string
+---@param client vim.lsp.Client
+---@param bufnr integer
 ---@return fun():nil run_tinymist_command, string cmd_name, string cmd_desc
 local function create_tinymist_command(command_name, client, bufnr)
   local export_type = command_name:match 'tinymist%.export(%w+)'
@@ -19,7 +21,6 @@ local function create_tinymist_command(command_name, client, bufnr)
     info_type = info_type:gsub('^get', 'Get')
   end
   local cmd_display = export_type or info_type
-  ---Execute the Tinymist command, supporting both 0.10 and 0.11 exec methods
   ---@return nil
   local function run_tinymist_command()
     local arguments = { vim.api.nvim_buf_get_name(bufnr) }
@@ -32,19 +33,14 @@ local function create_tinymist_command(command_name, client, bufnr)
       -- If exporting, show the string result; else, show the table for inspection
       vim.notify(export_type and res or vim.inspect(res), vim.log.levels.INFO)
     end
-    if vim.fn.has 'nvim-0.11' == 1 then
-      -- For Neovim 0.11+
-      return client:exec_cmd({
-        title = title_str,
-        command = command_name,
-        arguments = arguments,
-      }, { bufnr = bufnr }, handler)
-    else
-      return vim.notify('Tinymist commands require Neovim 0.11+', vim.log.levels.WARN)
-    end
+    return client:exec_cmd({
+      title = title_str,
+      command = command_name,
+      arguments = arguments,
+    }, { bufnr = bufnr }, handler)
   end
   -- Construct a readable command name/desc
-  local cmd_name = export_type and ('LspTinymistExport' .. cmd_display) or ('LspTinymist' .. cmd_display) ---@type string
+  local cmd_name = export_type and ('TinymistExport' .. cmd_display) or ('Tinymist' .. cmd_display) ---@type string
   local cmd_desc = export_type and ('Export to ' .. cmd_display) or ('Get ' .. cmd_display) ---@type string
   return run_tinymist_command, cmd_name, cmd_desc
 end
@@ -53,6 +49,8 @@ return {
   cmd = { 'tinymist' },
   filetypes = { 'typst' },
   root_markers = { '.git' },
+  ---@param client vim.lsp.Client
+  ---@param bufnr integer
   on_attach = function(client, bufnr)
     for _, command in ipairs {
       'tinymist.exportSvg',
@@ -69,7 +67,7 @@ return {
       'tinymist.getDocumentMetrics',
     } do
       local cmd_func, cmd_name, cmd_desc = create_tinymist_command(command, client, bufnr)
-      vim.api.nvim_buf_create_user_command(bufnr, cmd_name, cmd_func, { nargs = 0, desc = cmd_desc })
+      vim.api.nvim_buf_create_user_command(bufnr, 'Lsp' .. cmd_name, cmd_func, { nargs = 0, desc = cmd_desc })
     end
   end,
 }

--- a/lsp/zk.lua
+++ b/lsp/zk.lua
@@ -16,12 +16,15 @@ return {
   cmd = { 'zk', 'lsp' },
   filetypes = { 'markdown' },
   root_markers = { '.zk' },
+  ---@param bufnr integer
+  ---@param client vim.lsp.Client
   on_attach = function(client, bufnr)
     vim.api.nvim_buf_create_user_command(bufnr, 'LspZkIndex', function()
-      vim.lsp.buf.execute_command {
+      client:exec_cmd({
+        title = 'ZkIndex',
         command = 'zk.index',
         arguments = { vim.api.nvim_buf_get_name(bufnr) },
-      }
+      }, { bufnr = bufnr })
     end, {
       desc = 'ZkIndex',
     })
@@ -31,6 +34,7 @@ return {
       local root = find_zk_root(bufpath)
 
       client:exec_cmd({
+        title = 'ZkList',
         command = 'zk.list',
         arguments = { root, { select = { 'path' } } },
       }, { bufnr = bufnr }, function(_err, result)
@@ -50,6 +54,7 @@ return {
 
     vim.api.nvim_buf_create_user_command(bufnr, 'LspZkNew', function(...)
       client:exec_cmd({
+        title = 'ZkNew',
         command = 'zk.new',
         arguments = {
           vim.api.nvim_buf_get_name(bufnr),


### PR DESCRIPTION
This is a follow to the #3991.  I tried to update to the 0.11 api most of the config, that had some issues. The changes can be summed to:

    - Drop check for neovim version, for tinymist
    - Make sure the name starts with Lsp to remove the exemption from the CI
      check, for tinymist
    - Use bufnr and client as arguments of on_attach
    - Update documentation to indicate implemented commands
    - Drop .buf.execute_command and use :exec_cmd
    - Call request as method
    - Silence wrong 
    - Use vim.bo[bufnr] instead of nvim_buf_get_option 
    - Use vim.notify instead of 
    - Drop border setup in favor of winborder 
    - Set title on :exec_cmd

I made a separate commit for every server, I don't know if this is the preferred way to do it. 






