### PR TITLE
fix(expert): implement root_dir instead

### DIFF
--- a/lsp/expert.lua
+++ b/lsp/expert.lua
@@ -3,10 +3,19 @@
 --- https://github.com/elixir-lang/expert
 ---
 --- Expert is the official language server implementation for the Elixir programming language.
+---
+--- 'root_dir' is chosen like this: if two or more directories containing `mix.exs` were found when searching directories upward, the second one (higher up) is chosen, with the assumption that it is the root of an umbrella app. Otherwise the directory containing the single mix.exs that was found is chosen.
 
 ---@type vim.lsp.Config
 return {
   filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
-  root_markers = { '.git', 'mix.exs' },
   cmd = { 'expert' },
+  root_dir = function(bufnr, on_dir)
+    local fname = vim.api.nvim_buf_get_name(bufnr)
+    local matches = vim.fs.find({ 'mix.exs' }, { upward = true, limit = 2, path = fname })
+    local child_or_root_path, maybe_umbrella_path = unpack(matches)
+    local root_dir = vim.fs.dirname(maybe_umbrella_path or child_or_root_path)
+
+    on_dir(root_dir)
+  end,
 }

--- a/lsp/expert.lua
+++ b/lsp/expert.lua
@@ -15,6 +15,8 @@ return {
   cmd = { 'expert' },
   root_dir = function(bufnr, on_dir)
     local fname = vim.api.nvim_buf_get_name(bufnr)
+    --- Elixir workspaces may have `mix.exs` files, e.g. for an "umbrella" layout or monorepo. So we
+    --- specify `limit=2` and treat the highest one (if any) as the root of an umbrella app.
     local matches = vim.fs.find({ 'mix.exs' }, { upward = true, limit = 2, path = fname })
     local child_or_root_path, maybe_umbrella_path = unpack(matches)
     local root_dir = vim.fs.dirname(maybe_umbrella_path or child_or_root_path)

--- a/lsp/expert.lua
+++ b/lsp/expert.lua
@@ -4,7 +4,10 @@
 ---
 --- Expert is the official language server implementation for the Elixir programming language.
 ---
---- 'root_dir' is chosen like this: if two or more directories containing `mix.exs` were found when searching directories upward, the second one (higher up) is chosen, with the assumption that it is the root of an umbrella app. Otherwise the directory containing the single mix.exs that was found is chosen.
+--- 'root_dir' is chosen like this: if two or more directories containing `mix.exs` were found when
+--- searching directories upward, the second one (higher up) is chosen, with the assumption that it
+--- is the root of an umbrella app. Otherwise the directory containing the single mix.exs that was
+--- found is chosen.
 
 ---@type vim.lsp.Config
 return {


### PR DESCRIPTION
Copy the approach from `lsp/elixirls.lua` to support monorepos.

fix #4052