### PR TITLE
fix(roslyn_ls): remove unused handler

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -69,13 +69,6 @@ local function roslyn_handlers()
       refresh_diagnostics(client)
       return vim.NIL
     end,
-
-    ['workspace/_roslyn_projectHasUnresolvedDependencies'] = function()
-      vim.notify('Detected missing dependencies. Run `dotnet restore` command.', vim.log.levels.ERROR, {
-        title = 'roslyn_ls',
-      })
-      return vim.NIL
-    end,
     ['workspace/_roslyn_projectNeedsRestore'] = function(_, result, ctx)
       local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
 


### PR DESCRIPTION
This handler was removed a long time ago and was replaced with another handler that is already implemented here: https://github.com/dotnet/vscode-csharp/commit/9cc41f6d2535a5cb5533dc5ae8f3a10ade16e7b5

