### PR TITLE
fix: vtsls does not start in monorepo with `bun.lock`

### DIFF
--- a/lsp/vtsls.lua
+++ b/lsp/vtsls.lua
@@ -80,7 +80,7 @@ return {
     -- As stated in the documentation above, this LSP supports monorepos and simple projects.
     -- We select then from the project root, which is identified by the presence of a package
     -- manager lock file.
-    local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb' }
+    local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
     local project_root = vim.fs.root(bufnr, project_root_markers)
     if not project_root then
       return nil


### PR DESCRIPTION
After https://github.com/neovim/nvim-lspconfig/pull/3955, vtsls now detect lock file as root but does not include `bun.lock` file.

> Text-based lockfile
>
> Bun v1.2 changed the default lockfile format to the text-based bun.lock. Existing binary 
> bun.lockb lockfiles can be migrated to the new format by running bun install --save-text-
> lockfile --frozen-lockfile --lockfile-only and deleting bun.lockb.

Reference: [bun lock file](https://bun.com/docs/install/lockfile)

Fixes https://github.com/neovim/nvim-lspconfig/issues/4006