### PR TITLE
fix(eslint): fix performance regression on configuration lookup

### DIFF
--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -172,11 +172,17 @@ return {
       end, eslint_config_files)
 
       for _, file in ipairs(flat_config_files) do
-        local found_files = vim.fs.find(function(name, path)
-          return name == file and not path:match('[/\\]node_modules[/\\]')
-        end, { path = root_dir, type = 'file', limit = 1 })
+        local found_files = vim.fn.globpath(root_dir, file, true, true)
 
-        if #found_files > 0 then
+        -- Filter out files inside node_modules
+        local filtered_files = {}
+        for _, found_file in ipairs(found_files) do
+          if string.find(found_file, '[/\\]node_modules[/\\]') == nil then
+            table.insert(filtered_files, found_file)
+          end
+        end
+
+        if #filtered_files > 0 then
           config.settings.experimental = config.settings.experimental or {}
           config.settings.experimental.useFlatConfig = true
           break


### PR DESCRIPTION
I just found out that I introduced a pretty big performance bottleneck with #3955 on `eslint` LSP. I thought using `vim.fs.find` would be much faster, but in fact it's taking a solid 3-4 seconds on a project of mine, compared to around 100-200ms with the previous implementation I had with `vim.fn.globpath`.

I'm pretty sorry about having put this upstream, I thought it was my local setup that had an issue and did not think about this.