### PR TITLE
fix(utils): use fs_realpath to normalize paths in root_dir detection

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -41,7 +41,7 @@ function M.root_pattern(...)
       end)
 
       if match ~= nil then
-        local real = vim.loop.fs_realpath(match)
+        local real = vim.uv.fs_realpath(match)
         return real or match -- fallback to original if realpath fails
       end
     end


### PR DESCRIPTION
The path returned by `root_pattern` is based on the input which is, in many cases at least, `vim.api.nvim_buf_get_name(bufnr)` which can contain casing discrepancies depending (opening a buffer from snacks.picker vs netrw on windows as an example).

This PR ensures that the path returned by `root_pattern` is normalised using `fs_realpath` which provides consistent casing and structure as well as confirming that the path exists. Fallback to return match as it was previously. 