### PR TITLE
fix(leanls): migrate to vim.lsp.config

### DIFF
--- a/lsp/leanls.lua
+++ b/lsp/leanls.lua
@@ -1,0 +1,45 @@
+---@brief
+--- https://github.com/leanprover/lean4
+---
+--- Lean installation instructions can be found
+--- [here](https://leanprover-community.github.io/get_started.html#regular-install).
+---
+--- The Lean language server is included in any Lean installation and
+--- does not require any additional packages.
+---
+--- Note: that if you're using [lean.nvim](https://github.com/Julian/lean.nvim),
+--- that plugin fully handles the setup of the Lean language server,
+--- and you shouldn't set up `leanls` both with it and `lspconfig`.
+
+---@type vim.lsp.Config
+return {
+  cmd = function(dispatchers, config)
+    local local_cmd = { 'lake', 'serve', '--', config.root_dir }
+    return vim.lsp.rpc.start(local_cmd, dispatchers)
+  end,
+  filetypes = { 'lean' },
+  root_dir = function(bufnr, on_dir)
+    local fname = vim.api.nvim_buf_get_name(bufnr)
+    fname = vim.fs.normalize(fname)
+    -- check if inside lean stdlib
+    local stdlib_dir
+    do
+      local _, endpos = fname:find '/lean/library'
+      if endpos then
+        stdlib_dir = fname:sub(1, endpos)
+      end
+    end
+    if not stdlib_dir then
+      local _, endpos = fname:find '/lib/lean'
+      if endpos then
+        stdlib_dir = fname:sub(1, endpos)
+      end
+    end
+
+    on_dir(
+      vim.fs.root(fname, { 'lakefile.toml', 'lakefile.lean', 'lean-toolchain' })
+        or stdlib_dir
+        or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+    )
+  end,
+}


### PR DESCRIPTION
I have no experience with the lspconfigs, but I saw that the `leanls.lua` was the only one missing in `lsp/` compared to `lua/lspconfig/configs/`. I simply copied the old settings and migrated them.
This is related to the Issue [427](https://github.com/Julian/lean.nvim/issues/427) the lean.nvim repo. I will also write a PR that changes the use of the old `require('lspconfig').leanls` to `vim.lsp.enable` and `vim.lsp.config` but this will only work once the `leanls.lua` is in `lsp/`
I tested this PR with an updated `lean.nvim` plugin already using `vim.lsp.enable` and `vim.lsp.congig` and it seems to work.