### PR TITLE
fix(pyright): fix LspPyrightSetPythonPath user command

### DIFF
--- a/lsp/basedpyright.lua
+++ b/lsp/basedpyright.lua
@@ -4,7 +4,8 @@
 ---
 --- `basedpyright`, a static type checker and language server for python
 
-local function set_python_path(path)
+local function set_python_path(command)
+  local path = command.args
   local clients = vim.lsp.get_clients {
     bufnr = vim.api.nvim_get_current_buf(),
     name = 'basedpyright',

--- a/lsp/pyright.lua
+++ b/lsp/pyright.lua
@@ -4,7 +4,8 @@
 ---
 --- `pyright`, a static type checker and language server for python
 
-local function set_python_path(path)
+local function set_python_path(command)
+  local path = command.args
   local clients = vim.lsp.get_clients {
     bufnr = vim.api.nvim_get_current_buf(),
     name = 'pyright',


### PR DESCRIPTION
`vim.api.nvim_buf_create_user_command` callback is called with a table
argument that contains a parsed command. Need to use `args` or `fargs`
key to get command arguments.

## Closes: #4044.

## name: Pull Request about: Submit a pull request title: ''
