### PR TITLE
fix(gitlab_ls): root dir ordering

### DIFF
--- a/lsp/gitlab_ci_ls.lua
+++ b/lsp/gitlab_ci_ls.lua
@@ -17,7 +17,7 @@ return {
   filetypes = { 'yaml.gitlab' },
   root_dir = function(bufnr, on_dir)
     local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('.gitlab*', '.git')(fname))
+    on_dir(util.root_pattern('.git', '.gitlab*')(fname))
   end,
   init_options = {
     cache_path = cache_dir,

--- a/lua/lspconfig/configs/gitlab_ci_ls.lua
+++ b/lua/lspconfig/configs/gitlab_ci_ls.lua
@@ -5,7 +5,7 @@ return {
   default_config = {
     cmd = { 'gitlab-ci-ls' },
     filetypes = { 'yaml.gitlab' },
-    root_dir = util.root_pattern('.gitlab*', '.git'),
+    root_dir = util.root_pattern('.git', '.gitlab*'),
     init_options = {
       cache_path = cache_dir,
       log_path = cache_dir .. '/log/gitlab-ci-ls.log',


### PR DESCRIPTION
Problem:

If project had a nested child gitlab file named: .gitlab-ci.yml it would take it as root.

Solution:

If inside GIT repository just use git repository root as root and still keep the option for .gitlab* as fallback if there is no git repo yet.