### PR TITLE
feat: add llvm clangir lsp server

### DIFF
--- a/lsp/cir_lsp_server.lua
+++ b/lsp/cir_lsp_server.lua
@@ -1,0 +1,14 @@
+---@brief
+---
+--- https://llvm.github.io/clangir
+---
+--- The Language Server for the LLVM ClangIR language
+---
+--- `cir-lsp-server` can be installed at the llvm-project repository (https://github.com/llvm/llvm-project)
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'cir-lsp-server' },
+  filetypes = { 'cir' },
+  root_markers = { '.git' },
+}


### PR DESCRIPTION
This PR adds the default config for the LLVM ClangIR LSP Server (https://github.com/llvm/llvm-project/tree/main/clang/tools/cir-lsp-server)