### PR TITLE
feat(efm): add some default settings

### DIFF
--- a/lsp/efm.lua
+++ b/lsp/efm.lua
@@ -20,6 +20,80 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'efm-langserver' },
+  cmd = { 'efm-langserver', '-q'},
   root_markers = { '.git' },
+  settings = {
+    languages = {
+      cmake = {
+        {
+          formatCommand = "cmake-format -",
+          formatStdin = true
+        },
+        {
+          lintCommand = "cmake-lint",
+          lintFormats = {
+            "%f:%l,%c: %m"
+          }
+        }
+      },
+      json = {
+        {
+          formatCommand = "python3 -m json.tool",
+          formatStdin = true
+        },
+        {
+          lintCommand = "python3 -m json.tool",
+          lintStdin = true,
+          lintIgnoreExitCode = true,
+          lintFormats = {
+            "%m: line %l column %c (char %r)"
+          }
+        }
+      },
+      markdown = {
+        {
+          formatCommand = "pandoc -f markdown -t gfm -sp --tab-stop=2",
+          formatStdin = true
+        }
+      },
+      rst = {
+        {
+          formatCommand = "pandoc -f rst -t rst -s --columns=79",
+          formatStdin = true
+        },
+        {
+          lintCommand = "rstcheck -",
+          lintStdin = true,
+          lintFormats = {
+            "%f:%l: (%tNFO/1) %m",
+            "%f:%l: (%tARNING/2) %m",
+            "%f:%l: (%tRROR/3) %m",
+            "%f:%l: (%tEVERE/4) %m"
+          }
+        }
+      },
+      sh = {
+        {
+          formatCommand = "shfmt",
+          formatStdin = true
+        },
+        {
+          lintCommand = "shellcheck -f gcc -x -",
+          lintStdin = true,
+          lintFormats = {
+            "%f:%l:%c: %trror: %m",
+            "%f:%l:%c: %tarning: %m",
+            "%f:%l:%c: %tote: %m"
+          }
+        }
+      },
+      yaml = {
+        {
+          lintCommand = "yamllint -d '{extends: default, rules: {line-length: disable}}' -f parsable -",
+          lintStdin = true,
+          lintIgnoreExitCode = true
+        }
+      }
+    }
+  }
 }

--- a/lua/lspconfig/configs/efm.lua
+++ b/lua/lspconfig/configs/efm.lua
@@ -30,8 +30,9 @@ of the `FileType` autocommand, and the `filetype` variable used to populate the 
 
 ```lua
 require('lspconfig')['efm'].setup{
-  settings = ..., -- You must populate this according to the EFM readme
-  filetypes = { 'python','cpp','lua' }
+  settings = ..., -- You should populate this according to the EFM readme
+                  -- defaults for the filetypes listed below are provided
+  filetypes = {'cmake', 'json', 'markdown', 'rst', 'sh', 'yaml'}
 }
 ```
 


### PR DESCRIPTION
The user still needs to enable them by setting the filetpyes.
Also make efm less noisy by passing -q.