### PR TITLE
fix(nixd): use '.git' root marker

### DIFF
--- a/lsp/nixd.lua
+++ b/lsp/nixd.lua
@@ -9,5 +9,5 @@
 return {
   cmd = { 'nixd' },
   filetypes = { 'nix' },
-  root_markers = { 'flake.nix', 'git' },
+  root_markers = { 'flake.nix', '.git' },
 }


### PR DESCRIPTION
'nixd' is the only place I saw 'git' in root_markers, without the dot,
so I think it's a mistake. Change it to '.git'.
