### PR TITLE
fix(ts/js): give lockfiles equal priority when finding root

### DIFF
--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -45,7 +45,8 @@ return {
     -- We select then from the project root, which is identified by the presence of a package
     -- manager lock file.
     local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
-    local project_root = vim.fs.root(bufnr, project_root_markers)
+    -- Give the root markers equal priority by wrapping them in a table
+    local project_root = vim.fs.root(bufnr, { project_root_markers })
     if not project_root then
       return
     end

--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -92,9 +92,10 @@ return {
     -- We select then from the project root, which is identified by the presence of a package
     -- manager lock file.
     local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
-    local project_root = vim.fs.root(bufnr, project_root_markers)
+    -- Give the root markers equal priority by wrapping them in a table
+    local project_root = vim.fs.root(bufnr, { project_root_markers })
     if not project_root then
-      return nil
+      return
     end
 
     -- We know that the buffer is using ESLint if it has a config file
@@ -113,7 +114,7 @@ return {
       stop = vim.fs.dirname(project_root),
     })[1]
     if not is_buffer_using_eslint then
-      return nil
+      return
     end
 
     on_dir(project_root)

--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -59,7 +59,8 @@ return {
     -- We select then from the project root, which is identified by the presence of a package
     -- manager lock file.
     local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
-    local project_root = vim.fs.root(bufnr, project_root_markers)
+    -- Give the root markers equal priority by wrapping them in a table
+    local project_root = vim.fs.root(bufnr, { project_root_markers })
     if not project_root then
       return
     end

--- a/lsp/tsgo.lua
+++ b/lsp/tsgo.lua
@@ -30,7 +30,8 @@ return {
     -- We select then from the project root, which is identified by the presence of a package
     -- manager lock file.
     local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
-    local project_root = vim.fs.root(bufnr, project_root_markers)
+    -- Give the root markers equal priority by wrapping them in a table
+    local project_root = vim.fs.root(bufnr, { project_root_markers })
     if not project_root then
       return
     end

--- a/lsp/vtsls.lua
+++ b/lsp/vtsls.lua
@@ -82,7 +82,8 @@ return {
     -- We select then from the project root, which is identified by the presence of a package
     -- manager lock file.
     local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
-    local project_root = vim.fs.root(bufnr, project_root_markers)
+    -- Give the root markers equal priority by wrapping them in a table
+    local project_root = vim.fs.root(bufnr, { project_root_markers })
     if not project_root then
       return
     end


### PR DESCRIPTION
When `vim.fs.root` is given a table of markers, it performs one traversal per entry in the table (until a root is found).
What we actually want is to perform a single traversal that stops when any of the javascript root markers are found.