### PR TITLE
fix: type annotations

### DIFF
--- a/lsp/ada_ls.lua
+++ b/lsp/ada_ls.lua
@@ -20,6 +20,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'ada_language_server' },
   filetypes = { 'ada' },

--- a/lsp/agda_ls.lua
+++ b/lsp/agda_ls.lua
@@ -6,6 +6,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'als' },
   filetypes = { 'agda' },

--- a/lsp/aiken.lua
+++ b/lsp/aiken.lua
@@ -6,6 +6,7 @@
 --- [Installation](https://aiken-lang.org/installation-instructions)
 ---
 --- It can be i
+---@type vim.lsp.Config
 return {
   cmd = { 'aiken', 'lsp' },
   filetypes = { 'aiken' },

--- a/lsp/air.lua
+++ b/lsp/air.lua
@@ -5,6 +5,7 @@
 --- Air is an R formatter and language server, written in Rust.
 ---
 --- Refer to the [documentation](https://posit-dev.github.io/air/editors.html) for more details.
+---@type vim.lsp.Config
 return {
   cmd = { 'air', 'language-server' },
   filetypes = { 'r' },

--- a/lsp/alloy_ls.lua
+++ b/lsp/alloy_ls.lua
@@ -21,6 +21,7 @@
 --- ```
 ---
 --- Alternatively, you may use a syntax plugin like https://github.com/runoshun/vim-alloy.
+---@type vim.lsp.Config
 return {
   cmd = { 'alloy', 'lsp' },
   filetypes = { 'alloy' },

--- a/lsp/anakin_language_server.lua
+++ b/lsp/anakin_language_server.lua
@@ -8,6 +8,7 @@
 ---
 --- * Initialization: https://github.com/muffinmad/anakin-language-server#initialization-option
 --- * Configuration: https://github.com/muffinmad/anakin-language-server#configuration-options
+---@type vim.lsp.Config
 return {
   cmd = { 'anakinls' },
   filetypes = { 'python' },

--- a/lsp/angularls.lua
+++ b/lsp/angularls.lua
@@ -68,6 +68,7 @@ local ng_probe_dirs = vim
   end)
   :join(',')
 
+---@type vim.lsp.Config
 return {
   cmd = {
     'ngserver',

--- a/lsp/ansiblels.lua
+++ b/lsp/ansiblels.lua
@@ -9,6 +9,7 @@
 --- ```sh
 --- npm install -g @ansible/ansible-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'ansible-language-server', '--stdio' },
   settings = {

--- a/lsp/antlersls.lua
+++ b/lsp/antlersls.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- npm install -g antlers-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'antlersls', '--stdio' },
   filetypes = { 'html', 'antlers' },

--- a/lsp/arduino_language_server.lua
+++ b/lsp/arduino_language_server.lua
@@ -70,6 +70,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   filetypes = { 'arduino' },
   root_dir = function(bufnr, on_dir)

--- a/lsp/asm_lsp.lua
+++ b/lsp/asm_lsp.lua
@@ -6,6 +6,7 @@
 ---
 --- `asm-lsp` can be installed via cargo:
 --- cargo install asm-lsp
+---@type vim.lsp.Config
 return {
   cmd = { 'asm-lsp' },
   filetypes = { 'asm', 'vmasm' },

--- a/lsp/ast_grep.lua
+++ b/lsp/ast_grep.lua
@@ -7,6 +7,7 @@
 --- ```sh
 --- npm install [-g] @ast-grep/cli
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'ast-grep', 'lsp' },
   workspace_required = true,

--- a/lsp/astro.lua
+++ b/lsp/astro.lua
@@ -9,6 +9,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'astro-ls', '--stdio' },
   filetypes = { 'astro' },

--- a/lsp/atlas.lua
+++ b/lsp/atlas.lua
@@ -55,6 +55,7 @@
 --- vim.treesitter.language.register('hcl', 'atlas-rule')
 --- ```
 ---
+---@type vim.lsp.Config
 return {
   cmd = { 'atlas', 'tool', 'lsp', '--stdio' },
   filetypes = {

--- a/lsp/autohotkey_lsp.lua
+++ b/lsp/autohotkey_lsp.lua
@@ -11,6 +11,7 @@ local function get_autohotkey_path()
   return #path > 0 and path or ''
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'autohotkey_lsp', '--stdio' },
   filetypes = { 'autohotkey' },

--- a/lsp/autotools_ls.lua
+++ b/lsp/autotools_ls.lua
@@ -13,6 +13,7 @@ local util = require 'lspconfig.util'
 
 local root_files = { 'configure.ac', 'Makefile', 'Makefile.am', '*.mk' }
 
+---@type vim.lsp.Config
 return {
   cmd = { 'autotools-language-server' },
   filetypes = { 'config', 'automake', 'make' },

--- a/lsp/awk_ls.lua
+++ b/lsp/awk_ls.lua
@@ -7,6 +7,7 @@
 --- npm install -g awk-language-server
 --- ```
 
+---@type vim.lsp.Config
 return {
   cmd = { 'awk-language-server' },
   filetypes = { 'awk' },

--- a/lsp/azure_pipelines_ls.lua
+++ b/lsp/azure_pipelines_ls.lua
@@ -29,6 +29,7 @@
 --- })
 --- ```
 --- The Azure Pipelines LSP is a fork of `yaml-language-server` and as such the same settings can be passed to it as `yaml-language-server`.
+---@type vim.lsp.Config
 return {
   cmd = { 'azure-pipelines-language-server', '--stdio' },
   filetypes = { 'yaml' },

--- a/lsp/bacon_ls.lua
+++ b/lsp/bacon_ls.lua
@@ -37,6 +37,7 @@
 ---     synchronizeAllOpenFilesWaitMillis = 2000,
 --- }
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'bacon-ls' },
   filetypes = { 'rust' },

--- a/lsp/ballerina.lua
+++ b/lsp/ballerina.lua
@@ -4,6 +4,7 @@
 ---
 --- The Ballerina language's CLI tool comes with its own language server implementation.
 --- The `bal` command line tool must be installed and available in your system's PATH.
+---@type vim.lsp.Config
 return {
   cmd = { 'bal', 'start-language-server' },
   filetypes = { 'ballerina' },

--- a/lsp/basedpyright.lua
+++ b/lsp/basedpyright.lua
@@ -15,7 +15,7 @@ local function set_python_path(path)
     else
       client.config.settings = vim.tbl_deep_extend('force', client.config.settings, { python = { pythonPath = path } })
     end
-    client.notify('workspace/didChangeConfiguration', { settings = nil })
+    client:notify('workspace/didChangeConfiguration', { settings = nil })
   end
 end
 

--- a/lsp/basedpyright.lua
+++ b/lsp/basedpyright.lua
@@ -19,6 +19,7 @@ local function set_python_path(path)
   end
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'basedpyright-langserver', '--stdio' },
   filetypes = { 'python' },

--- a/lsp/bashls.lua
+++ b/lsp/bashls.lua
@@ -8,6 +8,7 @@
 --- ```
 ---
 --- Language server for bash, written using tree sitter in typescript.
+---@type vim.lsp.Config
 return {
   cmd = { 'bash-language-server', 'start' },
   settings = {

--- a/lsp/basics_ls.lua
+++ b/lsp/basics_ls.lua
@@ -7,6 +7,7 @@
 --- ```sh
 --- npm install -g basics-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'basics-language-server' },
   settings = {

--- a/lsp/bazelrc_lsp.lua
+++ b/lsp/bazelrc_lsp.lua
@@ -13,6 +13,7 @@
 ---   },
 --- }
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'bazelrc-lsp', 'lsp' },
   filetypes = { 'bazelrc' },

--- a/lsp/beancount.lua
+++ b/lsp/beancount.lua
@@ -3,6 +3,7 @@
 --- https://github.com/polarmutex/beancount-language-server#installation
 ---
 --- See https://github.com/polarmutex/beancount-language-server#configuration for configuration options
+---@type vim.lsp.Config
 return {
   cmd = { 'beancount-language-server', '--stdio' },
   filetypes = { 'beancount', 'bean' },

--- a/lsp/bicep.lua
+++ b/lsp/bicep.lua
@@ -31,6 +31,7 @@
 ---     && rm -rf /usr/local/bin/bicep-langserver \
 ---     && unzip -d /usr/local/bin/bicep-langserver bicep-langserver.zip)
 --- ```
+---@type vim.lsp.Config
 return {
   filetypes = { 'bicep', 'bicep-params' },
   root_markers = { '.git' },

--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -47,7 +47,7 @@ return {
     local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
     local project_root = vim.fs.root(bufnr, project_root_markers)
     if not project_root then
-      return nil
+      return
     end
 
     -- We know that the buffer is using Biome if it has a config file
@@ -63,7 +63,7 @@ return {
       stop = vim.fs.dirname(project_root),
     })[1]
     if not is_buffer_using_biome then
-      return nil
+      return
     end
 
     on_dir(project_root)

--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -13,6 +13,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = function(dispatchers, config)
     local cmd = 'biome'

--- a/lsp/bitbake_language_server.lua
+++ b/lsp/bitbake_language_server.lua
@@ -1,6 +1,7 @@
 ---@brief
 ---
 --- 🛠️ bitbake language server
+---@type vim.lsp.Config
 return {
   cmd = { 'bitbake-language-server' },
   filetypes = { 'bitbake' },

--- a/lsp/blueprint_ls.lua
+++ b/lsp/blueprint_ls.lua
@@ -6,6 +6,7 @@
 ---
 --- Language server for the blueprint markup language, written in python and part
 --- of the blueprint-compiler.
+---@type vim.lsp.Config
 return {
   cmd = { 'blueprint-compiler', 'lsp' },
   cmd_env = {

--- a/lsp/bqls.lua
+++ b/lsp/bqls.lua
@@ -7,6 +7,7 @@
 --- ```sh
 --- $ go install github.com/kitagry/bqls@latest
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'bqls' },
   filetypes = { 'sql' },

--- a/lsp/bright_script.lua
+++ b/lsp/bright_script.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- npm install -g brighterscript
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'bsc', '--lsp', '--stdio' },
   filetypes = { 'brs' },

--- a/lsp/bsl_ls.lua
+++ b/lsp/bsl_ls.lua
@@ -4,6 +4,7 @@
 ---
 --- Language Server Protocol implementation for 1C (BSL) - 1C:Enterprise 8 and OneScript languages.
 
