### PR TITLE
docs(hyprls): Install from hyprland-community org

### DIFF
--- a/lsp/hyprls.lua
+++ b/lsp/hyprls.lua
@@ -4,7 +4,7 @@
 ---
 --- `hyprls` can be installed via `go`:
 --- ```sh
---- go install github.com/ewen-lbh/hyprls/cmd/hyprls@latest
+--- go install github.com/hyprland-community/hyprls/cmd/hyprls@latest
 --- ```
 return {
   cmd = { 'hyprls', '--stdio' },


### PR DESCRIPTION
```bash
$ go install github.com/ewen-lbh/hyprls/cmd/hyprls@latest
go: downloading github.com/ewen-lbh/hyprls v0.8.0
go: github.com/ewen-lbh/hyprls/cmd/hyprls@latest: version constraints conflict:
        github.com/ewen-lbh/hyprls@v0.8.0: parsing go.mod:
        module declares its path as: github.com/hyprland-community/hyprls
                but was required as: github.com/ewen-lbh/hyprls
```