### PR TITLE
fix(ts/js): fixed behavior of root_dir funcion (issue #4015)

### DIFF
--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -59,12 +59,12 @@ return {
     -- We select then from the project root, which is identified by the presence of a package
     -- manager lock file.
     local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
+
     -- Give the root markers equal priority by wrapping them in a table
     local project_root = vim.fs.root(bufnr, { project_root_markers })
-    if not project_root then
-      return
-    end
 
+    -- If project root not found `project_root` will be nil and on_dir function will be called with nil value
+    -- to allow LSP to start for standalone TS/JS files.
     on_dir(project_root)
   end,
   handlers = {

--- a/lsp/tsgo.lua
+++ b/lsp/tsgo.lua
@@ -31,12 +31,12 @@ return {
     -- We select then from the project root, which is identified by the presence of a package
     -- manager lock file.
     local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
+
     -- Give the root markers equal priority by wrapping them in a table
     local project_root = vim.fs.root(bufnr, { project_root_markers })
-    if not project_root then
-      return
-    end
 
+    -- If project root not found `project_root` will be nil and on_dir function will be called with nil value
+    -- to allow LSP to start for standalone TS/JS files.
     on_dir(project_root)
   end,
 }

--- a/lsp/vtsls.lua
+++ b/lsp/vtsls.lua
@@ -82,12 +82,12 @@ return {
     -- We select then from the project root, which is identified by the presence of a package
     -- manager lock file.
     local project_root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
+
     -- Give the root markers equal priority by wrapping them in a table
     local project_root = vim.fs.root(bufnr, { project_root_markers })
-    if not project_root then
-      return
-    end
 
+    -- If project root not found `project_root` will be nil and on_dir function will be called with nil value
+    -- to allow LSP to start for standalone TS/JS files.
     on_dir(project_root)
   end,
 }


### PR DESCRIPTION
This pr is intended to fix issue #4015 
### Problem:

ts_ls, vtsls, tsgo LSP do not start for standalone files
eslint/biome LSP do not start when there is config file but lock file is absent in workspace directory

### Solution:

ts_ls, vtsls, tsgo: Remove redundant truthy check when calling `on_dir(project_root)`. If `project_root` is provided, it will be used as `root_dir`; otherwise, `root_dir` will be `nil`, allowing the LSP to start for standalone files.

eslint/biome: added check for config root directory when project root directory not found

Please, consider that i am a beginner, so I will be grateful for any suggestions for improvements.