### PR TITLE
fix(angularls): look for node_modules in subfolders and find correct path for mason Angular LS

### DIFF
--- a/lsp/angularls.lua
+++ b/lsp/angularls.lua
@@ -57,7 +57,14 @@ local default_angular_core_version = get_angular_core_version()
 --   - typescript
 local ngserver_exe = vim.fn.exepath('ngserver')
 local ngserver_path = #(ngserver_exe or '') > 0 and vim.fs.dirname(vim.uv.fs_realpath(ngserver_exe)) or '?'
-local extension_path = vim.fs.normalize(vim.fs.joinpath(ngserver_path, '../../../'))
+
+local extension_path = ''
+
+if ngserver_path:find('mason', 1, true) then
+  extension_path = vim.fs.joinpath(vim.fn.stdpath('data'), 'mason/packages/angular-language-server/node_modules')
+else
+  extension_path = vim.fs.normalize(vim.fs.joinpath(ngserver_path, '../../../'))
+end
 
 -- angularls will get module by `require.resolve(PROBE_PATH, MODULE_NAME)` of nodejs
 local ts_probe_dirs = vim.iter({ extension_path, default_probe_dir }):join(',')

--- a/lsp/angularls.lua
+++ b/lsp/angularls.lua
@@ -15,7 +15,7 @@
 -- Angular requires a node_modules directory to probe for @angular/language-service and typescript
 -- in order to use your projects configured versions.
 local root_dir = vim.fn.getcwd()
-local node_modules_dir = vim.fs.find('node_modules', { path = root_dir, upward = true })[1]
+local node_modules_dir = vim.fs.find('node_modules', { path = root_dir })[1]
 local project_root = node_modules_dir and vim.fs.dirname(node_modules_dir) or '?'
 
 local function get_probe_dir()


### PR DESCRIPTION
First commit fixes #3859 by removing an option to look for node_modules folder upwards in the dir hierarchy from the root folder.

Second commit fixes uncorrect node_modules path in extension path when the language server is installed via mason and falls back to the current strategy if not.