### PR TITLE
fix(expert): reorder the markers

### DIFF
--- a/lsp/expert.lua
+++ b/lsp/expert.lua
@@ -7,6 +7,6 @@
 ---@type vim.lsp.Config
 return {
   filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
-  root_markers = { 'mix.exs', '.git' },
+  root_markers = { '.git', 'mix.exs' },
   cmd = { 'expert' },
 }


### PR DESCRIPTION
Due to the current order, multiple instances of the LSP are created, even though they both belong to the same root directory. As seen in the screenshot, the project name is proxy, but when I use the 'go to definition' action, the Phoenix module gets opened, and a new LSP is spun up for it.

<img width="1283" height="200" alt="Screenshot 2025-08-31 at 17 36 15" src="https://github.com/user-attachments/assets/6b0c8a8f-8466-44b0-813c-5b163055bafc" />

So, the change in this PR is to mitigate the problem by making sure the .git has higher priority over the mixfile.