+---@type vim.lsp.Config
 return {
   filetypes = { 'bsl', 'os' },
   root_markers = { '.git' },

--- a/lsp/buck2.lua
+++ b/lsp/buck2.lua
@@ -9,6 +9,7 @@
 --- ```
 --- vim.cmd [[ autocmd BufRead,BufNewFile *.bxl,BUCK,TARGETS set filetype=bzl ]]
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'buck2', 'lsp' },
   filetypes = { 'bzl' },

--- a/lsp/buddy_ls.lua
+++ b/lsp/buddy_ls.lua
@@ -4,6 +4,7 @@
 --- The Language Server for the buddy-mlir, a drop-in replacement for mlir-lsp-server,
 --- supporting new dialects defined in buddy-mlir.
 --- `buddy-lsp-server` can be installed at the buddy-mlir repository (buddy-compiler/buddy-mlir)
+---@type vim.lsp.Config
 return {
   cmd = { 'buddy-lsp-server' },
   filetypes = { 'mlir' },

--- a/lsp/buf_ls.lua
+++ b/lsp/buf_ls.lua
@@ -5,6 +5,7 @@
 ---
 --- buf beta lsp is a Protobuf language server compatible with Buf modules and workspaces
 
+---@type vim.lsp.Config
 return {
   cmd = { 'buf', 'beta', 'lsp', '--timeout=0', '--log-format=text' },
   filetypes = { 'proto' },

--- a/lsp/bufls.lua
+++ b/lsp/bufls.lua
@@ -8,6 +8,7 @@
 --- ```
 ---
 --- bufls is a Protobuf language server compatible with Buf modules and workspaces
+---@type vim.lsp.Config
 return {
   cmd = { 'bufls', 'serve' },
   filetypes = { 'proto' },

--- a/lsp/bzl.lua
+++ b/lsp/bzl.lua
@@ -5,6 +5,7 @@
 --- https://docs.stack.build/docs/cli/installation
 ---
 --- https://docs.stack.build/docs/vscode/starlark-language-server
+---@type vim.lsp.Config
 return {
   cmd = { 'bzl', 'lsp', 'serve' },
   filetypes = { 'bzl' },

--- a/lsp/c3_lsp.lua
+++ b/lsp/c3_lsp.lua
@@ -3,6 +3,7 @@
 --- https://github.com/pherrymason/c3-lsp
 ---
 --- Language Server for c3.
+---@type vim.lsp.Config
 return {
   cmd = { 'c3lsp' },
   root_markers = { 'project.json', 'manifest.json', '.git' },

--- a/lsp/cairo_ls.lua
+++ b/lsp/cairo_ls.lua
@@ -10,6 +10,7 @@
 --- ```
 ---
 --- *cairo-language-server is still under active development, some features might not work yet !*
+---@type vim.lsp.Config
 return {
   init_options = { hostInfo = 'neovim' },
   cmd = { 'scarb', 'cairo-language-server', '/C', '--node-ipc' },

--- a/lsp/ccls.lua
+++ b/lsp/ccls.lua
@@ -37,6 +37,7 @@ local function switch_source_header(client, bufnr)
   end, bufnr)
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'ccls' },
   filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda' },

--- a/lsp/cds_lsp.lua
+++ b/lsp/cds_lsp.lua
@@ -7,6 +7,7 @@
 --- ```sh
 --- npm i -g @sap/cds-lsp
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'cds-lsp', '--stdio' },
   filetypes = { 'cds' },

--- a/lsp/circom-lsp.lua
+++ b/lsp/circom-lsp.lua
@@ -3,6 +3,7 @@
 --- [Circom Language Server](https://github.com/rubydusa/circom-lsp)
 ---
 --- `circom-lsp`, the language server for the Circom language.
+---@type vim.lsp.Config
 return {
   cmd = { 'circom-lsp' },
   filetypes = { 'circom' },

--- a/lsp/clangd.lua
+++ b/lsp/clangd.lua
@@ -61,6 +61,7 @@ end
 ---@class ClangdInitializeResult: lsp.InitializeResult
 ---@field offsetEncoding? string
 
+---@type vim.lsp.Config
 return {
   cmd = { 'clangd' },
   filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda' },

--- a/lsp/clangd.lua
+++ b/lsp/clangd.lua
@@ -82,15 +82,12 @@ return {
     },
     offsetEncoding = { 'utf-8', 'utf-16' },
   },
-  ---@param client vim.lsp.Client
   ---@param init_result ClangdInitializeResult
   on_init = function(client, init_result)
     if init_result.offsetEncoding then
       client.offset_encoding = init_result.offsetEncoding
     end
   end,
-  ---@param client vim.lsp.Client
-  ---@param bufnr integer
   on_attach = function(client, bufnr)
     vim.api.nvim_buf_create_user_command(bufnr, 'LspClangdSwitchSourceHeader', function()
       switch_source_header(bufnr, client)

--- a/lsp/clarinet.lua
+++ b/lsp/clarinet.lua
@@ -2,6 +2,7 @@
 --- https://github.com/hirosystems/clarinet
 ---
 --- Clarinet is the fastest way to build, test, and deploy smart contracts on the Stacks blockchain.
+---@type vim.lsp.Config
 return {
   cmd = { 'clarinet', 'lsp' },
   filetypes = { 'clar', 'clarity' },

--- a/lsp/clojure_lsp.lua
+++ b/lsp/clojure_lsp.lua
@@ -3,6 +3,7 @@
 --- https://github.com/clojure-lsp/clojure-lsp
 ---
 --- Clojure Language Server
+---@type vim.lsp.Config
 return {
   cmd = { 'clojure-lsp' },
   filetypes = { 'clojure', 'edn' },

--- a/lsp/cmake.lua
+++ b/lsp/cmake.lua
@@ -3,6 +3,7 @@
 --- https://github.com/regen100/cmake-language-server
 ---
 --- CMake LSP Implementation
+---@type vim.lsp.Config
 return {
   cmd = { 'cmake-language-server' },
   filetypes = { 'cmake' },

--- a/lsp/cobol_ls.lua
+++ b/lsp/cobol_ls.lua
@@ -1,6 +1,7 @@
 ---@brief
 ---
 --- Cobol language support
+---@type vim.lsp.Config
 return {
   cmd = { 'cobol-language-support' },
   filetypes = { 'cobol' },

--- a/lsp/codebook.lua
+++ b/lsp/codebook.lua
@@ -8,6 +8,7 @@
 ---
 --- The default `cmd` assumes that the `codebook-lsp` binary can be found in `$PATH`.
 ---
+---@type vim.lsp.Config
 return {
   cmd = { 'codebook-lsp', 'serve' },
   filetypes = {

--- a/lsp/coffeesense.lua
+++ b/lsp/coffeesense.lua
@@ -7,6 +7,7 @@
 --- ```sh
 --- npm install -g coffeesense-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'coffeesense-language-server', '--stdio' },
   filetypes = { 'coffee' },

--- a/lsp/contextive.lua
+++ b/lsp/contextive.lua
@@ -9,6 +9,7 @@
 --- To install the language server, you need to download the appropriate [GitHub release asset](https://github.com/dev-cycles/contextive/releases/) for your operating system and architecture.
 ---
 --- After the download unzip the Contextive.LanguageServer binary and copy the file into a folder that is included in your system's PATH.
+---@type vim.lsp.Config
 return {
   cmd = { 'Contextive.LanguageServer' },
   root_markers = { '.contextive', '.git' },

--- a/lsp/coq_lsp.lua
+++ b/lsp/coq_lsp.lua
@@ -1,6 +1,7 @@
 ---@brief
 ---
 --- https://github.com/ejgallego/coq-lsp/
+---@type vim.lsp.Config
 return {
   cmd = { 'coq-lsp' },
   filetypes = { 'coq' },

--- a/lsp/crystalline.lua
+++ b/lsp/crystalline.lua
@@ -3,6 +3,7 @@
 --- https://github.com/elbywan/crystalline
 ---
 --- Crystal language server.
+---@type vim.lsp.Config
 return {
   cmd = { 'crystalline' },
   filetypes = { 'crystal' },

--- a/lsp/csharp_ls.lua
+++ b/lsp/csharp_ls.lua
@@ -10,6 +10,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'csharp-ls' },
   root_dir = function(bufnr, on_dir)

--- a/lsp/cspell_ls.lua
+++ b/lsp/cspell_ls.lua
@@ -2,6 +2,7 @@
 ---
 --- [cspell language server](https://github.com/vlabo/cspell-lsp)
 ---
+---@type vim.lsp.Config
 return {
   cmd = { 'cspell-lsp', '--stdio' },
   root_markers = {

--- a/lsp/css_variables.lua
+++ b/lsp/css_variables.lua
@@ -9,6 +9,7 @@
 --- ```sh
 --- npm i -g css-variables-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'css-variables-language-server', '--stdio' },
   filetypes = { 'css', 'scss', 'less' },

--- a/lsp/cssls.lua
+++ b/lsp/cssls.lua
@@ -19,6 +19,7 @@
 ---   capabilities = capabilities,
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'vscode-css-language-server', '--stdio' },
   filetypes = { 'css', 'scss', 'less' },

--- a/lsp/cssmodules_ls.lua
+++ b/lsp/cssmodules_ls.lua
@@ -8,6 +8,7 @@
 --- ```sh
 --- npm install -g cssmodules-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'cssmodules-language-server' },
   filetypes = { 'javascript', 'javascriptreact', 'typescript', 'typescriptreact' },

--- a/lsp/cucumber_language_server.lua
+++ b/lsp/cucumber_language_server.lua
@@ -10,6 +10,7 @@
 --- ```sh
 --- npm install -g @cucumber/language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'cucumber-language-server', '--stdio' },
   filetypes = { 'cucumber' },

--- a/lsp/cue.lua
+++ b/lsp/cue.lua
@@ -3,6 +3,7 @@
 --- https://github.com/cue-lang/cue
 ---
 --- CUE makes it easy to validate data, write schemas, and ensure configurations align with policies.
+---@type vim.lsp.Config
 return {
   cmd = { 'cue', 'lsp' },
   filetypes = { 'cue' },

--- a/lsp/custom_elements_ls.lua
+++ b/lsp/custom_elements_ls.lua
@@ -23,6 +23,7 @@
 ---   ]
 --- }
 --- ```
+---@type vim.lsp.Config
 return {
   init_options = { hostInfo = 'neovim' },
   cmd = { 'custom-elements-languageserver', '--stdio' },

--- a/lsp/custom_elements_ls.lua
+++ b/lsp/custom_elements_ls.lua
@@ -27,5 +27,5 @@
 return {
   init_options = { hostInfo = 'neovim' },
   cmd = { 'custom-elements-languageserver', '--stdio' },
-  root_dir = { 'tsconfig.json', 'package.json', 'jsconfig.json', '.git' },
+  root_markers = { 'tsconfig.json', 'package.json', 'jsconfig.json', '.git' },
 }

--- a/lsp/cypher_ls.lua
+++ b/lsp/cypher_ls.lua
@@ -9,6 +9,7 @@
 --- ```sh
 --- npm i -g @neo4j-cypher/language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'cypher-language-server', '--stdio' },
   filetypes = { 'cypher' },

--- a/lsp/daedalus_ls.lua
+++ b/lsp/daedalus_ls.lua
@@ -2,6 +2,7 @@
 ---
 --- DaedalusLanguageServer
 
+---@type vim.lsp.Config
 return {
   cmd = { 'DaedalusLanguageServer' },
   filetypes = { 'd' },

--- a/lsp/dafny.lua
+++ b/lsp/dafny.lua
@@ -6,6 +6,7 @@
 -- older versions of Dafny, you can compile the language server from source at
 -- [dafny-lang/language-server-csharp](https://github.com/dafny-lang/language-server-csharp)
 -- and set `cmd = {"dotnet", "<Path to your language server>"}`.
+---@type vim.lsp.Config
 return {
   cmd = { 'dafny', 'server' },
   filetypes = { 'dfy', 'dafny' },

--- a/lsp/dagger.lua
+++ b/lsp/dagger.lua
@@ -3,6 +3,7 @@
 --- https://github.com/dagger/cuelsp
 ---
 --- Dagger's lsp server for cuelang.
+---@type vim.lsp.Config
 return {
   cmd = { 'cuelsp' },
   filetypes = { 'cue' },

--- a/lsp/dartls.lua
+++ b/lsp/dartls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/dart-lang/sdk/tree/master/pkg/analysis_server/tool/lsp_spec
 ---
 --- Language server for dart.
+---@type vim.lsp.Config
 return {
   cmd = { 'dart', 'language-server', '--protocol=lsp' },
   filetypes = { 'dart' },

--- a/lsp/dcmls.lua
+++ b/lsp/dcmls.lua
@@ -3,6 +3,7 @@
 --- https://dcm.dev/
 ---
 --- Language server for DCM analyzer.
+---@type vim.lsp.Config
 return {
   cmd = { 'dcm', 'start-server', '--client=neovim' },
   filetypes = { 'dart' },

--- a/lsp/debputy.lua
+++ b/lsp/debputy.lua
@@ -3,6 +3,7 @@
 --- https://salsa.debian.org/debian/debputy
 ---
 --- Language Server for Debian packages.
+---@type vim.lsp.Config
 return {
   cmd = { 'debputy', 'lsp', 'server' },
   filetypes = { 'debcontrol', 'debcopyright', 'debchangelog', 'autopkgtest', 'make', 'yaml' },

--- a/lsp/denols.lua
+++ b/lsp/denols.lua
@@ -98,7 +98,7 @@ return {
       client:exec_cmd({
         command = 'deno.cache',
         arguments = { {}, vim.uri_from_bufnr(bufnr) },
-      }, { bufnr = bufnr }, function(err, _result, ctx)
+      }, { bufnr = bufnr }, function(err, _, ctx)
         if err then
           local uri = ctx.params.arguments[2]
           vim.notify('cache command failed for' .. vim.uri_to_fname(uri), vim.log.levels.ERROR)

--- a/lsp/denols.lua
+++ b/lsp/denols.lua
@@ -63,6 +63,7 @@ local function denols_handler(err, result, ctx, config)
   lsp.handlers[ctx.method](err, result, ctx, config)
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'deno', 'lsp' },
   cmd_env = { NO_COLOR = true },

--- a/lsp/dhall_lsp_server.lua
+++ b/lsp/dhall_lsp_server.lua
@@ -10,6 +10,7 @@
 --- ```
 --- prebuilt binaries can be found [here](https://github.com/dhall-lang/dhall-haskell/releases).
 
+---@type vim.lsp.Config
 return {
   cmd = { 'dhall-lsp-server' },
   filetypes = { 'dhall' },

--- a/lsp/diagnosticls.lua
+++ b/lsp/diagnosticls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/iamcco/diagnostic-languageserver
 ---
 --- Diagnostic language server integrate with linters.
+---@type vim.lsp.Config
 return {
   -- Configuration from https://github.com/iamcco/diagnostic-languageserver#config--document
   cmd = { 'diagnostic-languageserver', '--stdio' },

--- a/lsp/digestif.lua
+++ b/lsp/digestif.lua
@@ -7,6 +7,7 @@
 --- context-sensitive completion, documentation, code navigation, and related functionality to any
 ---
 --- text editor that speaks the LSP protocol.
+---@type vim.lsp.Config
 return {
   cmd = { 'digestif' },
   filetypes = { 'tex', 'plaintex', 'context' },

--- a/lsp/djlsp.lua
+++ b/lsp/djlsp.lua
@@ -4,6 +4,7 @@
 ---
 --- `djlsp`, a language server for Django templates.
 
+---@type vim.lsp.Config
 return {
   cmd = { 'djlsp' },
   filetypes = { 'html', 'htmldjango' },

--- a/lsp/docker_compose_language_service.lua
+++ b/lsp/docker_compose_language_service.lua
@@ -11,6 +11,7 @@
 ---
 --- Note: If the docker-compose-langserver doesn't startup when entering a `docker-compose.yaml` file, make sure that the filetype is `yaml.docker-compose`. You can set with: `:set filetype=yaml.docker-compose`.
 
+---@type vim.lsp.Config
 return {
   cmd = { 'docker-compose-langserver', '--stdio' },
   filetypes = { 'yaml.docker-compose' },

--- a/lsp/docker_language_server.lua
+++ b/lsp/docker_language_server.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- go install github.com/docker/docker-language-server/cmd/docker-language-server@latest
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'docker-language-server', 'start', '--stdio' },
   filetypes = { 'dockerfile', 'yaml.docker-compose' },

--- a/lsp/dockerls.lua
+++ b/lsp/dockerls.lua
@@ -21,6 +21,7 @@
 ---     }
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'docker-langserver', '--stdio' },
   filetypes = { 'dockerfile' },

--- a/lsp/dolmenls.lua
+++ b/lsp/dolmenls.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- opam install dolmen_lsp
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'dolmenls' },
   filetypes = { 'smt2', 'tptp', 'p', 'cnf', 'icnf', 'zf' },

--- a/lsp/dotls.lua
+++ b/lsp/dotls.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- npm install -g dot-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'dot-language-server', '--stdio' },
   filetypes = { 'dot' },

--- a/lsp/dprint.lua
+++ b/lsp/dprint.lua
@@ -3,6 +3,7 @@
 --- https://github.com/dprint/dprint
 ---
 --- Pluggable and configurable code formatting platform written in Rust.
+---@type vim.lsp.Config
 return {
   cmd = { 'dprint', 'lsp' },
   filetypes = {

--- a/lsp/ds_pinyin_lsp.lua
+++ b/lsp/ds_pinyin_lsp.lua
@@ -23,7 +23,7 @@ end
 local function ds_pinyin_lsp_off(bufnr)
   local ds_pinyin_lsp_client = vim.lsp.get_clients({ bufnr = bufnr, name = 'ds_pinyin_lsp' })[1]
   if ds_pinyin_lsp_client then
-    ds_pinyin_lsp_client.notify('$/turn/completion', {
+    ds_pinyin_lsp_client:notify('$/turn/completion', {
       ['completion_on'] = false,
     })
   else
@@ -34,7 +34,7 @@ end
 local function ds_pinyin_lsp_on(bufnr)
   local ds_pinyin_lsp_client = vim.lsp.get_clients({ bufnr = bufnr, name = 'ds_pinyin_lsp' })[1]
   if ds_pinyin_lsp_client then
-    ds_pinyin_lsp_client.notify('$/turn/completion', {
+    ds_pinyin_lsp_client:notify('$/turn/completion', {
       ['completion_on'] = true,
     })
   else

--- a/lsp/ds_pinyin_lsp.lua
+++ b/lsp/ds_pinyin_lsp.lua
@@ -42,6 +42,7 @@ local function ds_pinyin_lsp_on(bufnr)
   end
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { bin_name },
   filetypes = { 'markdown', 'org' },

--- a/lsp/dts_lsp.lua
+++ b/lsp/dts_lsp.lua
@@ -12,6 +12,7 @@
 --- https://www.devicetree.org/
 --- https://docs.zephyrproject.org/latest/build/dts/index.html
 
+---@type vim.lsp.Config
 return {
   name = 'dts_lsp',
   cmd = { 'dts-lsp' },

--- a/lsp/earthlyls.lua
+++ b/lsp/earthlyls.lua
@@ -4,6 +4,7 @@
 ---
 --- A fast language server for earthly.
 
+---@type vim.lsp.Config
 return {
   cmd = { 'earthlyls' },
   filetypes = { 'earthfile' },

--- a/lsp/ecsact.lua
+++ b/lsp/ecsact.lua
@@ -6,6 +6,7 @@
 ---
 --- The default cmd assumes `ecsact_lsp_server` is in your PATH. Typically from the
 --- Ecsact SDK: https://ecsact.dev/start
+---@type vim.lsp.Config
 return {
   cmd = { 'ecsact_lsp_server', '--stdio' },
   filetypes = { 'ecsact' },

--- a/lsp/efm.lua
+++ b/lsp/efm.lua
@@ -18,6 +18,7 @@
 --- })
 --- ```
 
+---@type vim.lsp.Config
 return {
   cmd = { 'efm-langserver' },
   root_markers = { '.git' },

--- a/lsp/elixirls.lua
+++ b/lsp/elixirls.lua
@@ -25,6 +25,7 @@
 --- ```
 ---
 --- 'root_dir' is chosen like this: if two or more directories containing `mix.exs` were found when searching directories upward, the second one (higher up) is chosen, with the assumption that it is the root of an umbrella app. Otherwise the directory containing the single mix.exs that was found is chosen.
+---@type vim.lsp.Config
 return {
   filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
   root_dir = function(bufnr, on_dir)

--- a/lsp/elmls.lua
+++ b/lsp/elmls.lua
@@ -9,6 +9,7 @@
 
 local api = vim.api
 
+---@type vim.lsp.Config
 return {
   cmd = { 'elm-language-server' },
   -- TODO(ashkan) if we comment this out, it will allow elmls to operate on elm.json. It seems like it could do that, but no other editor allows it right now.

--- a/lsp/elp.lua
+++ b/lsp/elp.lua
@@ -4,6 +4,7 @@
 ---
 --- ELP integrates Erlang into modern IDEs via the language server protocol and was
 --- inspired by rust-analyzer.
+---@type vim.lsp.Config
 return {
   cmd = { 'elp', 'server' },
   filetypes = { 'erlang' },

--- a/lsp/ember.lua
+++ b/lsp/ember.lua
@@ -7,6 +7,7 @@
 --- ```sh
 --- npm install -g @ember-tooling/ember-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'ember-language-server', '--stdio' },
   filetypes = { 'handlebars', 'typescript', 'javascript', 'typescript.glimmer', 'javascript.glimmer' },

--- a/lsp/emmet_language_server.lua
+++ b/lsp/emmet_language_server.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- npm install -g @olrtg/emmet-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'emmet-language-server', '--stdio' },
   filetypes = {

--- a/lsp/emmet_ls.lua
+++ b/lsp/emmet_ls.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- npm install -g emmet-ls
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'emmet-ls', '--stdio' },
   filetypes = {

--- a/lsp/emmylua_ls.lua
+++ b/lsp/emmylua_ls.lua
@@ -10,6 +10,7 @@
 --- The default `cmd` assumes that the `emmylua_ls` binary can be found in `$PATH`.
 --- It might require you to provide cargo binaries installation path in it.
 
+---@type vim.lsp.Config
 return {
   cmd = { 'emmylua_ls' },
   filetypes = { 'lua' },

--- a/lsp/erg_language_server.lua
+++ b/lsp/erg_language_server.lua
@@ -11,6 +11,7 @@
 --- erg --language-server
 --- ```
 
+---@type vim.lsp.Config
 return {
   cmd = { 'erg', '--language-server' },
   filetypes = { 'erg' },

--- a/lsp/erlangls.lua
+++ b/lsp/erlangls.lua
@@ -12,6 +12,7 @@
 --- Installation requirements:
 ---     - [Erlang OTP 21+](https://github.com/erlang/otp)
 ---     - [rebar3 3.9.1+](https://github.com/erlang/rebar3)
+---@type vim.lsp.Config
 return {
   cmd = { 'erlang_ls' },
   filetypes = { 'erlang' },

--- a/lsp/esbonio.lua
+++ b/lsp/esbonio.lua
@@ -42,6 +42,7 @@
 --- ```
 ---
 --- A full list and explanation of the available options can be found [here](https://docs.esbon.io/en/esbonio-language-server-v0.16.4/lsp/getting-started.html?editor=neovim-lspconfig#configuration)
+---@type vim.lsp.Config
 return {
   cmd = { 'python3', '-m', 'esbonio' },
   filetypes = { 'rst' },

--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -57,6 +57,7 @@ local eslint_config_files = {
   'eslint.config.cts',
 }
 
+---@type vim.lsp.Config
 return {
   cmd = { 'vscode-eslint-language-server', '--stdio' },
   filetypes = {

--- a/lsp/facility_language_server.lua
+++ b/lsp/facility_language_server.lua
@@ -3,6 +3,7 @@
 --- https://github.com/FacilityApi/FacilityLanguageServer
 ---
 --- Facility language server protocol (LSP) support.
+---@type vim.lsp.Config
 return {
   cmd = { 'facility-language-server' },
   filetypes = { 'fsd' },

--- a/lsp/fennel_language_server.lua
+++ b/lsp/fennel_language_server.lua
@@ -3,6 +3,7 @@
 --- https://github.com/rydesun/fennel-language-server
 ---
 --- Fennel language server protocol (LSP) support.
+---@type vim.lsp.Config
 return {
   cmd = { 'fennel-language-server' },
   filetypes = { 'fennel' },

--- a/lsp/fennel_ls.lua
+++ b/lsp/fennel_ls.lua
@@ -7,6 +7,7 @@
 --- fennel-ls is configured using the closest file to your working directory named `flsproject.fnl`.
 --- All fennel-ls configuration options [can be found here](https://git.sr.ht/~xerool/fennel-ls/tree/HEAD/docs/manual.md#configuration).
 
+---@type vim.lsp.Config
 return {
   cmd = { 'fennel-ls' },
   filetypes = { 'fennel' },

--- a/lsp/fish_lsp.lua
+++ b/lsp/fish_lsp.lua
@@ -8,6 +8,7 @@
 --- scope aware symbol analysis, per-token hover generation, and many others.
 ---
 --- [homepage](https://www.fish-lsp.dev/)
+---@type vim.lsp.Config
 return {
   cmd = { 'fish-lsp', 'start' },
   filetypes = { 'fish' },

--- a/lsp/flow.lua
+++ b/lsp/flow.lua
@@ -11,6 +11,7 @@
 --- ```sh
 --- npx flow lsp --help
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'npx', '--no-install', 'flow', 'lsp' },
   filetypes = { 'javascript', 'javascriptreact', 'javascript.jsx' },

--- a/lsp/flux_lsp.lua
+++ b/lsp/flux_lsp.lua
@@ -5,6 +5,7 @@
 --- ```sh
 --- cargo install --git https://github.com/influxdata/flux-lsp
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'flux-lsp' },
   filetypes = { 'flux' },

--- a/lsp/foam_ls.lua
+++ b/lsp/foam_ls.lua
@@ -7,6 +7,7 @@
 --- npm install -g foam-language-server
 --- ```
 
+---@type vim.lsp.Config
 return {
   cmd = { 'foam-ls', '--stdio' },
   filetypes = { 'foam', 'OpenFOAM' },

--- a/lsp/fortls.lua
+++ b/lsp/fortls.lua
@@ -11,6 +11,7 @@
 --- Settings to the server can be passed either through the `cmd` option or through
 --- a local configuration file e.g. `.fortls`. For more information
 --- see the `fortls` [documentation](https://fortls.fortran-lang.org/options.html).
+---@type vim.lsp.Config
 return {
   cmd = {
     'fortls',

--- a/lsp/fsautocomplete.lua
+++ b/lsp/fsautocomplete.lua
@@ -19,6 +19,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'fsautocomplete', '--adaptive-lsp-server-enabled' },
   root_dir = function(bufnr, on_dir)

--- a/lsp/fsharp_language_server.lua
+++ b/lsp/fsharp_language_server.lua
@@ -15,6 +15,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'dotnet', 'FSharpLanguageServer.dll' },
   root_dir = function(bufnr, on_dir)

--- a/lsp/fstar.lua
+++ b/lsp/fstar.lua
@@ -3,6 +3,7 @@
 --- https://github.com/FStarLang/FStar
 ---
 --- LSP support is included in FStar. Make sure `fstar.exe` is in your PATH.
+---@type vim.lsp.Config
 return {
   cmd = { 'fstar.exe', '--lsp' },
   filetypes = { 'fstar' },

--- a/lsp/futhark_lsp.lua
+++ b/lsp/futhark_lsp.lua
@@ -8,6 +8,7 @@
 --- ```
 --- futhark lsp
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'futhark', 'lsp' },
   filetypes = { 'futhark', 'fut' },

--- a/lsp/gdscript.lua
+++ b/lsp/gdscript.lua
@@ -7,6 +7,7 @@
 local port = os.getenv 'GDScript_Port' or '6005'
 local cmd = vim.lsp.rpc.connect('127.0.0.1', tonumber(port))
 
+---@type vim.lsp.Config
 return {
   cmd = cmd,
   filetypes = { 'gd', 'gdscript', 'gdscript3' },

--- a/lsp/gdshader_lsp.lua
+++ b/lsp/gdshader_lsp.lua
@@ -3,6 +3,7 @@
 --- https://github.com/godofavacyn/gdshader-lsp
 ---
 --- A language server for the Godot Shading language.
+---@type vim.lsp.Config
 return {
   cmd = { 'gdshader-lsp', '--stdio' },
   filetypes = { 'gdshader', 'gdshaderinc' },

--- a/lsp/gh_actions_ls.lua
+++ b/lsp/gh_actions_ls.lua
@@ -13,6 +13,7 @@
 --- ```sh
 --- npm install -g gh-actions-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'gh-actions-language-server', '--stdio' },
   filetypes = { 'yaml' },

--- a/lsp/ghcide.lua
+++ b/lsp/ghcide.lua
@@ -4,6 +4,7 @@
 ---
 --- A library for building Haskell IDE tooling.
 --- "ghcide" isn't for end users now. Use "haskell-language-server" instead of "ghcide".
+---@type vim.lsp.Config
 return {
   cmd = { 'ghcide', '--lsp' },
   filetypes = { 'haskell', 'lhaskell' },

--- a/lsp/ghdl_ls.lua
+++ b/lsp/ghdl_ls.lua
@@ -6,6 +6,7 @@
 ---
 --- `ghdl-ls` is part of pyghdl, for installation instructions see
 --- [the upstream README](https://github.com/ghdl/ghdl/tree/master/pyGHDL/lsp).
+---@type vim.lsp.Config
 return {
   cmd = { 'ghdl-ls' },
   filetypes = { 'vhdl' },

--- a/lsp/ginko_ls.lua
+++ b/lsp/ginko_ls.lua
@@ -7,6 +7,7 @@
 --- Install `ginko_ls` from https://github.com/Schottkyc137/ginko and add it to path
 ---
 --- `ginko_ls` doesn't require any configuration.
+---@type vim.lsp.Config
 return {
   cmd = { 'ginko_ls' },
   filetypes = { 'dts' },

--- a/lsp/gitlab_ci_ls.lua
+++ b/lsp/gitlab_ci_ls.lua
@@ -11,6 +11,7 @@ local util = require 'lspconfig.util'
 
 local cache_dir = vim.uv.os_homedir() .. '/.cache/gitlab-ci-ls/'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'gitlab-ci-ls' },
   filetypes = { 'yaml.gitlab' },

--- a/lsp/glasgow.lua
+++ b/lsp/glasgow.lua
@@ -20,6 +20,7 @@
 --- ```sh
 --- cargo install glasgow
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'glasgow' },
   filetypes = { 'wgsl' },

--- a/lsp/gleam.lua
+++ b/lsp/gleam.lua
@@ -5,6 +5,7 @@
 --- A language server for Gleam Programming Language.
 ---
 --- It comes with the Gleam compiler, for installation see: [Installing Gleam](https://gleam.run/getting-started/installing/)
+---@type vim.lsp.Config
 return {
   cmd = { 'gleam', 'lsp' },
   filetypes = { 'gleam' },

--- a/lsp/glint.lua
+++ b/lsp/glint.lua
@@ -22,6 +22,7 @@
 ---   },
 --- })
 
+---@type vim.lsp.Config
 return {
   cmd = function(dispatchers, config)
     local cmd = (config.init_options.glint.useGlobal or not config.root_dir) and { 'glint-language-server' }

--- a/lsp/glsl_analyzer.lua
+++ b/lsp/glsl_analyzer.lua
@@ -3,6 +3,7 @@
 --- https://github.com/nolanderc/glsl_analyzer
 ---
 --- Language server for GLSL
+---@type vim.lsp.Config
 return {
   cmd = { 'glsl_analyzer' },
   filetypes = { 'glsl', 'vert', 'tesc', 'tese', 'frag', 'geom', 'comp' },

--- a/lsp/glslls.lua
+++ b/lsp/glslls.lua
@@ -6,6 +6,7 @@
 ---
 --- `glslls` can be compiled and installed manually, or, if your distribution has access to the AUR,
 --- via the `glsl-language-server` AUR package
+---@type vim.lsp.Config
 return {
   cmd = { 'glslls', '--stdin' },
   filetypes = { 'glsl', 'vert', 'tesc', 'tese', 'frag', 'geom', 'comp' },

--- a/lsp/gnls.lua
+++ b/lsp/gnls.lua
@@ -12,6 +12,7 @@
 ---
 --- exec node ${GNLS_SRC_DIR}/build/server.js $@
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'gnls', '--stdio' },
   filetypes = { 'gn' },

--- a/lsp/golangci_lint_ls.lua
+++ b/lsp/golangci_lint_ls.lua
@@ -12,6 +12,7 @@
 --- go install github.com/nametake/golangci-lint-langserver@latest
 --- go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'golangci-lint-langserver' },
   filetypes = { 'go', 'gomod' },

--- a/lsp/gopls.lua
+++ b/lsp/gopls.lua
@@ -85,6 +85,7 @@ local function get_root_dir(fname)
   return vim.fs.root(fname, 'go.work') or vim.fs.root(fname, 'go.mod') or vim.fs.root(fname, '.git')
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'gopls' },
   filetypes = { 'go', 'gomod', 'gowork', 'gotmpl' },

--- a/lsp/gradle_ls.lua
+++ b/lsp/gradle_ls.lua
@@ -11,6 +11,7 @@ if vim.fn.has 'win32' == 1 then
   bin_name = bin_name .. '.bat'
 end
 
+---@type vim.lsp.Config
 return {
   filetypes = { 'groovy' },
   root_markers = {

--- a/lsp/grammarly.lua
+++ b/lsp/grammarly.lua
@@ -9,6 +9,7 @@
 --- ```
 ---
 --- WARNING: Since this language server uses Grammarly's API, any document you open with it running is shared with them. Please evaluate their [privacy policy](https://www.grammarly.com/privacy-policy) before using this.
+---@type vim.lsp.Config
 return {
   cmd = { 'grammarly-languageserver', '--stdio' },
   filetypes = { 'markdown' },

--- a/lsp/graphql.lua
+++ b/lsp/graphql.lua
@@ -12,6 +12,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'graphql-lsp', 'server', '-m', 'stream' },
   filetypes = { 'graphql', 'typescriptreact', 'javascriptreact' },

--- a/lsp/groovyls.lua
+++ b/lsp/groovyls.lua
@@ -17,6 +17,7 @@
 ---     ...
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = {
     'java',

--- a/lsp/guile_ls.lua
+++ b/lsp/guile_ls.lua
@@ -10,6 +10,7 @@
 --- Checkout the repo for more info.
 ---
 --- Note: This LSP will start on `scheme.guile` filetype. You can set this file type using `:help modeline` or adding https://gitlab.com/HiPhish/guile.vim to your plugins to automatically set it.
+---@type vim.lsp.Config
 return {
   cmd = { 'guile-lsp-server' },
   filetypes = {

--- a/lsp/harper_ls.lua
+++ b/lsp/harper_ls.lua
@@ -16,6 +16,7 @@
 ---   },
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'harper-ls', '--stdio' },
   filetypes = {

--- a/lsp/hdl_checker.lua
+++ b/lsp/hdl_checker.lua
@@ -3,6 +3,7 @@
 --- https://github.com/suoto/hdl_checker
 --- Language server for hdl-checker.
 --- Install using: `pip install hdl-checker --upgrade`
+---@type vim.lsp.Config
 return {
   cmd = { 'hdl_checker', '--lsp' },
   filetypes = { 'vhdl', 'verilog', 'systemverilog' },

--- a/lsp/helm_ls.lua
+++ b/lsp/helm_ls.lua
@@ -9,6 +9,7 @@
 --- The default `cmd` assumes that the `helm_ls` binary can be found in `$PATH`.
 ---
 --- If need Helm file highlight use [vim-helm](https://github.com/towolf/vim-helm) plugin.
+---@type vim.lsp.Config
 return {
   cmd = { 'helm_ls', 'serve' },
   filetypes = { 'helm', 'yaml.helm-values' },

--- a/lsp/herb_ls.lua
+++ b/lsp/herb_ls.lua
@@ -20,6 +20,7 @@
 --- ```sh
 --- yarn global add @herb-tools/language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'herb-language-server', '--stdio' },
   filetypes = { 'html', 'ruby', 'eruby' },

--- a/lsp/hhvm.lua
+++ b/lsp/hhvm.lua
@@ -5,6 +5,7 @@
 --- https://github.com/facebook/hhvm
 --- See below for how to setup HHVM & typechecker:
 --- https://docs.hhvm.com/hhvm/getting-started/getting-started
+---@type vim.lsp.Config
 return {
   cmd = { 'hh_client', 'lsp' },
   filetypes = { 'php', 'hack' },

--- a/lsp/hie.lua
+++ b/lsp/hie.lua
@@ -16,6 +16,7 @@
 ---   }
 --- }
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'hie-wrapper', '--lsp' },
   filetypes = { 'haskell' },

--- a/lsp/hlasm.lua
+++ b/lsp/hlasm.lua
@@ -3,6 +3,7 @@
 --- `hlasm_language_server` is a language server for the High Level Assembler language used on IBM SystemZ mainframes.
 ---
 --- To learn how to configure the HLASM language server, see the [HLASM Language Support documentation](https://github.com/eclipse-che4z/che-che4z-lsp-for-hlasm).
+---@type vim.lsp.Config
 return {
   cmd = { 'hlasm_language_server' },
   filetypes = { 'hlasm' },

--- a/lsp/hls.lua
+++ b/lsp/hls.lua
@@ -14,6 +14,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'haskell-language-server-wrapper', '--lsp' },
   filetypes = { 'haskell', 'lhaskell' },

--- a/lsp/hoon_ls.lua
+++ b/lsp/hoon_ls.lua
@@ -8,6 +8,7 @@
 ---
 --- Start a fake ~zod with `urbit -F zod`.
 --- Start the language server at the Urbit Dojo prompt with: `|start %language-server`
+---@type vim.lsp.Config
 return {
   cmd = { 'hoon-language-server' },
   filetypes = { 'hoon' },

--- a/lsp/html.lua
+++ b/lsp/html.lua
@@ -21,6 +21,7 @@
 ---   capabilities = capabilities,
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'vscode-html-language-server', '--stdio' },
   filetypes = { 'html', 'templ' },

--- a/lsp/htmx.lua
+++ b/lsp/htmx.lua
@@ -8,6 +8,7 @@
 --- ```
 ---
 --- Lsp is still very much work in progress and experimental. Use at your own risk.
+---@type vim.lsp.Config
 return {
   cmd = { 'htmx-lsp' },
   filetypes = { -- filetypes copied and adjusted from tailwindcss-intellisense

--- a/lsp/hydra_lsp.lua
+++ b/lsp/hydra_lsp.lua
@@ -3,6 +3,7 @@
 --- https://github.com/Retsediv/hydra-lsp
 ---
 --- LSP for Hydra Python package config files.
+---@type vim.lsp.Config
 return {
   cmd = { 'hydra-lsp' },
   filetypes = { 'yaml' },

--- a/lsp/hyprls.lua
+++ b/lsp/hyprls.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- go install github.com/hyprland-community/hyprls/cmd/hyprls@latest
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'hyprls', '--stdio' },
   filetypes = { 'hyprlang' },

--- a/lsp/idris2_lsp.lua
+++ b/lsp/idris2_lsp.lua
@@ -31,6 +31,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'idris2-lsp' },
   filetypes = { 'idris2' },

--- a/lsp/intelephense.lua
+++ b/lsp/intelephense.lua
@@ -25,6 +25,7 @@
 --- }
 --- ```
 
+---@type vim.lsp.Config
 return {
   cmd = { 'intelephense', '--stdio' },
   filetypes = { 'php' },

--- a/lsp/janet_lsp.lua
+++ b/lsp/janet_lsp.lua
@@ -3,6 +3,7 @@
 --- https://github.com/CFiggers/janet-lsp
 ---
 --- A Language Server Protocol implementation for Janet.
+---@type vim.lsp.Config
 return {
   cmd = {
     'janet-lsp',

--- a/lsp/java_language_server.lua
+++ b/lsp/java_language_server.lua
@@ -5,6 +5,7 @@
 --- Java language server
 ---
 --- Point `cmd` to `lang_server_linux.sh` or the equivalent script for macOS/Windows provided by java-language-server
+---@type vim.lsp.Config
 return {
   filetypes = { 'java' },
   root_markers = { 'build.gradle', 'build.gradle.kts', 'pom.xml', '.git' },

--- a/lsp/jdtls.lua
+++ b/lsp/jdtls.lua
@@ -109,6 +109,7 @@ local function on_language_status(_, result)
   command 'echohl None'
 end
 
+---@type vim.lsp.Config
 return {
   cmd = {
     'jdtls',

--- a/lsp/jedi_language_server.lua
+++ b/lsp/jedi_language_server.lua
@@ -3,6 +3,7 @@
 --- https://github.com/pappasam/jedi-language-server
 ---
 --- `jedi-language-server`, a language server for Python, built on top of jedi
+---@type vim.lsp.Config
 return {
   cmd = { 'jedi-language-server' },
   filetypes = { 'python' },

--- a/lsp/jinja_lsp.lua
+++ b/lsp/jinja_lsp.lua
@@ -13,6 +13,7 @@
 ---   },
 --- }
 --- ```
+---@type vim.lsp.Config
 return {
   name = 'jinja_lsp',
   cmd = { 'jinja-lsp' },

--- a/lsp/jqls.lua
+++ b/lsp/jqls.lua
@@ -15,6 +15,7 @@
 --- ```lua
 --- vim.cmd([[au BufRead,BufNewFile *.jq setfiletype jq]])
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'jq-lsp' },
   filetypes = { 'jq' },

--- a/lsp/jsonls.lua
+++ b/lsp/jsonls.lua
@@ -20,6 +20,7 @@
 ---   capabilities = capabilities,
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'vscode-json-language-server', '--stdio' },
   filetypes = { 'json', 'jsonc' },

--- a/lsp/jsonnet_ls.lua
+++ b/lsp/jsonnet_ls.lua
@@ -8,6 +8,7 @@
 --- ```sh
 --- go install github.com/grafana/jsonnet-language-server@latest
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'jsonnet-language-server' },
   filetypes = {

--- a/lsp/julials.lua
+++ b/lsp/julials.lua
@@ -116,6 +116,7 @@ local cmd = {
   ]],
 }
 
+---@type vim.lsp.Config
 return {
   cmd = cmd,
   filetypes = { 'julia' },

--- a/lsp/just.lua
+++ b/lsp/just.lua
@@ -3,6 +3,7 @@
 --- https://github.com/terror/just-lsp
 ---
 --- `just-lsp` is an LSP for just built on top of the tree-sitter-just parser.
+---@type vim.lsp.Config
 return {
   cmd = { 'just-lsp' },
   filetypes = { 'just' },

--- a/lsp/kcl.lua
+++ b/lsp/kcl.lua
@@ -4,6 +4,7 @@
 ---
 --- Language server for the KCL configuration and policy language.
 ---
+---@type vim.lsp.Config
 return {
   cmd = { 'kcl-language-server' },
   filetypes = { 'kcl' },

--- a/lsp/koka.lua
+++ b/lsp/koka.lua
@@ -2,6 +2,7 @@
 ---
 --- https://koka-lang.github.io/koka/doc/index.html
 --- Koka is a functional programming language with effect types and handlers.
+---@type vim.lsp.Config
 return {
   cmd = { 'koka', '--language-server', '--lsstdio' },
   filetypes = { 'koka' },

--- a/lsp/kotlin_language_server.lua
+++ b/lsp/kotlin_language_server.lua
@@ -30,6 +30,7 @@ local root_files = {
   'build.gradle.kts', -- Gradle
 }
 
+---@type vim.lsp.Config
 return {
   filetypes = { 'kotlin' },
   root_markers = root_files,

--- a/lsp/kotlin_lsp.lua
+++ b/lsp/kotlin_lsp.lua
@@ -7,6 +7,7 @@
 --
 --  These are configuration files for the various build systems supported by
 --  Kotlin.
+---@type vim.lsp.Config
 return {
   filetypes = { 'kotlin' },
   cmd = { 'kotlin-lsp', '--stdio' },

--- a/lsp/kulala_ls.lua
+++ b/lsp/kulala_ls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/mistweaverco/kulala-ls
 ---
 --- A minimal language server for HTTP syntax.
+---@type vim.lsp.Config
 return {
   cmd = { 'kulala-ls', '--stdio' },
   filetypes = { 'http' },

--- a/lsp/laravel_ls.lua
+++ b/lsp/laravel_ls.lua
@@ -6,6 +6,7 @@
 ---
 --- The default `cmd` assumes that the `laravel-ls` binary can be found in `$PATH`.
 
+---@type vim.lsp.Config
 return {
   cmd = { 'laravel-ls' },
   filetypes = { 'php', 'blade' },

--- a/lsp/lean3ls.lua
+++ b/lsp/lean3ls.lua
@@ -14,6 +14,7 @@
 --- that plugin fully handles the setup of the Lean language server,
 --- and you shouldn't set up `lean3ls` both with it and `lspconfig`.
 
+---@type vim.lsp.Config
 return {
   cmd = { 'lean-language-server', '--stdio', '--', '-M', '4096', '-T', '100000' },
   filetypes = { 'lean3' },

--- a/lsp/lelwel_ls.lua
+++ b/lsp/lelwel_ls.lua
@@ -8,6 +8,7 @@
 --- ```sh
 --- cargo install --features="lsp" lelwel
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'lelwel-ls' },
   filetypes = { 'llw' },

--- a/lsp/lemminx.lua
+++ b/lsp/lemminx.lua
@@ -5,6 +5,7 @@
 --- The easiest way to install the server is to get a binary from https://github.com/redhat-developer/vscode-xml/releases and place it on your PATH.
 ---
 --- NOTE to macOS users: Binaries from unidentified developers are blocked by default. If you trust the downloaded binary, run it once, cancel the prompt, then remove the binary from Gatekeeper quarantine with `xattr -d com.apple.quarantine lemminx`. It should now run without being blocked.
+---@type vim.lsp.Config
 return {
   cmd = { 'lemminx' },
   filetypes = { 'xml', 'xsd', 'xsl', 'xslt', 'svg' },

--- a/lsp/lexical.lua
+++ b/lsp/lexical.lua
@@ -8,6 +8,7 @@
 ---
 --- **By default, `lexical` doesn't have a `cmd` set.**
 --- This is because nvim-lspconfig does not make assumptions about your path.
+---@type vim.lsp.Config
 return {
   filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
   root_markers = { 'mix.exs', '.git' },

--- a/lsp/lsp_ai.lua
+++ b/lsp/lsp_ai.lua
@@ -9,6 +9,7 @@
 --- You will need to provide configuration for the inference backends and models you want to use, as well as configure
 --- completion/code actions. See the [wiki docs](https://github.com/SilasMarvin/lsp-ai/wiki/Configuration) and
 --- [examples](https://github.com/SilasMarvin/lsp-ai/blob/main/examples/nvim) for more information.
+---@type vim.lsp.Config
 return {
   cmd = { 'lsp-ai' },
   filetypes = {},

--- a/lsp/ltex.lua
+++ b/lsp/ltex.lua
@@ -71,6 +71,7 @@ do
   end
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'ltex-ls' },
   filetypes = filetypes,

--- a/lsp/ltex_plus.lua
+++ b/lsp/ltex_plus.lua
@@ -32,10 +32,6 @@ local language_id_mapping = {
   text = 'plaintext',
 }
 
-local function get_language_id(_, filetype)
-  return language_id_mapping[filetype] or filetype
-end
-
 ---@type vim.lsp.Config
 return {
   cmd = { 'ltex-ls-plus' },
@@ -60,7 +56,9 @@ return {
     'xhtml',
   },
   root_markers = { '.git' },
-  get_language_id = get_language_id,
+  get_language_id = function(_, filetype)
+    return language_id_mapping[filetype] or filetype
+  end,
   settings = {
     ltex = {
       enabled = {

--- a/lsp/ltex_plus.lua
+++ b/lsp/ltex_plus.lua
@@ -36,6 +36,7 @@ local function get_language_id(_, filetype)
   return language_id_mapping[filetype] or filetype
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'ltex-ls-plus' },
   filetypes = {

--- a/lsp/lua_ls.lua
+++ b/lsp/lua_ls.lua
@@ -67,6 +67,7 @@
 --- * [Lua.runtime.path](https://luals.github.io/wiki/settings/#runtimepath)
 --- * [Lua.workspace.library](https://luals.github.io/wiki/settings/#workspacelibrary)
 ---
+---@type vim.lsp.Config
 return {
   cmd = { 'lua-language-server' },
   filetypes = { 'lua' },

--- a/lsp/luau_lsp.lua
+++ b/lsp/luau_lsp.lua
@@ -11,6 +11,7 @@
 --- ```vim
 --- autocmd BufRead,BufNewFile *.luau setf luau
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'luau-lsp', 'lsp' },
   filetypes = { 'luau' },

--- a/lsp/lwc_ls.lua
+++ b/lsp/lwc_ls.lua
@@ -16,6 +16,7 @@
 ---   }
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'lwc-language-server', '--stdio' },
   filetypes = { 'javascript', 'html' },

--- a/lsp/m68k.lua
+++ b/lsp/m68k.lua
@@ -15,6 +15,7 @@
 --- ```lua
 --- vim.g.asmsyntax = 'asm68k'
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'm68k-lsp-server', '--stdio' },
   filetypes = { 'asm68k' },

--- a/lsp/markdown_oxide.lua
+++ b/lsp/markdown_oxide.lua
@@ -20,6 +20,7 @@ local function command_factory(client, bufnr, cmd)
   }, { bufnr = bufnr })
 end
 
+---@type vim.lsp.Config
 return {
   root_markers = { '.git', '.obsidian', '.moxide.toml' },
   filetypes = { 'markdown' },

--- a/lsp/marko-js.lua
+++ b/lsp/marko-js.lua
@@ -8,6 +8,7 @@
 --- ```
 --- npm i -g @marko/language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'marko-language-server', '--stdio' },
   filetypes = { 'marko' },

--- a/lsp/marksman.lua
+++ b/lsp/marksman.lua
@@ -11,6 +11,7 @@
 local bin_name = 'marksman'
 local cmd = { bin_name, 'server' }
 
+---@type vim.lsp.Config
 return {
   cmd = cmd,
   filetypes = { 'markdown', 'markdown.mdx' },

--- a/lsp/marksman.lua
+++ b/lsp/marksman.lua
@@ -8,12 +8,9 @@
 ---
 --- Pre-built binaries can be downloaded from https://github.com/artempyanykh/marksman/releases
 
-local bin_name = 'marksman'
-local cmd = { bin_name, 'server' }
-
 ---@type vim.lsp.Config
 return {
-  cmd = cmd,
+  cmd = { 'marksman', 'server' },
   filetypes = { 'markdown', 'markdown.mdx' },
   root_markers = { '.marksman.toml', '.git' },
 }

--- a/lsp/matlab_ls.lua
+++ b/lsp/matlab_ls.lua
@@ -14,6 +14,7 @@
 ---   },
 --- },
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'matlab-language-server', '--stdio' },
   filetypes = { 'matlab' },

--- a/lsp/mdx_analyzer.lua
+++ b/lsp/mdx_analyzer.lua
@@ -5,6 +5,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'mdx-language-server', '--stdio' },
   filetypes = { 'mdx' },

--- a/lsp/mesonlsp.lua
+++ b/lsp/mesonlsp.lua
@@ -28,6 +28,7 @@ local meson_matcher = function(_, path)
   return false
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'mesonlsp', '--lsp' },
   filetypes = { 'meson' },

--- a/lsp/metals.lua
+++ b/lsp/metals.lua
@@ -11,6 +11,7 @@
 --- Note: that if you're using [nvim-metals](https://github.com/scalameta/nvim-metals), that plugin fully handles the setup and installation of Metals, and you shouldn't set up Metals both with it and `lspconfig`.
 ---
 --- To install Metals, make sure to have [coursier](https://get-coursier.io/docs/cli-installation) installed, and once you do you can install the latest Metals with `cs install metals`.
+---@type vim.lsp.Config
 return {
   cmd = { 'metals' },
   filetypes = { 'scala' },

--- a/lsp/millet.lua
+++ b/lsp/millet.lua
@@ -10,6 +10,7 @@
 --- 2. Clone the repo
 --- 3. Run `cargo build --release --bin millet-ls`
 --- 4. Move `target/release/millet-ls` to somewhere on your $PATH as `millet`
+---@type vim.lsp.Config
 return {
   cmd = { 'millet' },
   filetypes = { 'sml' },

--- a/lsp/mint.lua
+++ b/lsp/mint.lua
@@ -4,6 +4,7 @@
 ---
 --- Install Mint using the [instructions](https://www.mint-lang.com/install).
 --- The language server is included since version 0.12.0.
+---@type vim.lsp.Config
 return {
   cmd = { 'mint', 'ls' },
   filetypes = { 'mint' },

--- a/lsp/mlir_lsp_server.lua
+++ b/lsp/mlir_lsp_server.lua
@@ -5,6 +5,7 @@
 --- The Language Server for the LLVM MLIR language
 ---
 --- `mlir-lsp-server` can be installed at the llvm-project repository (https://github.com/llvm/llvm-project)
+---@type vim.lsp.Config
 return {
   cmd = { 'mlir-lsp-server' },
   filetypes = { 'mlir' },

--- a/lsp/mlir_pdll_lsp_server.lua
+++ b/lsp/mlir_pdll_lsp_server.lua
@@ -5,6 +5,7 @@
 --- The Language Server for the LLVM PDLL language
 ---
 --- `mlir-pdll-lsp-server` can be installed at the llvm-project repository (https://github.com/llvm/llvm-project)
+---@type vim.lsp.Config
 return {
   cmd = { 'mlir-pdll-lsp-server' },
   filetypes = { 'pdll' },

--- a/lsp/mm0_ls.lua
+++ b/lsp/mm0_ls.lua
@@ -6,6 +6,7 @@
 ---
 --- Requires [mm0-rs](https://github.com/digama0/mm0/tree/master/mm0-rs) to be installed
 --- and available on the `PATH`.
+---@type vim.lsp.Config
 return {
   cmd = { 'mm0-rs', 'server' },
   root_markers = { '.git' },

--- a/lsp/mojo.lua
+++ b/lsp/mojo.lua
@@ -5,6 +5,7 @@
 --- `mojo-lsp-server` can be installed [via Modular](https://developer.modular.com/download)
 ---
 --- Mojo is a new programming language that bridges the gap between research and production by combining Python syntax and ecosystem with systems programming and metaprogramming features.
+---@type vim.lsp.Config
 return {
   cmd = { 'mojo-lsp-server' },
   filetypes = { 'mojo' },

--- a/lsp/motoko_lsp.lua
+++ b/lsp/motoko_lsp.lua
@@ -3,6 +3,7 @@
 --- https://github.com/dfinity/vscode-motoko
 ---
 --- Language server for the Motoko programming language.
+---@type vim.lsp.Config
 return {
   cmd = { 'motoko-lsp', '--stdio' },
   filetypes = { 'motoko' },

--- a/lsp/move_analyzer.lua
+++ b/lsp/move_analyzer.lua
@@ -11,6 +11,7 @@
 --- ```
 ---
 --- See [`move-analyzer`'s doc](https://github.com/move-language/move/blob/1b258a06e3c7d2bc9174578aac92cca3ac19de71/language/move-analyzer/editors/code/README.md#how-to-install) for details.
+---@type vim.lsp.Config
 return {
   cmd = { 'move-analyzer' },
   filetypes = { 'move' },

--- a/lsp/msbuild_project_tools_server.lua
+++ b/lsp/msbuild_project_tools_server.lua
@@ -35,6 +35,7 @@
 local host_dll_name = 'MSBuildProjectTools.LanguageServer.Host.dll'
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   filetypes = { 'msbuild' },
   root_dir = function(bufnr, on_dir)

--- a/lsp/muon.lua
+++ b/lsp/muon.lua
@@ -1,6 +1,7 @@
 ---@brief
 ---
 --- https://muon.build
+---@type vim.lsp.Config
 return {
   cmd = { 'muon', 'analyze', 'lsp' },
   filetypes = { 'meson' },

--- a/lsp/mutt_ls.lua
+++ b/lsp/mutt_ls.lua
@@ -7,6 +7,7 @@
 --- ```sh
 --- pip install mutt-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'mutt-language-server' },
   filetypes = { 'muttrc', 'neomuttrc' },

--- a/lsp/nelua_lsp.lua
+++ b/lsp/nelua_lsp.lua
@@ -23,6 +23,7 @@
 ---     cmd = { "nelua", "-L", "/path/to/nelua-lsp/", "--script", "/path/to/nelua-lsp/nelua-lsp.lua" },
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   filetypes = { 'nelua' },
   root_markers = { 'Makefile', '.git', '*.nelua' },

--- a/lsp/neocmake.lua
+++ b/lsp/neocmake.lua
@@ -15,6 +15,7 @@
 ---   capabilities = capabilities,
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'neocmakelsp', '--stdio' },
   filetypes = { 'cmake' },

--- a/lsp/nextflow_ls.lua
+++ b/lsp/nextflow_ls.lua
@@ -22,6 +22,7 @@
 ---     },
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'java', '-jar', 'nextflow-language-server-all.jar' },
   filetypes = { 'nextflow' },

--- a/lsp/nextls.lua
+++ b/lsp/nextls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/elixir-tools/next-ls
 ---
 --- **By default, next-ls does not set its `cmd`. Please see the following [detailed instructions](https://www.elixir-tools.dev/docs/next-ls/installation/) for possible installation methods.**
+---@type vim.lsp.Config
 return {
   filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
   root_markers = { 'mix.exs', '.git' },

--- a/lsp/nginx_language_server.lua
+++ b/lsp/nginx_language_server.lua
@@ -7,6 +7,7 @@
 --- ```sh
 --- pip install -U nginx-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'nginx-language-server' },
   filetypes = { 'nginx' },

--- a/lsp/nickel_ls.lua
+++ b/lsp/nickel_ls.lua
@@ -23,6 +23,7 @@
 ---
 --- In order to have lspconfig detect Nickel filetypes (a prerequisite for autostarting a server),
 --- install the [Nickel vim plugin](https://github.com/nickel-lang/vim-nickel).
+---@type vim.lsp.Config
 return {
   cmd = { 'nls' },
   filetypes = { 'ncl', 'nickel' },

--- a/lsp/nil_ls.lua
+++ b/lsp/nil_ls.lua
@@ -8,6 +8,7 @@
 --- Check the repository README for more information.
 ---
 --- _See an example config at https://github.com/oxalica/nil/blob/main/dev/nvim-lsp.nix._
+---@type vim.lsp.Config
 return {
   cmd = { 'nil' },
   filetypes = { 'nix' },

--- a/lsp/nim_langserver.lua
+++ b/lsp/nim_langserver.lua
@@ -10,6 +10,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'nimlangserver' },
   filetypes = { 'nim' },

--- a/lsp/nimls.lua
+++ b/lsp/nimls.lua
@@ -10,6 +10,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'nimlsp' },
   filetypes = { 'nim' },

--- a/lsp/nixd.lua
+++ b/lsp/nixd.lua
@@ -6,6 +6,7 @@
 ---
 --- If you are using Nix with Flakes support, run `nix profile install github:nix-community/nixd` to install.
 --- Check the repository README for more information.
+---@type vim.lsp.Config
 return {
   cmd = { 'nixd' },
   filetypes = { 'nix' },

--- a/lsp/nomad_lsp.lua
+++ b/lsp/nomad_lsp.lua
@@ -23,6 +23,7 @@ if vim.fn.has 'win32' == 1 then
   bin_name = bin_name .. '.exe'
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { bin_name },
   filetypes = { 'hcl.nomad', 'nomad' },

--- a/lsp/ntt.lua
+++ b/lsp/ntt.lua
@@ -12,6 +12,7 @@
 --- })
 --- ```
 
+---@type vim.lsp.Config
 return {
   cmd = { 'ntt', 'langserver' },
   filetypes = { 'ttcn' },

--- a/lsp/nushell.lua
+++ b/lsp/nushell.lua
@@ -3,6 +3,7 @@
 --- https://github.com/nushell/nushell
 ---
 --- Nushell built-in language server.
+---@type vim.lsp.Config
 return {
   cmd = { 'nu', '--lsp' },
   filetypes = { 'nu' },

--- a/lsp/nxls.lua
+++ b/lsp/nxls.lua
@@ -8,6 +8,7 @@
 --- ```sh
 --- npm i -g nxls
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'nxls', '--stdio' },
   filetypes = { 'json', 'jsonc' },

--- a/lsp/ocamlls.lua
+++ b/lsp/ocamlls.lua
@@ -9,6 +9,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'ocaml-language-server', '--stdio' },
   filetypes = { 'ocaml', 'reason' },

--- a/lsp/ocamllsp.lua
+++ b/lsp/ocamllsp.lua
@@ -24,6 +24,7 @@ local get_language_id = function(_, ftype)
   return language_id_of[ftype]
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'ocamllsp' },
   filetypes = { 'ocaml', 'menhir', 'ocamlinterface', 'ocamllex', 'reason', 'dune' },

--- a/lsp/ols.lua
+++ b/lsp/ols.lua
@@ -6,6 +6,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'ols' },
   filetypes = { 'odin' },

--- a/lsp/omnisharp.lua
+++ b/lsp/omnisharp.lua
@@ -16,6 +16,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = {
     vim.fn.executable('OmniSharp') == 1 and 'OmniSharp' or 'omnisharp',

--- a/lsp/opencl_ls.lua
+++ b/lsp/opencl_ls.lua
@@ -5,6 +5,7 @@
 --- Build instructions can be found [here](https://github.com/Galarius/opencl-language-server/blob/main/_dev/build.md).
 ---
 --- Prebuilt binaries are available for Linux, macOS and Windows [here](https://github.com/Galarius/opencl-language-server/releases).
+---@type vim.lsp.Config
 return {
   cmd = { 'opencl-language-server' },
   filetypes = { 'opencl' },

--- a/lsp/openscad_ls.lua
+++ b/lsp/openscad_ls.lua
@@ -18,6 +18,7 @@
 --- ```
 ---
 --- or by installing a filetype plugin such as https://github.com/sirtaj/vim-openscad
+---@type vim.lsp.Config
 return {
   cmd = { 'openscad-language-server' },
   filetypes = { 'openscad' },

--- a/lsp/openscad_lsp.lua
+++ b/lsp/openscad_lsp.lua
@@ -8,6 +8,7 @@
 --- ```sh
 --- cargo install openscad-lsp
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'openscad-lsp', '--stdio' },
   filetypes = { 'openscad' },

--- a/lsp/oxlint.lua
+++ b/lsp/oxlint.lua
@@ -11,6 +11,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'oxc_language_server' },
   filetypes = {

--- a/lsp/pact_ls.lua
+++ b/lsp/pact_ls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/kadena-io/pact-lsp
 ---
 --- The Pact language server
+---@type vim.lsp.Config
 return {
   cmd = { 'pact-lsp' },
   filetypes = { 'pact' },

--- a/lsp/pasls.lua
+++ b/lsp/pasls.lua
@@ -17,6 +17,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'pasls' },
   filetypes = { 'pascal' },

--- a/lsp/pbls.lua
+++ b/lsp/pbls.lua
@@ -10,6 +10,7 @@
 --- ```
 ---
 --- pbls is a Language Server for protobuf
+---@type vim.lsp.Config
 return {
   cmd = { 'pbls' },
   filetypes = { 'proto' },

--- a/lsp/perlls.lua
+++ b/lsp/perlls.lua
@@ -5,6 +5,7 @@
 --- `Perl-LanguageServer`, a language server for Perl.
 ---
 --- To use the language server, ensure that you have Perl::LanguageServer installed and perl command is on your path.
+---@type vim.lsp.Config
 return {
   cmd = {
     'perl',

--- a/lsp/perlnavigator.lua
+++ b/lsp/perlnavigator.lua
@@ -19,6 +19,7 @@
 ---
 --- The `contributes.configuration.properties` section of `perlnavigator`'s `package.json` has all available configuration settings. All
 --- settings have a reasonable default, but, at minimum, you may want to point `perlnavigator` at your `perltidy` and `perlcritic` configurations.
+---@type vim.lsp.Config
 return {
   cmd = { 'perlnavigator' },
   filetypes = { 'perl' },

--- a/lsp/perlpls.lua
+++ b/lsp/perlpls.lua
@@ -6,6 +6,7 @@
 --- `PLS`, another language server for Perl.
 ---
 --- To use the language server, ensure that you have PLS installed and that it is in your path
+---@type vim.lsp.Config
 return {
   cmd = { 'pls' },
   settings = {

--- a/lsp/pest_ls.lua
+++ b/lsp/pest_ls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/pest-parser/pest-ide-tools
 ---
 --- Language server for pest grammars.
+---@type vim.lsp.Config
 return {
   cmd = { 'pest-language-server' },
   filetypes = { 'pest' },

--- a/lsp/phan.lua
+++ b/lsp/phan.lua
@@ -17,6 +17,7 @@ local cmd = {
   '--allow-polyfill-parser',
 }
 
+---@type vim.lsp.Config
 return {
   cmd = cmd,
   filetypes = { 'php' },

--- a/lsp/phpactor.lua
+++ b/lsp/phpactor.lua
@@ -4,6 +4,7 @@
 ---
 --- Installation: https://phpactor.readthedocs.io/en/master/usage/standalone.html#global-installation
 
+---@type vim.lsp.Config
 return {
   cmd = { 'phpactor', 'language-server' },
   filetypes = { 'php' },

--- a/lsp/pico8_ls.lua
+++ b/lsp/pico8_ls.lua
@@ -6,6 +6,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'pico8-ls', '--stdio' },
   filetypes = { 'p8' },

--- a/lsp/please.lua
+++ b/lsp/please.lua
@@ -5,6 +5,7 @@
 --- High-performance extensible build system for reproducible multi-language builds.
 ---
 --- The `plz` binary will automatically install the LSP for you on first run
+---@type vim.lsp.Config
 return {
   cmd = { 'plz', 'tool', 'lps' },
   filetypes = { 'bzl' },

--- a/lsp/pli.lua
+++ b/lsp/pli.lua
@@ -3,6 +3,7 @@
 --- `pli_language_server` is a language server for the PL/I language used on IBM SystemZ mainframes.
 ---
 --- To learn how to configure the PL/I language server, see the [PL/I Language Support documentation](https://github.com/zowe/zowe-pli-language-support).
+---@type vim.lsp.Config
 return {
   cmd = { 'pli_language_server' },
   filetypes = { 'pli' },

--- a/lsp/poryscript_pls.lua
+++ b/lsp/poryscript_pls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/huderlem/poryscript-pls
 ---
 --- Language server for poryscript (a high level scripting language for GBA-era Pokémon decompilation projects)
+---@type vim.lsp.Config
 return {
   cmd = { 'poryscript-pls' },
   filetypes = { 'pory' },

--- a/lsp/postgres_lsp.lua
+++ b/lsp/postgres_lsp.lua
@@ -3,6 +3,7 @@
 --- https://pgtools.dev
 ---
 --- A collection of language tools and a Language Server Protocol (LSP) implementation for Postgres, focusing on developer experience and reliable SQL tooling.
+---@type vim.lsp.Config
 return {
   cmd = { 'postgrestools', 'lsp-proxy' },
   filetypes = {

--- a/lsp/powershell_es.lua
+++ b/lsp/powershell_es.lua
@@ -36,6 +36,7 @@
 --- })
 --- ```
 
+---@type vim.lsp.Config
 return {
   cmd = function(dispatchers)
     local temp_path = vim.fn.stdpath('cache')

--- a/lsp/prismals.lua
+++ b/lsp/prismals.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- npm install -g @prisma/language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'prisma-language-server', '--stdio' },
   filetypes = { 'prisma' },

--- a/lsp/prolog_ls.lua
+++ b/lsp/prolog_ls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/jamesnvc/lsp_server
 ---
 --- Language Server Protocol server for SWI-Prolog
+---@type vim.lsp.Config
 return {
   cmd = {
     'swipl',

--- a/lsp/prosemd_lsp.lua
+++ b/lsp/prosemd_lsp.lua
@@ -5,6 +5,7 @@
 --- An experimental LSP for Markdown.
 ---
 --- Please see the manual installation instructions: https://github.com/kitten/prosemd-lsp#manual-installation
+---@type vim.lsp.Config
 return {
   cmd = { 'prosemd-lsp', '--stdio' },
   filetypes = { 'markdown' },

--- a/lsp/protols.lua
+++ b/lsp/protols.lua
@@ -8,6 +8,7 @@
 --- ```
 ---
 --- A Language Server for proto3 files. It uses tree-sitter and runs in single file mode.
+---@type vim.lsp.Config
 return {
   cmd = { 'protols' },
   filetypes = { 'proto' },

--- a/lsp/psalm.lua
+++ b/lsp/psalm.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- composer global require vimeo/psalm
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'psalm', '--language-server' },
   filetypes = { 'php' },

--- a/lsp/pug.lua
+++ b/lsp/pug.lua
@@ -5,6 +5,7 @@
 --- An implementation of the Language Protocol Server for [Pug.js](http://pugjs.org)
 ---
 --- PugLSP can be installed via `go install github.com/opa-oz/pug-lsp@latest`, or manually downloaded from [releases page](https://github.com/opa-oz/pug-lsp/releases)
+---@type vim.lsp.Config
 return {
   cmd = { 'pug-lsp' },
   filetypes = { 'pug' },

--- a/lsp/puppet.lua
+++ b/lsp/puppet.lua
@@ -14,6 +14,7 @@
 --- - Add that repository to $PATH.
 ---
 --- - Ensure you can run `puppet-languageserver` from outside the editor-services directory.
+---@type vim.lsp.Config
 return {
   cmd = { 'puppet-languageserver', '--stdio' },
   filetypes = { 'puppet' },

--- a/lsp/purescriptls.lua
+++ b/lsp/purescriptls.lua
@@ -6,6 +6,7 @@
 ---
 --- * JavaScript package manager such as npm, pnpm, Yarn, et al.
 --- * Nix under the `nodePackages` and `nodePackages_latest` package sets
+---@type vim.lsp.Config
 return {
   cmd = { 'purescript-language-server', '--stdio' },
   filetypes = { 'purescript' },

--- a/lsp/pylsp.lua
+++ b/lsp/pylsp.lua
@@ -25,6 +25,7 @@
 --- ```
 ---
 --- Note: This is a community fork of `pyls`.
+---@type vim.lsp.Config
 return {
   cmd = { 'pylsp' },
   filetypes = { 'python' },

--- a/lsp/pylyzer.lua
+++ b/lsp/pylyzer.lua
@@ -8,6 +8,7 @@
 --- This config sets `ERG_PATH="~/.erg"`. Set `cmd_env` if you want to change it.
 --- To install Erg, simply extract tarball/zip from [Erg releases](https://github.com/erg-lang/erg/releases/latest)
 --- to the the path where you want to install it, e.g. `~/.erg`.
+---@type vim.lsp.Config
 return {
   cmd = { 'pylyzer', '--server' },
   filetypes = { 'python' },

--- a/lsp/pyre.lua
+++ b/lsp/pyre.lua
@@ -8,6 +8,7 @@
 --- which are triggered on save.
 ---
 --- Do not report issues for missing features in `pyre` to `lspconfig`.
+---@type vim.lsp.Config
 return {
   cmd = { 'pyre', 'persistent' },
   filetypes = { 'python' },

--- a/lsp/pyrefly.lua
+++ b/lsp/pyrefly.lua
@@ -7,6 +7,7 @@
 -- `pyrefly` is still in development, so please report any errors to
 -- our issues page at https://github.com/facebook/pyrefly/issues.
 
+---@type vim.lsp.Config
 return {
   cmd = { 'pyrefly', 'lsp' },
   filetypes = { 'python' },

--- a/lsp/pyright.lua
+++ b/lsp/pyright.lua
@@ -15,7 +15,7 @@ local function set_python_path(path)
     else
       client.config.settings = vim.tbl_deep_extend('force', client.config.settings, { python = { pythonPath = path } })
     end
-    client.notify('workspace/didChangeConfiguration', { settings = nil })
+    client:notify('workspace/didChangeConfiguration', { settings = nil })
   end
 end
 

--- a/lsp/pyright.lua
+++ b/lsp/pyright.lua
@@ -19,6 +19,7 @@ local function set_python_path(path)
   end
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'pyright-langserver', '--stdio' },
   filetypes = { 'python' },

--- a/lsp/qmlls.lua
+++ b/lsp/qmlls.lua
@@ -5,6 +5,7 @@
 --- > QML Language Server is a tool shipped with Qt that helps you write code in your favorite (LSP-supporting) editor.
 ---
 --- Source in the [QtDeclarative repository](https://code.qt.io/cgit/qt/qtdeclarative.git/)
+---@type vim.lsp.Config
 return {
   cmd = { 'qmlls' },
   filetypes = { 'qml', 'qmljs' },

--- a/lsp/quick_lint_js.lua
+++ b/lsp/quick_lint_js.lua
@@ -5,6 +5,7 @@
 --- quick-lint-js finds bugs in JavaScript programs.
 ---
 --- See installation [instructions](https://quick-lint-js.com/install/)
+---@type vim.lsp.Config
 return {
   cmd = { 'quick-lint-js', '--lsp-server' },
   filetypes = { 'javascript', 'typescript' },

--- a/lsp/r_language_server.lua
+++ b/lsp/r_language_server.lua
@@ -9,6 +9,7 @@
 --- ```r
 --- install.packages("languageserver")
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'R', '--no-echo', '-e', 'languageserver::run()' },
   filetypes = { 'r', 'rmd', 'quarto' },

--- a/lsp/racket_langserver.lua
+++ b/lsp/racket_langserver.lua
@@ -7,6 +7,7 @@
 --- functionality that mimics DrRacket's code tools as closely as possible.
 ---
 --- Install via `raco`: `raco pkg install racket-langserver`
+---@type vim.lsp.Config
 return {
   cmd = { 'racket', '--lib', 'racket-langserver' },
   filetypes = { 'racket', 'scheme' },

--- a/lsp/raku_navigator.lua
+++ b/lsp/raku_navigator.lua
@@ -19,6 +19,7 @@
 --- ```
 --- The `contributes.configuration.properties` section of `raku_navigator`'s `package.json` has all available configuration settings. All
 --- settings have a reasonable default, but, at minimum, you may want to point `raku_navigator` at your `raku_tidy` and `raku_critic` configurations.
+---@type vim.lsp.Config
 return {
   cmd = {},
   filetypes = { 'raku' },

--- a/lsp/reason_ls.lua
+++ b/lsp/reason_ls.lua
@@ -3,6 +3,7 @@
 --- Reason language server
 ---
 --- You can install reason language server from [reason-language-server](https://github.com/jaredly/reason-language-server) repository.
+---@type vim.lsp.Config
 return {
   cmd = { 'reason-language-server' },
   filetypes = { 'reason' },

--- a/lsp/regal.lua
+++ b/lsp/regal.lua
@@ -11,6 +11,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'regal', 'language-server' },
   filetypes = { 'rego' },

--- a/lsp/regols.lua
+++ b/lsp/regols.lua
@@ -11,6 +11,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'regols' },
   filetypes = { 'rego' },

--- a/lsp/remark_ls.lua
+++ b/lsp/remark_ls.lua
@@ -28,6 +28,7 @@
 --- ```sh
 --- npm install remark-preset-lint-recommended
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'remark-language-server', '--stdio' },
   filetypes = { 'markdown' },

--- a/lsp/rescriptls.lua
+++ b/lsp/rescriptls.lua
@@ -33,6 +33,7 @@
 ---     },
 --- }
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'rescript-language-server', '--stdio' },
   filetypes = { 'rescript' },

--- a/lsp/rls.lua
+++ b/lsp/rls.lua
@@ -26,6 +26,7 @@
 --- ```lua
 --- cmd = {"rustup", "run", "nightly", "rls"}
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'rls' },
   filetypes = { 'rust' },

--- a/lsp/rnix.lua
+++ b/lsp/rnix.lua
@@ -7,6 +7,7 @@
 --- To install manually, run `cargo install rnix-lsp`. If you are using nix, rnix-lsp is in nixpkgs.
 ---
 --- This server accepts configuration via the `settings` key.
+---@type vim.lsp.Config
 return {
   cmd = { 'rnix-lsp' },
   filetypes = { 'nix' },

--- a/lsp/robotcode.lua
+++ b/lsp/robotcode.lua
@@ -3,6 +3,7 @@
 --- https://robotcode.io
 ---
 --- RobotCode - Language Server Protocol implementation for Robot Framework.
+---@type vim.lsp.Config
 return {
   cmd = { 'robotcode', 'language-server' },
   filetypes = { 'robot', 'resource' },

--- a/lsp/robotframework_ls.lua
+++ b/lsp/robotframework_ls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/robocorp/robotframework-lsp
 ---
 --- Language Server Protocol implementation for Robot Framework.
+---@type vim.lsp.Config
 return {
   cmd = { 'robotframework_ls' },
   filetypes = { 'robot' },

--- a/lsp/roc_ls.lua
+++ b/lsp/roc_ls.lua
@@ -4,6 +4,7 @@
 ---
 --- The built-in language server for the Roc programming language.
 --- [Installation](https://github.com/roc-lang/roc/tree/main/crates/language_server#installing)
+---@type vim.lsp.Config
 return {
   cmd = { 'roc_language_server' },
   filetypes = { 'roc' },

--- a/lsp/rome.lua
+++ b/lsp/rome.lua
@@ -9,6 +9,7 @@
 --- ```sh
 --- npm install [-g] rome
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'rome', 'lsp-proxy' },
   filetypes = {

--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -91,7 +91,7 @@ local function roslyn_handlers()
   }
 end
 
----@type vim.lsp.ClientConfig
+---@type vim.lsp.Config
 return {
   name = 'roslyn_ls',
   offset_encoding = 'utf-8',

--- a/lsp/rpmspec.lua
+++ b/lsp/rpmspec.lua
@@ -9,6 +9,7 @@
 --- ```sh
 --- pip install rpm-spec-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'rpm_lsp_server', '--stdio' },
   filetypes = { 'spec' },

--- a/lsp/rubocop.lua
+++ b/lsp/rubocop.lua
@@ -1,6 +1,7 @@
 ---@brief
 ---
 --- https://github.com/rubocop/rubocop
+---@type vim.lsp.Config
 return {
   cmd = { 'rubocop', '--lsp' },
   filetypes = { 'ruby' },

--- a/lsp/ruby_lsp.lua
+++ b/lsp/ruby_lsp.lua
@@ -11,6 +11,7 @@
 --- ```sh
 --- gem install ruby-lsp
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'ruby-lsp' },
   filetypes = { 'ruby', 'eruby' },

--- a/lsp/ruff.lua
+++ b/lsp/ruff.lua
@@ -25,6 +25,7 @@
 --- ```
 ---
 --- Refer to the [documentation](https://docs.astral.sh/ruff/editors/) for more details.
+---@type vim.lsp.Config
 return {
   cmd = { 'ruff', 'server' },
   filetypes = { 'python' },

--- a/lsp/ruff_lsp.lua
+++ b/lsp/ruff_lsp.lua
@@ -20,6 +20,7 @@
 ---   }
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'ruff-lsp' },
   filetypes = { 'python' },

--- a/lsp/rune_languageserver.lua
+++ b/lsp/rune_languageserver.lua
@@ -4,6 +4,7 @@
 ---
 --- A language server for the [Rune](https://rune-rs.github.io/) Language,
 --- an embeddable dynamic programming language for Rust
+---@type vim.lsp.Config
 return {
   cmd = { 'rune-languageserver' },
   filetypes = { 'rune' },

--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -52,6 +52,7 @@ local function is_library(fname)
   end
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'rust-analyzer' },
   filetypes = { 'rust' },

--- a/lsp/salt_ls.lua
+++ b/lsp/salt_ls.lua
@@ -7,6 +7,7 @@
 --- ```sh
 --- pip install salt-lsp
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'salt_lsp_server' },
   filetypes = { 'sls' },

--- a/lsp/scheme_langserver.lua
+++ b/lsp/scheme_langserver.lua
@@ -6,6 +6,7 @@
 
 local cmd = { 'scheme-langserver', '~/.scheme-langserver.log', 'enable', 'disable' }
 
+---@type vim.lsp.Config
 return {
   cmd = cmd,
   filetypes = { 'scheme' },

--- a/lsp/scheme_langserver.lua
+++ b/lsp/scheme_langserver.lua
@@ -4,11 +4,9 @@
 --- `scheme-langserver`, a language server protocol implementation for scheme.
 --- And for nvim user, please add .sls to scheme file extension list.
 
-local cmd = { 'scheme-langserver', '~/.scheme-langserver.log', 'enable', 'disable' }
-
 ---@type vim.lsp.Config
 return {
-  cmd = cmd,
+  cmd = { 'scheme-langserver', '~/.scheme-langserver.log', 'enable', 'disable' },
   filetypes = { 'scheme' },
   root_markers = {
     'Akku.manifest',

--- a/lsp/scry.lua
+++ b/lsp/scry.lua
@@ -3,6 +3,7 @@
 --- https://github.com/crystal-lang-tools/scry
 ---
 --- Crystal language server.
+---@type vim.lsp.Config
 return {
   cmd = { 'scry' },
   filetypes = { 'crystal' },

--- a/lsp/selene3p_ls.lua
+++ b/lsp/selene3p_ls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/antonk52/lua-3p-language-servers
 ---
 --- 3rd party Language Server for Selene lua linter
+---@type vim.lsp.Config
 return {
   cmd = { 'selene-3p-language-server' },
   filetypes = { 'lua' },

--- a/lsp/serve_d.lua
+++ b/lsp/serve_d.lua
@@ -4,6 +4,7 @@
 ---
 --- Microsoft language server protocol implementation for D using workspace-d.
 --- Download a binary from https://github.com/Pure-D/serve-d/releases and put it in your $PATH.
+---@type vim.lsp.Config
 return {
   cmd = { 'serve-d' },
   filetypes = { 'd' },

--- a/lsp/shopify_theme_ls.lua
+++ b/lsp/shopify_theme_ls.lua
@@ -7,6 +7,7 @@
 --- `shopify` can be installed via npm `npm install -g @shopify/cli`.
 ---
 --- Note: This LSP already includes Theme Check so you don't need to use the `theme_check` server configuration as well.
+---@type vim.lsp.Config
 return {
   cmd = {
     'shopify',

--- a/lsp/sixtyfps.lua
+++ b/lsp/sixtyfps.lua
@@ -17,6 +17,7 @@
 --- ```
 ---
 --- or by installing a filetype plugin such as https://github.com/RustemB/sixtyfps-vim
+---@type vim.lsp.Config
 return {
   cmd = { 'sixtyfps-lsp' },
   filetypes = { 'sixtyfps' },

--- a/lsp/slangd.lua
+++ b/lsp/slangd.lua
@@ -29,6 +29,7 @@ if vim.fn.has 'win32' == 1 then
   bin_name = 'slangd.exe'
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { bin_name },
   filetypes = { 'hlsl', 'shaderslang' },

--- a/lsp/slint_lsp.lua
+++ b/lsp/slint_lsp.lua
@@ -15,6 +15,7 @@
 --- ```lua
 --- vim.cmd [[ autocmd BufRead,BufNewFile *.slint set filetype=slint ]]
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'slint-lsp' },
   filetypes = { 'slint' },

--- a/lsp/smarty_ls.lua
+++ b/lsp/smarty_ls.lua
@@ -10,6 +10,7 @@
 --- npm i -g vscode-smarty-langserver-extracted
 --- ```
 
+---@type vim.lsp.Config
 return {
   cmd = { 'smarty-language-server', '--stdio' },
   filetypes = { 'smarty' },

--- a/lsp/smithy_ls.lua
+++ b/lsp/smithy_ls.lua
@@ -19,6 +19,7 @@
 ---    coursier launch software.amazon.smithy:smithy-language-server:0.7.0
 ---    ```
 
+---@type vim.lsp.Config
 return {
   -- pass 0 as the first argument to use STDIN/STDOUT for communication
   cmd = {

--- a/lsp/snakeskin_ls.lua
+++ b/lsp/snakeskin_ls.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- npm install -g @snakeskin/cli
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'snakeskin-cli', 'lsp', '--stdio' },
   filetypes = { 'ss' },

--- a/lsp/snyk_ls.lua
+++ b/lsp/snyk_ls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/snyk/snyk-ls
 ---
 --- LSP for Snyk Open Source, Snyk Infrastructure as Code, and Snyk Code.
+---@type vim.lsp.Config
 return {
   cmd = { 'snyk-ls' },
   root_markers = { '.git', '.snyk' },

--- a/lsp/solang.lua
+++ b/lsp/solang.lua
@@ -10,6 +10,7 @@
 --- * Hover
 ---
 --- There is currently no support for completion, goto definition, references, or other functionality.
+---@type vim.lsp.Config
 return {
   cmd = { 'solang', 'language-server', '--target', 'evm' },
   filetypes = { 'solidity' },

--- a/lsp/solargraph.lua
+++ b/lsp/solargraph.lua
@@ -9,6 +9,7 @@
 --- ```sh
 --- gem install --user-install solargraph
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'solargraph', 'stdio' },
   settings = {

--- a/lsp/solc.lua
+++ b/lsp/solc.lua
@@ -6,6 +6,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'solc', '--lsp' },
   filetypes = { 'solidity' },

--- a/lsp/solidity.lua
+++ b/lsp/solidity.lua
@@ -32,6 +32,7 @@
 --- ```
 ---
 --- You can omit the node_modules as well.
+---@type vim.lsp.Config
 return {
   cmd = { 'solidity-ls', '--stdio' },
   filetypes = { 'solidity' },

--- a/lsp/solidity_ls.lua
+++ b/lsp/solidity_ls.lua
@@ -9,6 +9,7 @@
 --- ```
 ---
 --- `vscode-solidity-server` is a language server for the Solidity language ported from the VSCode "solidity" extension.
+---@type vim.lsp.Config
 return {
   cmd = { 'vscode-solidity-server', '--stdio' },
   filetypes = { 'solidity' },

--- a/lsp/solidity_ls_nomicfoundation.lua
+++ b/lsp/solidity_ls_nomicfoundation.lua
@@ -9,6 +9,7 @@
 --- ```
 ---
 --- A language server for the Solidity programming language, built by the Nomic Foundation for the Ethereum community.
+---@type vim.lsp.Config
 return {
   cmd = { 'nomicfoundation-solidity-language-server', '--stdio' },
   filetypes = { 'solidity' },

--- a/lsp/somesass_ls.lua
+++ b/lsp/somesass_ls.lua
@@ -15,6 +15,7 @@
 --- - Rich documentation through SassDoc.
 --- - Language features for %placeholder-selectors, both when using them and writing them.
 --- - Suggestions and hover info for built-in Sass modules, when used with @use.
+---@type vim.lsp.Config
 return {
   name = 'somesass_ls',
   cmd = { 'some-sass-language-server', '--stdio' },

--- a/lsp/sorbet.lua
+++ b/lsp/sorbet.lua
@@ -10,6 +10,7 @@
 --- ```sh
 --- gem install sorbet
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'srb', 'tc', '--lsp' },
   filetypes = { 'ruby' },

--- a/lsp/sourcekit.lua
+++ b/lsp/sourcekit.lua
@@ -6,6 +6,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'sourcekit-lsp' },
   filetypes = { 'swift', 'objc', 'objcpp', 'c', 'cpp' },

--- a/lsp/spectral.lua
+++ b/lsp/spectral.lua
@@ -9,6 +9,7 @@
 --- ```
 --- See [vscode-spectral](https://github.com/stoplightio/vscode-spectral#extension-settings) for configuration options.
 
+---@type vim.lsp.Config
 return {
   cmd = { 'spectral-language-server', '--stdio' },
   filetypes = { 'yaml', 'json', 'yml' },

--- a/lsp/spyglassmc_language_server.lua
+++ b/lsp/spyglassmc_language_server.lua
@@ -15,6 +15,7 @@
 --- `autocmd BufNewFile,BufRead *.mcfunction set filetype=mcfunction`
 ---
 --- This is automatically done by [CrystalAlpha358/vim-mcfunction](https://github.com/CrystalAlpha358/vim-mcfunction), which also provide syntax highlight.
+---@type vim.lsp.Config
 return {
   cmd = { 'spyglassmc-language-server', '--stdio' },
   filetypes = { 'mcfunction' },

--- a/lsp/sqlls.lua
+++ b/lsp/sqlls.lua
@@ -4,6 +4,7 @@
 ---
 --- This LSP can be installed via  `npm`. Find further instructions on manual installation of the sql-language-server at [joe-re/sql-language-server](https://github.com/joe-re/sql-language-server).
 
+---@type vim.lsp.Config
 return {
   cmd = { 'sql-language-server', 'up', '--method', 'stdio' },
   filetypes = { 'sql', 'mysql' },

--- a/lsp/sqls.lua
+++ b/lsp/sqls.lua
@@ -9,6 +9,7 @@
 --- })
 --- ```
 --- Sqls can be installed via `go install github.com/sqls-server/sqls@latest`. Instructions for compiling Sqls from the source can be found at [sqls-server/sqls](https://github.com/sqls-server/sqls).
+---@type vim.lsp.Config
 return {
   cmd = { 'sqls' },
   filetypes = { 'sql', 'mysql' },

--- a/lsp/sqruff.lua
+++ b/lsp/sqruff.lua
@@ -4,6 +4,7 @@
 ---
 --- `sqruff` can be installed by following the instructions [here](https://github.com/quarylabs/sqruff?tab=readme-ov-file#installation)
 ---
+---@type vim.lsp.Config
 return {
   cmd = { 'sqruff', 'lsp' },
   filetypes = { 'sql' },

--- a/lsp/standardrb.lua
+++ b/lsp/standardrb.lua
@@ -3,6 +3,7 @@
 --- https://github.com/testdouble/standard
 ---
 --- Ruby Style Guide, with linter & automatic code fixer.
+---@type vim.lsp.Config
 return {
   cmd = { 'standardrb', '--lsp' },
   filetypes = { 'ruby' },

--- a/lsp/starlark_rust.lua
+++ b/lsp/starlark_rust.lua
@@ -7,6 +7,7 @@
 --- but does not support refactorings.
 ---
 --- It can be installed with cargo: https://crates.io/crates/starlark
+---@type vim.lsp.Config
 return {
   cmd = { 'starlark', '--lsp' },
   filetypes = { 'star', 'bzl', 'BUILD.bazel' },

--- a/lsp/starpls.lua
+++ b/lsp/starpls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/withered-magic/starpls
 ---
 --- `starpls` is an LSP implementation for Starlark. Installation instructions can be found in the project's README.
+---@type vim.lsp.Config
 return {
   cmd = { 'starpls' },
   filetypes = { 'bzl' },

--- a/lsp/statix.lua
+++ b/lsp/statix.lua
@@ -3,6 +3,7 @@
 --- https://github.com/nerdypepper/statix
 ---
 --- lints and suggestions for the nix programming language
+---@type vim.lsp.Config
 return {
   cmd = { 'statix', 'check', '--stdin' },
   filetypes = { 'nix' },

--- a/lsp/steep.lua
+++ b/lsp/steep.lua
@@ -5,6 +5,7 @@
 --- `steep` is a static type checker for Ruby.
 ---
 --- You need `Steepfile` to make it work. Generate it with `steep init`.
+---@type vim.lsp.Config
 return {
   cmd = { 'steep', 'langserver' },
   filetypes = { 'ruby', 'eruby' },

--- a/lsp/stimulus_ls.lua
+++ b/lsp/stimulus_ls.lua
@@ -13,6 +13,7 @@
 --- ```sh
 --- yarn global add stimulus-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'stimulus-language-server', '--stdio' },
   filetypes = { 'html', 'ruby', 'eruby', 'blade', 'php' },

--- a/lsp/stylelint_lsp.lua
+++ b/lsp/stylelint_lsp.lua
@@ -37,6 +37,7 @@ local root_file = {
 
 root_file = util.insert_package_json(root_file, 'stylelint')
 
+---@type vim.lsp.Config
 return {
   cmd = { 'stylelint-lsp', '--stdio' },
   filetypes = {

--- a/lsp/stylua3p_ls.lua
+++ b/lsp/stylua3p_ls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/antonk52/lua-3p-language-servers
 ---
 --- 3rd party Language Server for Stylua lua formatter
+---@type vim.lsp.Config
 return {
   cmd = { 'stylua-3p-language-server' },
   filetypes = { 'lua' },

--- a/lsp/superhtml.lua
+++ b/lsp/superhtml.lua
@@ -15,6 +15,7 @@
 ---   filetypes = { 'superhtml' }
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'superhtml', 'lsp' },
   filetypes = { 'superhtml', 'html' },

--- a/lsp/svelte.lua
+++ b/lsp/svelte.lua
@@ -9,6 +9,7 @@
 --- npm install -g svelte-language-server
 --- ```
 
+---@type vim.lsp.Config
 return {
   cmd = { 'svelteserver', '--stdio' },
   filetypes = { 'svelte' },

--- a/lsp/svelte.lua
+++ b/lsp/svelte.lua
@@ -34,6 +34,7 @@ return {
     })
     vim.api.nvim_buf_create_user_command(bufnr, 'LspMigrateToSvelte5', function()
       client:exec_cmd({
+        title = 'Migrate Component to Svelte 5 Syntax',
         command = 'migrate_to_svelte_5',
         arguments = { vim.uri_from_bufnr(bufnr) },
       })

--- a/lsp/svlangserver.lua
+++ b/lsp/svlangserver.lua
@@ -10,6 +10,7 @@
 --- $ npm install -g @imc-trading/svlangserver
 --- ```
 
+---@type vim.lsp.Config
 return {
   cmd = { 'svlangserver' },
   filetypes = { 'verilog', 'systemverilog' },

--- a/lsp/svlangserver.lua
+++ b/lsp/svlangserver.lua
@@ -20,8 +20,6 @@ return {
       includeIndexing = { '*.{v,vh,sv,svh}', '**/*.{v,vh,sv,svh}' },
     },
   },
-  ---@param client vim.lsp.Client
-  ---@param bufnr integer
   on_attach = function(client, bufnr)
     vim.api.nvim_buf_create_user_command(bufnr, 'LspSvlangserverBuildIndex', function()
       client:exec_cmd({

--- a/lsp/svls.lua
+++ b/lsp/svls.lua
@@ -8,6 +8,7 @@
 ---  ```sh
 ---  cargo install svls
 ---  ```
+---@type vim.lsp.Config
 return {
   cmd = { 'svls' },
   filetypes = { 'verilog', 'systemverilog' },

--- a/lsp/swift_mesonls.lua
+++ b/lsp/swift_mesonls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/JCWasmx86/Swift-MesonLSP
 ---
 --- Meson language server written in Swift
+---@type vim.lsp.Config
 return {
   cmd = { 'Swift-MesonLSP', '--lsp' },
   filetypes = { 'meson' },

--- a/lsp/syntax_tree.lua
+++ b/lsp/syntax_tree.lua
@@ -12,6 +12,7 @@
 --- ```sh
 --- gem install syntax_tree
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'stree', 'lsp' },
   filetypes = { 'ruby' },

--- a/lsp/systemd_ls.lua
+++ b/lsp/systemd_ls.lua
@@ -8,6 +8,7 @@
 --- ```
 ---
 --- Language Server for Systemd unit files
+---@type vim.lsp.Config
 return {
   cmd = { 'systemd-language-server' },
   filetypes = { 'systemd' },

--- a/lsp/tabby_ml.lua
+++ b/lsp/tabby_ml.lua
@@ -9,6 +9,7 @@
 --- ```sh
 --- npm install --global tabby-agent
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'tabby-agent', '--lsp', '--stdio' },
   filetypes = {},

--- a/lsp/tailwindcss.lua
+++ b/lsp/tailwindcss.lua
@@ -6,6 +6,7 @@
 --- npm install -g @tailwindcss/language-server
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'tailwindcss-language-server', '--stdio' },
   -- filetypes copied and adjusted from tailwindcss-intellisense

--- a/lsp/taplo.lua
+++ b/lsp/taplo.lua
@@ -8,6 +8,7 @@
 --- ```sh
 --- cargo install --features lsp --locked taplo-cli
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'taplo', 'lsp', 'stdio' },
   filetypes = { 'toml' },

--- a/lsp/tblgen_lsp_server.lua
+++ b/lsp/tblgen_lsp_server.lua
@@ -17,6 +17,7 @@ local function get_command()
   return cmd
 end
 
+---@type vim.lsp.Config
 return {
   cmd = get_command(),
   filetypes = { 'tablegen' },

--- a/lsp/teal_ls.lua
+++ b/lsp/teal_ls.lua
@@ -11,6 +11,7 @@
 --- * "--log-mode=by_date" - Enable logging in $HOME/.cache/teal-language-server. Log name will be date + pid of process
 --- * "--log-mode=by_proj_path" - Enable logging in $HOME/.cache/teal-language-server. Log name will be project path + pid of process
 --- * "--verbose=true" - Increases log level.  Does nothing unless log-mode is set
+---@type vim.lsp.Config
 return {
   cmd = {
     'teal-language-server',

--- a/lsp/templ.lua
+++ b/lsp/templ.lua
@@ -3,6 +3,7 @@
 --- https://templ.guide
 ---
 --- The official language server for the templ HTML templating language.
+---@type vim.lsp.Config
 return {
   cmd = { 'templ', 'lsp' },
   filetypes = { 'templ' },

--- a/lsp/termux_language_server.lua
+++ b/lsp/termux_language_server.lua
@@ -3,6 +3,7 @@
 --- https://github.com/termux/termux-language-server
 ---
 --- Language server for various bash scripts such as Arch PKGBUILD, Gentoo ebuild, Termux build.sh, etc.
+---@type vim.lsp.Config
 return {
   cmd = { 'termux-language-server' },
   filetypes = { 'PKGBUILD' },

--- a/lsp/terraform_lsp.lua
+++ b/lsp/terraform_lsp.lua
@@ -27,6 +27,7 @@
 ---   - compatibility with a single particular Terraform (0.12.20 at time of writing)
 ---     - configs designed for other 0.12 versions may work, but interpretation may be inaccurate
 ---   - less stability (due to reliance on Terraform's own internal packages)
+---@type vim.lsp.Config
 return {
   cmd = { 'terraform-lsp' },
   filetypes = { 'terraform', 'hcl' },

--- a/lsp/terraformls.lua
+++ b/lsp/terraformls.lua
@@ -31,6 +31,7 @@
 --- [which is not supported by terraform-ls](https://github.com/hashicorp/terraform-ls/blob/main/docs/features.md).
 --- Instead you should use `init_options` which passes the settings as part of the LSP initialize call
 --- [as is required by terraform-ls](https://github.com/hashicorp/terraform-ls/blob/main/docs/SETTINGS.md#how-to-pass-settings).
+---@type vim.lsp.Config
 return {
   cmd = { 'terraform-ls', 'serve' },
   filetypes = { 'terraform', 'terraform-vars' },

--- a/lsp/texlab.lua
+++ b/lsp/texlab.lua
@@ -132,6 +132,7 @@ local function buf_change_env(client, bufnr)
   }, { bufnr = bufnr })
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'texlab' },
   filetypes = { 'tex', 'plaintex', 'bib' },

--- a/lsp/texlab.lua
+++ b/lsp/texlab.lua
@@ -164,8 +164,6 @@ return {
       formatterLineLength = 80,
     },
   },
-  ---@param client vim.lsp.Client
-  ---@param bufnr integer
   on_attach = function(client, bufnr)
     for _, cmd in ipairs({
       { name = 'TexlabBuild', fn = buf_build, desc = 'Build the current buffer' },

--- a/lsp/textlsp.lua
+++ b/lsp/textlsp.lua
@@ -10,6 +10,7 @@
 --- For quick testing, LanguageTool is enabled in the default `nvim-lspconfig` configuration.
 ---
 --- To install run: `pip install textLSP`
+---@type vim.lsp.Config
 return {
   cmd = { 'textlsp' },
   filetypes = { 'text', 'tex', 'org' },

--- a/lsp/tflint.lua
+++ b/lsp/tflint.lua
@@ -4,6 +4,7 @@
 ---
 --- A pluggable Terraform linter that can act as lsp server.
 --- Installation instructions can be found in https://github.com/terraform-linters/tflint#installation.
+---@type vim.lsp.Config
 return {
   cmd = { 'tflint', '--langserver' },
   filetypes = { 'terraform' },

--- a/lsp/theme_check.lua
+++ b/lsp/theme_check.lua
@@ -15,6 +15,7 @@
 --- })
 --- ```
 
+---@type vim.lsp.Config
 return {
   cmd = { 'theme-check-language-server', '--stdio' },
   filetypes = { 'liquid' },

--- a/lsp/thriftls.lua
+++ b/lsp/thriftls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/joyme123/thrift-ls
 ---
 --- you can install thriftls by mason or download binary here: https://github.com/joyme123/thrift-ls/releases
+---@type vim.lsp.Config
 return {
   cmd = { 'thriftls' },
   filetypes = { 'thrift' },

--- a/lsp/tilt_ls.lua
+++ b/lsp/tilt_ls.lua
@@ -9,6 +9,7 @@
 --- ```vim
 --- autocmd BufRead Tiltfile setf=tiltfile
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'tilt', 'lsp', 'start' },
   filetypes = { 'tiltfile' },

--- a/lsp/tinymist.lua
+++ b/lsp/tinymist.lua
@@ -50,8 +50,6 @@ return {
   cmd = { 'tinymist' },
   filetypes = { 'typst' },
   root_markers = { '.git' },
-  ---@param client vim.lsp.Client
-  ---@param bufnr integer
   on_attach = function(client, bufnr)
     for _, command in ipairs {
       'tinymist.exportSvg',

--- a/lsp/tinymist.lua
+++ b/lsp/tinymist.lua
@@ -45,6 +45,7 @@ local function create_tinymist_command(command_name, client, bufnr)
   return run_tinymist_command, cmd_name, cmd_desc
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'tinymist' },
   filetypes = { 'typst' },

--- a/lsp/tofu_ls.lua
+++ b/lsp/tofu_ls.lua
@@ -2,6 +2,7 @@
 ---
 --- [OpenTofu Language Server](https://github.com/opentofu/tofu-ls)
 ---
+---@type vim.lsp.Config
 return {
   cmd = { 'tofu-ls', 'serve' },
   filetypes = { 'opentofu', 'opentofu-vars' },

--- a/lsp/tombi.lua
+++ b/lsp/tombi.lua
@@ -4,6 +4,7 @@
 ---
 --- Language server for Tombi, a TOML toolkit.
 ---
+---@type vim.lsp.Config
 return {
   cmd = { 'tombi', 'lsp' },
   filetypes = { 'toml' },

--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -41,6 +41,7 @@
 --- It is recommended to use the same version of TypeScript in all packages, and therefore have it available in your workspace root. The location of the TypeScript binary will be determined automatically, but only once.
 ---
 
+---@type vim.lsp.Config
 return {
   init_options = { hostInfo = 'neovim' },
   cmd = { 'typescript-language-server', '--stdio' },

--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -61,7 +61,7 @@ return {
     local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
     local project_root = vim.fs.root(bufnr, project_root_markers)
     if not project_root then
-      return nil
+      return
     end
 
     -- We know that the buffer is using Typescript if it has a config file
@@ -75,7 +75,7 @@ return {
       stop = vim.fs.dirname(project_root),
     })[1]
     if not is_buffer_using_typescript then
-      return nil
+      return
     end
 
     on_dir(project_root)

--- a/lsp/ts_query_ls.lua
+++ b/lsp/ts_query_ls.lua
@@ -25,6 +25,7 @@
 ---     },
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'ts_query_ls' },
   filetypes = { 'query' },

--- a/lsp/tsgo.lua
+++ b/lsp/tsgo.lua
@@ -13,6 +13,7 @@
 ---
 --- It is recommended to use the same version of TypeScript in all packages, and therefore have it available in your workspace root. The location of the TypeScript binary will be determined automatically, but only once.
 ---
+---@type vim.lsp.Config
 return {
   cmd = { 'tsgo', '--lsp', '--stdio' },
   filetypes = {

--- a/lsp/tsgo.lua
+++ b/lsp/tsgo.lua
@@ -32,7 +32,7 @@ return {
     local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
     local project_root = vim.fs.root(bufnr, project_root_markers)
     if not project_root then
-      return nil
+      return
     end
 
     -- We know that the buffer is using Typescript if it has a config file
@@ -46,7 +46,7 @@ return {
       stop = vim.fs.dirname(project_root),
     })[1]
     if not is_buffer_using_typescript then
-      return nil
+      return
     end
 
     on_dir(project_root)

--- a/lsp/tsp_server.lua
+++ b/lsp/tsp_server.lua
@@ -8,6 +8,7 @@
 --- ```sh
 --- npm install -g @typespec/compiler
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'tsp-server', '--stdio' },
   filetypes = { 'typespec' },

--- a/lsp/ttags.lua
+++ b/lsp/ttags.lua
@@ -1,6 +1,7 @@
 ---@brief
 ---
 --- https://github.com/npezza93/ttags
+---@type vim.lsp.Config
 return {
   cmd = { 'ttags', 'lsp' },
   filetypes = { 'ruby', 'rust', 'javascript', 'haskell' },

--- a/lsp/turbo_ls.lua
+++ b/lsp/turbo_ls.lua
@@ -13,6 +13,7 @@
 --- ```sh
 --- yarn global add turbo-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'turbo-language-server', '--stdio' },
   filetypes = { 'html', 'ruby', 'eruby', 'blade', 'php' },

--- a/lsp/turtle_ls.lua
+++ b/lsp/turtle_ls.lua
@@ -31,6 +31,7 @@ else
   full_path = table.concat({ bin_path, bin_name }, '/')
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'node', full_path, '--stdio' },
   filetypes = { 'turtle', 'ttl' },

--- a/lsp/tvm_ffi_navigator.lua
+++ b/lsp/tvm_ffi_navigator.lua
@@ -6,6 +6,7 @@
 ---
 --- FFI navigator can be installed with `pip install ffi-navigator`, buf for more details, please see
 --- https://github.com/tqchen/ffi-navigator?tab=readme-ov-file#installation
+---@type vim.lsp.Config
 return {
   cmd = { 'python', '-m', 'ffi_navigator.langserver' },
   filetypes = { 'python', 'cpp' },

--- a/lsp/twiggy_language_server.lua
+++ b/lsp/twiggy_language_server.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- npm install -g twiggy-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'twiggy-language-server', '--stdio' },
   filetypes = { 'twig' },

--- a/lsp/ty.lua
+++ b/lsp/ty.lua
@@ -5,6 +5,7 @@
 --- A Language Server Protocol implementation for ty, an extremely fast Python type checker and language server, written in Rust.
 ---
 --- For installation instructions, please refer to the [ty documentation](https://github.com/astral-sh/ty/blob/main/README.md#getting-started).
+---@type vim.lsp.Config
 return {
   cmd = { 'ty', 'server' },
   filetypes = { 'python' },

--- a/lsp/typeprof.lua
+++ b/lsp/typeprof.lua
@@ -3,6 +3,7 @@
 --- https://github.com/ruby/typeprof
 ---
 --- `typeprof` is the built-in analysis and LSP tool for Ruby 3.1+.
+---@type vim.lsp.Config
 return {
   cmd = { 'typeprof', '--lsp', '--stdio' },
   filetypes = { 'ruby', 'eruby' },

--- a/lsp/typos_lsp.lua
+++ b/lsp/typos_lsp.lua
@@ -6,6 +6,7 @@
 --- A Language Server Protocol implementation for Typos, a low false-positive
 --- source code spell checker, written in Rust. Download it from the releases page
 --- on GitHub: https://github.com/tekumara/typos-lsp/releases
+---@type vim.lsp.Config
 return {
   cmd = { 'typos-lsp' },
   root_markers = { 'typos.toml', '_typos.toml', '.typos.toml', 'pyproject.toml', 'Cargo.toml' },

--- a/lsp/typst_lsp.lua
+++ b/lsp/typst_lsp.lua
@@ -3,6 +3,7 @@
 --- https://github.com/nvarner/typst-lsp
 ---
 --- Language server for Typst.
+---@type vim.lsp.Config
 return {
   cmd = { 'typst-lsp' },
   filetypes = { 'typst' },

--- a/lsp/uiua.lua
+++ b/lsp/uiua.lua
@@ -5,6 +5,7 @@
 --- The builtin language server of the Uiua interpreter.
 ---
 --- The Uiua interpreter can be installed with `cargo install uiua`
+---@type vim.lsp.Config
 return {
   cmd = { 'uiua', 'lsp' },
   filetypes = { 'uiua' },

--- a/lsp/ungrammar_languageserver.lua
+++ b/lsp/ungrammar_languageserver.lua
@@ -7,6 +7,7 @@
 --- ```sh
 --- npm i ungrammar-languageserver -g
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'ungrammar-languageserver', '--stdio' },
   filetypes = { 'ungrammar' },

--- a/lsp/unison.lua
+++ b/lsp/unison.lua
@@ -4,6 +4,7 @@
 
 local util = require 'lspconfig.util'
 
+---@type vim.lsp.Config
 return {
   cmd = { 'nc', 'localhost', os.getenv 'UNISON_LSP_PORT' or '5757' },
   filetypes = { 'unison' },

--- a/lsp/unocss.lua
+++ b/lsp/unocss.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- npm i unocss-language-server -g
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'unocss-language-server', '--stdio' },
   -- copied from https://github.com/unocss/unocss/blob/35297359bf61917bda499db86e3728a7ebd05d6c/packages/vscode/src/autocomplete.ts#L12-L35

--- a/lsp/uvls.lua
+++ b/lsp/uvls.lua
@@ -14,6 +14,7 @@
 --- ```lua
 --- vim.cmd([[au BufRead,BufNewFile *.uvl setfiletype uvl]])
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'uvls' },
   filetypes = { 'uvl' },

--- a/lsp/v_analyzer.lua
+++ b/lsp/v_analyzer.lua
@@ -5,6 +5,7 @@
 --- V language server.
 ---
 --- `v-analyzer` can be installed by following the instructions [here](https://github.com/vlang/v-analyzer#installation).
+---@type vim.lsp.Config
 return {
   cmd = { 'v-analyzer' },
   filetypes = { 'v', 'vsh', 'vv' },

--- a/lsp/vacuum.lua
+++ b/lsp/vacuum.lua
@@ -14,6 +14,7 @@
 ---   },
 --- }
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'vacuum', 'language-server' },
   filetypes = { 'yaml.openapi', 'json.openapi' },

--- a/lsp/vala_ls.lua
+++ b/lsp/vala_ls.lua
@@ -23,6 +23,7 @@ local meson_matcher = function(path)
   end
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'vala-language-server' },
   filetypes = { 'vala', 'genie' },

--- a/lsp/vale_ls.lua
+++ b/lsp/vale_ls.lua
@@ -3,6 +3,7 @@
 --- https://github.com/errata-ai/vale-ls
 ---
 --- An implementation of the Language Server Protocol (LSP) for the Vale command-line tool.
+---@type vim.lsp.Config
 return {
   cmd = { 'vale-ls' },
   filetypes = { 'markdown', 'text', 'tex', 'rst' },

--- a/lsp/vectorcode_server.lua
+++ b/lsp/vectorcode_server.lua
@@ -2,6 +2,7 @@
 --- https://github.com/Davidyz/VectorCode
 ---
 --- A Language Server Protocol implementation for VectorCode, a code repository indexing tool.
+---@type vim.lsp.Config
 return {
   cmd = { 'vectorcode-server' },
   root_dir = vim.fs.root(0, { '.vectorcode', '.git' }),

--- a/lsp/verible.lua
+++ b/lsp/verible.lua
@@ -8,6 +8,7 @@
 --- and placed in a directory on PATH.
 ---
 --- See https://github.com/chipsalliance/verible/tree/master/verilog/tools/ls/README.md for options.
+---@type vim.lsp.Config
 return {
   cmd = { 'verible-verilog-ls' },
   filetypes = { 'systemverilog', 'verilog' },

--- a/lsp/veridian.lua
+++ b/lsp/veridian.lua
@@ -15,6 +15,7 @@
 --- ```
 --- cargo install --git https://github.com/vivekmalneedi/veridian.git
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'veridian' },
   filetypes = { 'systemverilog', 'verilog' },

--- a/lsp/veryl_ls.lua
+++ b/lsp/veryl_ls.lua
@@ -8,6 +8,7 @@
 ---  ```sh
 ---  cargo install veryl-ls
 ---  ```
+---@type vim.lsp.Config
 return {
   cmd = { 'veryl-ls' },
   filetypes = { 'veryl' },

--- a/lsp/vespa_ls.lua
+++ b/lsp/vespa_ls.lua
@@ -28,6 +28,7 @@
 ---       },
 ---     }
 
+---@type vim.lsp.Config
 return {
   cmd = { 'java', '-jar', 'vespa-language-server.jar' },
   filetypes = { 'sd', 'profile', 'yql' },

--- a/lsp/vhdl_ls.lua
+++ b/lsp/vhdl_ls.lua
@@ -26,6 +26,7 @@
 ---   'tb_ent.vhd'
 --- ]
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'vhdl_ls' },
   filetypes = { 'vhd', 'vhdl' },

--- a/lsp/vimls.lua
+++ b/lsp/vimls.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- npm install -g vim-language-server
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'vim-language-server', '--stdio' },
   filetypes = { 'vim' },

--- a/lsp/visualforce_ls.lua
+++ b/lsp/visualforce_ls.lua
@@ -17,6 +17,7 @@
 ---   }
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   filetypes = { 'visualforce' },
   root_markers = { 'sfdx-project.json' },

--- a/lsp/vls.lua
+++ b/lsp/vls.lua
@@ -5,6 +5,7 @@
 --- V language server.
 ---
 --- `v-language-server` can be installed by following the instructions [here](https://github.com/vlang/vls#installation).
+---@type vim.lsp.Config
 return {
   cmd = { 'v', 'ls' },
   filetypes = { 'v', 'vlang' },

--- a/lsp/vscoqtop.lua
+++ b/lsp/vscoqtop.lua
@@ -1,6 +1,7 @@
 ---@brief
 ---
 --- https://github.com/coq-community/vscoq
+---@type vim.lsp.Config
 return {
   cmd = { 'vscoqtop' },
   filetypes = { 'coq' },

--- a/lsp/vtsls.lua
+++ b/lsp/vtsls.lua
@@ -84,7 +84,7 @@ return {
     local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
     local project_root = vim.fs.root(bufnr, project_root_markers)
     if not project_root then
-      return nil
+      return
     end
 
     -- We know that the buffer is using Typescript if it has a config file
@@ -98,7 +98,7 @@ return {
       stop = vim.fs.dirname(project_root),
     })[1]
     if not is_buffer_using_typescript then
-      return nil
+      return
     end
 
     on_dir(project_root)

--- a/lsp/vtsls.lua
+++ b/lsp/vtsls.lua
@@ -65,6 +65,7 @@
 ---
 --- It is recommended to use the same version of TypeScript in all packages, and therefore have it available in your workspace root. The location of the TypeScript binary will be determined automatically, but only once.
 
+---@type vim.lsp.Config
 return {
   cmd = { 'vtsls', '--stdio' },
   filetypes = {

--- a/lsp/vue_ls.lua
+++ b/lsp/vue_ls.lua
@@ -18,6 +18,7 @@
 ---
 --- NOTE: Since v3.0.0, the Vue Language Server [no longer supports takeover mode](https://github.com/vuejs/language-tools/pull/5248).
 
+---@type vim.lsp.Config
 return {
   cmd = { 'vue-language-server', '--stdio' },
   filetypes = { 'vue' },

--- a/lsp/wasm_language_tools.lua
+++ b/lsp/wasm_language_tools.lua
@@ -4,6 +4,7 @@
 ---
 --- WebAssembly Language Tools aims to provide and improve the editing experience of WebAssembly Text Format.
 --- It also provides an out-of-the-box formatter (a.k.a. pretty printer) for WebAssembly Text Format.
+---@type vim.lsp.Config
 return {
   cmd = { 'wat_server' },
   filetypes = { 'wat' },

--- a/lsp/wgsl_analyzer.lua
+++ b/lsp/wgsl_analyzer.lua
@@ -6,6 +6,7 @@
 --- ```sh
 --- cargo install --git https://github.com/wgsl-analyzer/wgsl-analyzer wgsl-analyzer
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'wgsl-analyzer' },
   filetypes = { 'wgsl' },

--- a/lsp/yamlls.lua
+++ b/lsp/yamlls.lua
@@ -58,6 +58,7 @@
 ---   }
 --- })
 --- ```
+---@type vim.lsp.Config
 return {
   cmd = { 'yaml-language-server', '--stdio' },
   filetypes = { 'yaml', 'yaml.docker-compose', 'yaml.gitlab', 'yaml.helm-values' },

--- a/lsp/yang_lsp.lua
+++ b/lsp/yang_lsp.lua
@@ -3,6 +3,7 @@
 --- https://github.com/TypeFox/yang-lsp
 ---
 --- A Language Server for the YANG data modeling language.
+---@type vim.lsp.Config
 return {
   cmd = { 'yang-language-server' },
   filetypes = { 'yang' },

--- a/lsp/yls.lua
+++ b/lsp/yls.lua
@@ -7,6 +7,7 @@
 --- This plugin runs yara.compile on every save, parses the errors, and returns list of diagnostic messages.
 ---
 --- Language Server: https://github.com/avast/yls
+---@type vim.lsp.Config
 return {
   cmd = { 'yls', '-vv' },
   filetypes = { 'yar', 'yara' },

--- a/lsp/ziggy.lua
+++ b/lsp/ziggy.lua
@@ -3,6 +3,7 @@
 --- https://ziggy-lang.io/documentation/ziggy-lsp/
 ---
 --- Language server for the Ziggy data serialization format
+---@type vim.lsp.Config
 return {
   cmd = { 'ziggy', 'lsp' },
   filetypes = { 'ziggy' },

--- a/lsp/ziggy_schema.lua
+++ b/lsp/ziggy_schema.lua
@@ -3,6 +3,7 @@
 --- https://ziggy-lang.io/documentation/ziggy-lsp/
 ---
 --- Language server for schema files of the Ziggy data serialization format
+---@type vim.lsp.Config
 return {
   cmd = { 'ziggy', 'lsp', '--schema' },
   filetypes = { 'ziggy_schema' },

--- a/lsp/zk.lua
+++ b/lsp/zk.lua
@@ -12,6 +12,7 @@ local function find_zk_root(startpath)
   end
 end
 
+---@type vim.lsp.Config
 return {
   cmd = { 'zk', 'lsp' },
   filetypes = { 'markdown' },

--- a/lsp/zls.lua
+++ b/lsp/zls.lua
@@ -3,6 +3,7 @@
 ---
 --- Zig LSP implementation + Zig Language Server
 
+---@type vim.lsp.Config
 return {
   cmd = { 'zls' },
   filetypes = { 'zig', 'zir' },


### PR DESCRIPTION
Adds `---@type vim.lsp.Config` for configs and fixes some type related issues (and some minor inconsistencies). 

To make it easier for review, it's split into 2 commits.

TODO: add lint rule