### PR TITLE
feat(gh_actions_ls): add handler for actions/readFile request

### DIFF
--- a/lsp/gh_actions_ls.lua
+++ b/lsp/gh_actions_ls.lua
@@ -37,8 +37,10 @@ return {
       end
       local file_path = vim.uri_to_fname(result.path)
       if vim.fn.filereadable(file_path) == 1 then
-        local content = vim.fn.readfile(file_path)
-        local text = table.concat(content, '\n')
+        local f = assert(io.open(file_path, 'r'))
+        local text = f:read('*a')
+        f:close()
+
         return text, nil
       end
       return nil, nil


### PR DESCRIPTION
Implement a custom handler for the "actions/readFile" request in the gh_actions_ls config. This handler reads the requested file from disk and returns its contents if the file is readable. This improves integration with the GitHub Actions language server by supporting file content requests.


Here is how vscode github actions extension is setting the handler
https://github.com/github/vscode-github-actions/blob/main/src/workflow/languageServer.ts#L68

Solves:
https://github.com/lttb/gh-actions-language-server/issues/5



We could also provide an implementation for populating the init_options properly, now in the docs it is documented as an empty table

But in order for the lsp to work properly, it should be populated with this "shape", i dont know whats your opinion on providing a default implementation for this

```lua

				init_options = {
					sessionToken = session_token,
					repos = {
						{
							id = 1008200293,
							owner = org_name,
							name = repo_name,
							workspaceUri = "file://" .. vim.fn.getcwd(),
							organizationOwned = true,
						},
					},
				},
```
