### PR TITLE
fix(stylua): include EditorConfig as a possible root marker

### DIFF
--- a/lsp/stylua.lua
+++ b/lsp/stylua.lua
@@ -8,5 +8,5 @@
 return {
   cmd = { 'stylua', '--lsp' },
   filetypes = { 'lua' },
-  root_markers = { '.stylua.toml', 'stylua.toml' },
+  root_markers = { '.stylua.toml', 'stylua.toml', '.editorconfig' },
 }


### PR DESCRIPTION
Documented here as a possible place to load configuration from:

https://github.com/JohnnyMorganz/StyLua#finding-the-configuration
