### PR TITLE
fix: vim.lsp.get_log_path() -> vim.lsp.log.get_filename()

### DIFF
--- a/lua/lspconfig/health.lua
+++ b/lua/lspconfig/health.lua
@@ -253,7 +253,7 @@ local function check_lspconfig(bufnr)
   end
 
   health.start(('LSP configs active in this buffer (bufnr: %s)'):format(bufnr or '(invalid buffer)'))
-  health.info('Language client log: ' .. fmtpath(vim.lsp.get_log_path()))
+  health.info('Language client log: ' .. fmtpath(vim.lsp.log.get_filename()))
   health.info(('Detected filetype: `%s`'):format(buffer_filetype))
   health.info(('%d client(s) attached to this buffer'):format(#vim.tbl_keys(buf_clients)))
   for _, client in ipairs(buf_clients) do

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -68,7 +68,7 @@ end
 api.nvim_create_user_command('LspInfo', ':checkhealth vim.lsp', { desc = 'Alias to `:checkhealth vim.lsp`' })
 
 api.nvim_create_user_command('LspLog', function()
-  vim.cmd(string.format('tabnew %s', lsp.get_log_path()))
+  vim.cmd(string.format('tabnew %s', lsp.log.get_filename()))
 end, {
   desc = 'Opens the Nvim LSP client log.',
 })


### PR DESCRIPTION
Problem: `vim.lsp.get_log_path()` was recently deprecated because it is just a unnecessary wrapper around `vim.lsp.log.get_filename()`

Solution: Use the non deprecated function