### PR TITLE
fix(jdtls): remove nonstandard WorkspaceEdit version handlers

### DIFF
--- a/lsp/jdtls.lua
+++ b/lsp/jdtls.lua
@@ -32,8 +32,6 @@
 ---       vim.lsp.config('jdtls', { cmd = { 'jdtls' } })
 ---     ```
 
-local handlers = require 'vim.lsp.handlers'
-
 local env = {
   HOME = vim.uv.os_homedir(),
   XDG_CACHE_HOME = os.getenv 'XDG_CACHE_HOME',
@@ -65,42 +63,6 @@ local function get_jdtls_jvm_args()
   return unpack(args)
 end
 
--- TextDocument version is reported as 0, override with nil so that
--- the client doesn't think the document is newer and refuses to update
--- See: https://github.com/eclipse/eclipse.jdt.ls/issues/1695
-local function fix_zero_version(workspace_edit)
-  if workspace_edit and workspace_edit.documentChanges then
-    for _, change in pairs(workspace_edit.documentChanges) do
-      local text_document = change.textDocument
-      if text_document and text_document.version and text_document.version == 0 then
-        text_document.version = nil
-      end
-    end
-  end
-  return workspace_edit
-end
-
-local function on_textdocument_codeaction(err, actions, ctx)
-  for _, action in ipairs(actions) do
-    -- TODO: (steelsojka) Handle more than one edit?
-    if action.command == 'java.apply.workspaceEdit' then -- 'action' is Command in java format
-      action.edit = fix_zero_version(action.edit or action.arguments[1])
-    elseif type(action.command) == 'table' and action.command.command == 'java.apply.workspaceEdit' then -- 'action' is CodeAction in java format
-      action.edit = fix_zero_version(action.edit or action.command.arguments[1])
-    end
-  end
-
-  handlers[ctx.method](err, actions, ctx)
-end
-
-local function on_textdocument_rename(err, workspace_edit, ctx)
-  handlers[ctx.method](err, fix_zero_version(workspace_edit), ctx)
-end
-
-local function on_workspace_applyedit(err, workspace_edit, ctx)
-  handlers[ctx.method](err, fix_zero_version(workspace_edit), ctx)
-end
-
 ---@type vim.lsp.Config
 return {
   cmd = {
@@ -127,12 +89,5 @@ return {
     workspace = get_jdtls_workspace_dir(),
     jvm_args = {},
     os_config = nil,
-  },
-  handlers = {
-    -- Due to an invalid protocol implementation in the jdtls we have to conform these to be spec compliant.
-    -- https://github.com/eclipse/eclipse.jdt.ls/issues/376
-    ['textDocument/codeAction'] = on_textdocument_codeaction,
-    ['textDocument/rename'] = on_textdocument_rename,
-    ['workspace/applyEdit'] = on_workspace_applyedit,
   },
 }


### PR DESCRIPTION
Remove custom handlers and version fix for WorkspaceEdit, as jdtls now conforms to the LSP spec (eclipse-jdtls/eclipse.jdt.ls#1742)

See eclipse-jdtls/eclipse.jdt.ls#1695 for more background on why the workaround was introduced. The original problem was fixed in the upstream LSP server four years ago: remove the workaround.