### PR TITLE
fix(ts_ls): remove extra table wrapper in root_markers

### DIFF
--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -59,8 +59,6 @@ return {
     -- We select then from the project root, which is identified by the presence of a package
     -- manager lock file.
     local root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock' }
-    -- Give the root markers equal priority by wrapping them in a table
-    root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers } or root_markers
     local project_root = vim.fs.root(bufnr, root_markers)
     if not project_root then
       return


### PR DESCRIPTION
fix(ts_ls): remove extra table wrapper in root_markers

The previous code wrapped root_markers in an extra table, causing
vim.fs.root to fail in Neovim 0.11.3+. This fixes the type error
and ensures ts_ls works correctly.
