### PR TITLE
fix(stylua): set cmd_cwd to root_dir for config lookup

### DIFF
--- a/lsp/stylua.lua
+++ b/lsp/stylua.lua
@@ -7,6 +7,11 @@
 ---@type vim.lsp.Config
 return {
   cmd = { 'stylua', '--lsp' },
+  -- server looks for configuration in CWD only, does not use rootUri
+  reuse_client = function(client, config)
+    config.cmd_cwd = config.root_dir
+    return client.config.cmd_cwd == config.cmd_cwd
+  end,
   filetypes = { 'lua' },
   root_markers = { '.stylua.toml', 'stylua.toml' },
 }


### PR DESCRIPTION
PROBLEM

Stylua LSP server does not make use of rootUri in any way. If nvim is launched from a directory where cwd != rootDir, stylua will apply the incorrect configuration (internal defaults), and reformat code with an unexpected style.

SOLUTION

Set the cmd_cwd via reuse_client(), similar to ast_grep. See #3850 for more details.