### PR TITLE
fix(ruby_lsp): set cmd_cwd to root_dir

### DIFF
--- a/lsp/ruby_lsp.lua
+++ b/lsp/ruby_lsp.lua
@@ -20,4 +20,8 @@ return {
   init_options = {
     formatter = 'auto',
   },
+  reuse_client = function(client, config)
+    config.cmd_cwd = config.root_dir
+    return client.config.cmd_cwd == config.cmd_cwd
+  end,
 }


### PR DESCRIPTION
Problem:

When running from a directory other than root (i.e monorepo), ruby-lsp does not load correctly. Unsure why, [previous lspconfig](https://github.com/neovim/nvim-lspconfig/blob/33d351cbcc2b12b8e12078515829d042863743a9/lua/lspconfig/manager.lua#L119) had cmd_cwd set to the same as root_dir.

Solution:

Set the cmd_cwd via reuse_client(), similar to ast_grep. See #3850, #4082 for more details.

Tested both from root_dir and monorepo multi-root.