### PR TITLE
fix(vue_ls): make tsserver handler more resilient 

### DIFF
--- a/lsp/vue_ls.lua
+++ b/lsp/vue_ls.lua
@@ -25,18 +25,13 @@ return {
   root_markers = { 'package.json' },
   on_init = function(client)
     client.handlers['tsserver/request'] = function(_, result, context)
-      local ts_clients = vim.lsp.get_clients({ bufnr = context.bufnr, name = 'ts_ls' })
-      local vtsls_clients = vim.lsp.get_clients({ bufnr = context.bufnr, name = 'vtsls' })
-      local clients = {}
+      local ts_client = vim.lsp.get_clients({ bufnr = context.bufnr, name = 'ts_ls' })[1]
+        or vim.lsp.get_clients({ bufnr = context.bufnr, name = 'vtsls' })[1]
 
-      vim.list_extend(clients, ts_clients)
-      vim.list_extend(clients, vtsls_clients)
-
-      if #clients == 0 then
+      if not ts_client then
         vim.notify('Could not find `ts_ls` or `vtsls` lsp client, required by `vue_ls`.', vim.log.levels.ERROR)
         return
       end
-      local ts_client = clients[1]
 
       local param = unpack(result)
       local id, command, payload = unpack(param)


### PR DESCRIPTION
## Problem

After updating the Vue Language Server to version 3 I ran into the error "Could not find `ts_ls` or `vtsls` lsp client, required by `vue_ls`." at startup. It did not happen every time but most of the time. After playing around with as part of [this discussion](https://github.com/vuejs/language-tools/discussions/5603), I found out that it only happens when I have the lsp configurations in `/after/lsp`. If I configure everything in the same file the issue does not seem to occur.

I presume that there is some kind of race condition going on which either does not or is far less likely to happen with a single configuration file.

## Solution

In any case since I'm probably not the only one using the `/after/lsp` style of configuration, I think it makes sense to have some kind of solution within lspconfig.

I added a retry into the handler that allows some time for the typescript ls to attach.

## Additional notes

- If there is clean way of having one language server wait for another I would be all ears
- I also made a small refactor which I can split into its own PR if desired
