### PR TITLE
fix(copilot): fix device flow authentication

### DIFF
--- a/lsp/copilot.lua
+++ b/lsp/copilot.lua
@@ -32,7 +32,7 @@ local function sign_in(bufnr, client)
         vim.fn.setreg('+', code)
         vim.fn.setreg('*', code)
         local continue = vim.fn.confirm(
-          'Copyied your one-time code to clipboard.\n' .. 'Open the browser to complete the sign-in process?',
+          'Copied your one-time code to clipboard.\n' .. 'Open the browser to complete the sign-in process?',
           '&Yes\n&No'
         )
         if continue == 1 then
@@ -49,7 +49,7 @@ local function sign_in(bufnr, client)
       end
 
       if result.status == 'PromptUserDeviceFlow' then
-        vim.notify('Enter your one-time code ' .. result.code .. ' in ' .. result.verificationUri)
+        vim.notify('Enter your one-time code ' .. result.userCode .. ' in ' .. result.verificationUri)
       elseif result.status == 'AlreadySignedIn' then
         vim.notify('Already signed in as ' .. result.user .. '.')
       end


### PR DESCRIPTION
Current code will always trigger error (unless you are already authd), because result.code is invalid. result.userCode must be used instead.