### PR TITLE
fix:remove extra table wrapper in root_markersUpdate ts_ls.lua

### DIFF
--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -59,8 +59,6 @@ return {
     -- We select then from the project root, which is identified by the presence of a package
     -- manager lock file.
     local root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock' }
-    -- Give the root markers equal priority by wrapping them in a table
-    root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers } or root_markers
     local project_root = vim.fs.root(bufnr, root_markers)
     if not project_root then
       return


### PR DESCRIPTION
The `root_markers` variable was wrapped in an extra table when Neovim >= 0.11.3:

root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers } or root_markers

This causes `vim.fs.root` to receive a table-of-table, resulting in errors:
"invalid value (table) at index 2 in table for 'concat'"

This PR removes the unnecessary wrapper to keep root_markers as a flat array.