### PR TITLE
feat(lsp/ocamllsp.lua): use root_markers instead of root_dir

### DIFF
--- a/lsp/ocamllsp.lua
+++ b/lsp/ocamllsp.lua
@@ -9,8 +9,6 @@
 --- opam install ocaml-lsp-server
 --- ```
 
-local util = require 'lspconfig.util'
-
 local language_id_of = {
   menhir = 'ocaml.menhir',
   ocaml = 'ocaml',
@@ -20,17 +18,31 @@ local language_id_of = {
   dune = 'dune',
 }
 
-local get_language_id = function(_, ftype)
-  return language_id_of[ftype]
+local language_id_of_ext = {
+  mll = language_id_of.ocamllex,
+  mly = language_id_of.menhir,
+  mli = language_id_of.ocamlinterface,
+}
+
+local get_language_id = function(bufnr, ftype)
+  if ftype == 'ocaml' then
+    local path = vim.api.nvim_buf_get_name(bufnr)
+    local ext = vim.fn.fnamemodify(path, ':e')
+    return language_id_of_ext[ext] or language_id_of.ocaml
+  else
+    return language_id_of[ftype]
+  end
 end
+
+local root_markers1 = { 'dune-project', 'dune-workspace' }
+local root_markers2 = { '*.opam', 'opam', 'esy.json', 'package.json' }
+local root_markers3 = { '.git' }
 
 ---@type vim.lsp.Config
 return {
   cmd = { 'ocamllsp' },
   filetypes = { 'ocaml', 'menhir', 'ocamlinterface', 'ocamllex', 'reason', 'dune' },
-  root_dir = function(bufnr, on_dir)
-    local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('*.opam', 'esy.json', 'package.json', '.git', 'dune-project', 'dune-workspace')(fname))
-  end,
+  root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers1, root_markers2, root_markers3 }
+    or vim.list_extend(vim.list_extend(root_markers1, root_markers2), root_markers3),
   get_language_id = get_language_id,
 }


### PR DESCRIPTION
This drops the dependency on `lspconfig.util`, which appears deprecated.

This also makes it possible to use just the config file without the rest of the framework.

The root pattern grouping and prioritisation follows the one proposed here: https://github.com/ocaml/ocaml.org/pull/3322/files#diff-6721080d4f565e09348cab4e8fe6d6393b9e4449bf9c7e2b3f054a0b986809d6R224

Tested with NeoVim v0.11.4