### PR TITLE
perf: use has() instead of vim.version

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -73,7 +73,7 @@ end, {
   desc = 'Opens the Nvim LSP client log.',
 })
 
-if vim.version.ge(vim.version(), { 0, 11, 2 }) then
+if vim.fn.has('nvim-0.11.2') == 1 then
   local complete_client = function(arg)
     return vim
       .iter(vim.lsp.get_clients())


### PR DESCRIPTION
In `plugin/lspconfig.lua`, `vim.version` is slow, so replace it with `has()`.

Local benchmark `:runtime plugin/lspconfig.lua`:
| function | time |
|-|-|
|`vim.version`|3-6ms|
|`has()`|0.2-1ms|