### PR TITLE
fix(herb): remove ruby filetype

### DIFF
--- a/lsp/herb_ls.lua
+++ b/lsp/herb_ls.lua
@@ -24,6 +24,6 @@
 ---@type vim.lsp.Config
 return {
   cmd = { 'herb-language-server', '--stdio' },
-  filetypes = { 'html', 'ruby', 'eruby' },
+  filetypes = { 'html', 'eruby' },
   root_markers = { 'Gemfile', '.git' },
 }


### PR DESCRIPTION
As outlined in [this issue on herb](https://github.com/marcoroth/herb/issues/309#issuecomment-3130071214), herb should not actually run on Ruby files. This PR removes the offending filetype.

> Yeah, I think Herb shouldn't be run on .rb files in general. So it would probably be best to remove the ruby file type in the Language Server configuration.

@marcoroth FYI