### PR TITLE
fix(ts_query_ls): root pattern fixup, override query ftplugin opts

### DIFF
--- a/lsp/ts_query_ls.lua
+++ b/lsp/ts_query_ls.lua
@@ -4,38 +4,40 @@
 --- Can be configured by passing a "settings" object to `vim.lsp.config('ts_query_ls', {})`:
 --- ```lua
 --- vim.lsp.config('ts_query_ls', {
----     settings = {
----       parser_install_directories = {
----         -- If using nvim-treesitter with lazy.nvim
----         vim.fs.joinpath(
----           vim.fn.stdpath('data'),
----           '/lazy/nvim-treesitter/parser/'
----         ),
----       },
----       -- This setting is provided by default
----       parser_aliases = {
----         ecma = 'javascript',
----         jsx = 'javascript',
----         php_only = 'php',
----       },
----       -- E.g. zed support
----       language_retrieval_patterns = {
----         'languages/src/([^/]+)/[^/]+\\.scm$',
----       },
+---   init_options = {
+---     parser_install_directories = {
+---       '/my/parser/install/dir',
 ---     },
+---     -- This setting is provided by default
+---     parser_aliases = {
+---       ecma = 'javascript',
+---       jsx = 'javascript',
+---       php_only = 'php',
+---     },
+---   },
 --- })
 --- ```
+
+-- Disable the (slow) built-in query linter, which will show duplicate diagnostics. This must be done before the query
+-- ftplugin is sourced.
+vim.g.query_lint_on = {}
 
 ---@type vim.lsp.Config
 return {
   cmd = { 'ts_query_ls' },
   filetypes = { 'query' },
-  root_markers = { 'queries', '.git' },
-  settings = {
+  root_markers = { '.tsqueryrc.json', '.git' },
+  init_options = {
     parser_aliases = {
       ecma = 'javascript',
       jsx = 'javascript',
       php_only = 'php',
     },
+    parser_install_directories = {
+      vim.fn.stdpath('data') .. '/site/parser',
+    },
   },
+  on_attach = function(_, buf)
+    vim.bo[buf].omnifunc = 'v:lua.vim.lsp.omnifunc'
+  end,
 }


### PR DESCRIPTION
**Problem:** The built-in query linter will cause duplicate diagnostics when running the query LSP. It is also slower and blocking, and can cause jarring editor freezes for short times.

**Solution:** Disable it when using `ts_query_ls`. Also, set the omnifunc to the LSP omnifunc rather than the custom `query` one.