### PR TITLE
refactor(yamlls): Non-hacky way to enable formatting

### DIFF
--- a/lsp/yamlls.lua
+++ b/lsp/yamlls.lua
@@ -66,9 +66,7 @@ return {
   settings = {
     -- https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting
     redhat = { telemetry = { enabled = false } },
+    -- formatting disabled by default in yaml-language-server; enable it
+    yaml = { format = { enable = true } },
   },
-  on_init = function(client)
-    -- https://github.com/redhat-developer/yaml-language-server/issues/486
-    client.server_capabilities.documentFormattingProvider = true
-  end,
 }

--- a/lua/lspconfig/configs/yamlls.lua
+++ b/lua/lspconfig/configs/yamlls.lua
@@ -9,6 +9,8 @@ return {
     settings = {
       -- https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting
       redhat = { telemetry = { enabled = false } },
+      -- formatting disabled by default in yaml-language-server; enable it
+      yaml = { format = { enable = true } },
     },
   },
   docs = {


### PR DESCRIPTION
Faking capabilities isn't necessary to enable formatting support. It's a dynamically registered capability that yamlls announces whenever yaml formatting is enabled in settings, which it isn't by default.

See:
https://github.com/redhat-developer/yaml-language-server/blob/3821411ee8c92e5b7e5ca88f84ab443ae3b2791a/src/yamlServerInit.ts#L128
https://github.com/redhat-developer/yaml-language-server/blob/3821411ee8c92e5b7e5ca88f84ab443ae3b2791a/src/languageserver/handlers/settingsHandlers.ts#L159-L174

Fixes: 63a016437e44 ("feat(yamlls): document formatting support #4003")
