### PR TITLE
Adjust jdtls root_marker list.

### DIFF
--- a/lsp/jdtls.lua
+++ b/lsp/jdtls.lua
@@ -76,7 +76,6 @@ return {
   filetypes = { 'java' },
   root_markers = {
     -- Multi-module projects
-    '.git',
     'build.gradle',
     'build.gradle.kts',
     -- Single-module projects
@@ -84,6 +83,7 @@ return {
     'pom.xml', -- Maven
     'settings.gradle', -- Gradle
     'settings.gradle.kts', -- Gradle
+    '.git'
   },
   init_options = {
     workspace = get_jdtls_workspace_dir(),


### PR DESCRIPTION
Alter the order for '.git' so it becomes a catch all rather than an identifier for an explicit type of java project. Appending '.git' to the marker list will alleviate root identification problems where the java project directory is a subdirectory of the directory containing the '.git' marker.