### PR TITLE
feat(biome,eslint,svelte,ts_ls,tsgo,vtsls): add .git root marker

### DIFF
--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -43,8 +43,9 @@ return {
     -- The project root is where the LSP can be started from
     -- As stated in the documentation above, this LSP supports monorepos and simple projects.
     -- We select then from the project root, which is identified by the presence of a package
-    -- manager lock file.
-    local root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock' }
+    -- manager lock file or .git directory/file.
+    local root_markers =
+      { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock', '.git' }
     -- Give the root markers equal priority by wrapping them in a table
     root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers } or root_markers
     local project_root = vim.fs.root(bufnr, root_markers)

--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -90,8 +90,9 @@ return {
     -- The project root is where the LSP can be started from
     -- As stated in the documentation above, this LSP supports monorepos and simple projects.
     -- We select then from the project root, which is identified by the presence of a package
-    -- manager lock file.
-    local root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock' }
+    -- manager lock file or .git directory/file.
+    local root_markers =
+      { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock', '.git' }
     -- Give the root markers equal priority by wrapping them in a table
     root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers } or root_markers
     local project_root = vim.fs.root(bufnr, root_markers)

--- a/lsp/svelte.lua
+++ b/lsp/svelte.lua
@@ -14,7 +14,8 @@ return {
   cmd = { 'svelteserver', '--stdio' },
   filetypes = { 'svelte' },
   root_dir = function(bufnr, on_dir)
-    local root_files = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock' }
+    local root_files =
+      { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock', '.git' }
     local fname = vim.api.nvim_buf_get_name(bufnr)
     -- Svelte LSP only supports file:// schema. https://github.com/sveltejs/language-tools/issues/2777
     if vim.uv.fs_stat(fname) ~= nil then

--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -57,8 +57,9 @@ return {
     -- The project root is where the LSP can be started from
     -- As stated in the documentation above, this LSP supports monorepos and simple projects.
     -- We select then from the project root, which is identified by the presence of a package
-    -- manager lock file.
-    local root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock' }
+    -- manager lock file or .git directory/file.
+    local root_markers =
+      { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock', '.git' }
     -- Give the root markers equal priority by wrapping them in a table
     root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers } or root_markers
     local project_root = vim.fs.root(bufnr, root_markers)

--- a/lsp/tsgo.lua
+++ b/lsp/tsgo.lua
@@ -29,8 +29,9 @@ return {
     -- The project root is where the LSP can be started from
     -- As stated in the documentation above, this LSP supports monorepos and simple projects.
     -- We select then from the project root, which is identified by the presence of a package
-    -- manager lock file.
-    local root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock' }
+    -- manager lock file or .git directory/file.
+    local root_markers =
+      { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock', '.git' }
     -- Give the root markers equal priority by wrapping them in a table
     root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers } or root_markers
     local project_root = vim.fs.root(bufnr, root_markers)

--- a/lsp/vtsls.lua
+++ b/lsp/vtsls.lua
@@ -83,8 +83,9 @@ return {
     -- The project root is where the LSP can be started from
     -- As stated in the documentation above, this LSP supports monorepos and simple projects.
     -- We select then from the project root, which is identified by the presence of a package
-    -- manager lock file.
-    local root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock' }
+    -- manager lock file or .git directory/file.
+    local root_markers =
+      { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock', '.git' }
     -- Give the root markers equal priority by wrapping them in a table
     root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers } or root_markers
     local project_root = vim.fs.root(bufnr, root_markers)


### PR DESCRIPTION
Problem:
In a [Rush](https://rushjs.io/) monorepo, the lock file is not located in the project root directory. As a result, the LSP client does not activate for files in such monorepos.

Solution:
Use the `.git` directory/file as a root marker.