### PR TITLE
feat(yamlls): added lsp capability override

### DIFF
--- a/lsp/yamlls.lua
+++ b/lsp/yamlls.lua
@@ -69,4 +69,8 @@ return {
     -- formatting disabled by default in yaml-language-server; enable it
     yaml = { format = { enable = true } },
   },
+  on_init = function(client)
+    -- Fix for https://github.com/redhat-developer/yaml-language-server/issues/486
+    client.server_capabilities.documentFormattingProvider = true
+  end,
 }

--- a/lsp/yamlls.lua
+++ b/lsp/yamlls.lua
@@ -70,7 +70,10 @@ return {
     yaml = { format = { enable = true } },
   },
   on_init = function(client)
-    -- Fix for https://github.com/redhat-developer/yaml-language-server/issues/486
+    --- https://github.com/neovim/nvim-lspconfig/pull/4016
+    --- Since formatting is disabled by default if you check `client:supports_method('textDocument/formatting')`
+    --- during `LspAttach` it will return `false`. This hack sets the capability to `true` to facilitate
+    --- autocmd's which check this capability
     client.server_capabilities.documentFormattingProvider = true
   end,
 }


### PR DESCRIPTION
Some back and forth on this, I didn't explain things properly on #4003 and this section got removed in #4012.

The current version of the config will let you do formatting manually `:lua vim.lsp.buf.format()` but the lsp doesn't have capabilities registered correctly so if you use auto formatting like outlined in [help pages](https://neovim.io/doc/user/lsp.html#lsp-attach)
```lua
    if not client:supports_method('textDocument/willSaveWaitUntil')
        and client:supports_method('textDocument/formatting') then
      vim.api.nvim_create_autocmd('BufWritePre', {
        group = vim.api.nvim_create_augroup('my.lsp', {clear=false}),
        buffer = args.buf,
        callback = function()
          vim.lsp.buf.format({ bufnr = args.buf, id = client.id, timeout_ms = 1000 })
        end,
      })
    end
```
It won't enable for the yaml lsp because `client:supports_method('textDocument/formatting')` returns false.

The hook, while hacky, will mark the capability as true which is worthwhile in my opinion.

@justinmk @liskin 