### PR TITLE
fix: add tf filetype for terraform and tofu ls

### DIFF
--- a/lsp/terraformls.lua
+++ b/lsp/terraformls.lua
@@ -35,6 +35,6 @@
 ---@type vim.lsp.Config
 return {
   cmd = { 'terraform-ls', 'serve' },
-  filetypes = { 'terraform', 'terraform-vars' },
+  filetypes = { 'tf', 'terraform', 'terraform-vars' },
   root_markers = { '.terraform', '.git' },
 }

--- a/lsp/tofu_ls.lua
+++ b/lsp/tofu_ls.lua
@@ -6,6 +6,6 @@
 ---@type vim.lsp.Config
 return {
   cmd = { 'tofu-ls', 'serve' },
-  filetypes = { 'opentofu', 'opentofu-vars' },
+  filetypes = { 'tf', 'opentofu', 'opentofu-vars' },
   root_markers = { '.terraform', '.git' },
 }


### PR DESCRIPTION
To activate terraform-ls and tofu-ls to files with the filetype `.tf` I want to add the `tf` filetype.