### PR TITLE
fix(ts_ls): ensure flat root_markers table for project roots

### DIFF
--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -60,7 +60,7 @@ return {
     -- manager lock file.
     local root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'deno.lock' }
     -- Give the root markers equal priority by wrapping them in a table
-    root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers, { '.git' } }
+    root_markers = vim.fn.has('nvim-0.11.3') == 1 and table.insert(root_markers, '.git')
       or vim.list_extend(root_markers, { '.git' })
     -- We fallback to the current working directory if no project root is found
     local project_root = vim.fs.root(bufnr, root_markers) or vim.fn.getcwd()


### PR DESCRIPTION
The previous logic could create a nested table when adding '.git' as a root marker, leading to incorrect root detection. This change ensures that '.git' is always appended to the root_markers list, resulting in a flat table and correct project root identification.

Fixes this error when opening javascript files (at least in NVIM v0.12.0-dev)
```
Error detected while processing BufReadPost Autocommands for "*":                                                                                                                                                                                                                      
Error executing lua callback: /usr/share/nvim/runtime/filetype.lua:36: BufReadPost Autocommands for "*"..FileType Autocommands for "*": Vim(append):Error executing lua callback: vim/fs.lua:0: invalid value (table) at index 2 in table for 'concat'                                 
stack traceback:                                                                                                                                                                                                                                                                       
        [C]: in function 'concat'                                                                                                                                                                                                                                                      
        vim/fs.lua: in function 'joinpath'                                                                                                                                                                                                                                             
        vim/fs.lua: in function <vim/fs.lua:0>                                                                                                                                                                                                                                         
        vim/fs.lua: in function 'find'                                                                                                                                                                                                                                                 
        vim/fs.lua: in function 'root'                                                                                                                                                                                                                                                 
        .../.../.local/share/nvim/lazy/nvim-lspconfig/lsp/ts_ls.lua:67: in function 'root_dir'                                                                                                                                                                                         
        /usr/share/nvim/runtime/lua/vim/lsp.lua:525: in function 'lsp_enable_callback'                                                                                                                                                                                                 
        /usr/share/nvim/runtime/lua/vim/lsp.lua:576: in function </usr/share/nvim/runtime/lua/vim/lsp.lua:575>                                                                                                                                                                         
        [C]: in function 'nvim_cmd'                                                                                                                                                                                                                                                    
        /usr/share/nvim/runtime/filetype.lua:36: in function </usr/share/nvim/runtime/filetype.lua:35>                                                                                                                                                                                 
        [C]: in function 'pcall'                                                                                                                                                                                                                                                       
        vim/shared.lua: in function <vim/shared.lua:0>                                                                                                                                                                                                                                 
        [C]: in function '_with'                                                                                                                                                                                                                                                       
        /usr/share/nvim/runtime/filetype.lua:35: in function </usr/share/nvim/runtime/filetype.lua:10>                                                                                                                                                                                 
stack traceback:                                                                                                                                                                                                                                                                       
        [C]: in function '_with'                                                                                                                                                                                                                                                       
        /usr/share/nvim/runtime/filetype.lua:35: in function </usr/share/nvim/runtime/filetype.lua:10>  
```