### PR TITLE
fix(jdtls): increase priority of .git marker and add mvnw and gradlew

### DIFF
--- a/lsp/jdtls.lua
+++ b/lsp/jdtls.lua
@@ -65,16 +65,22 @@ end
 
 local root_markers1 = {
   -- Multi-module projects
+  'mvnw',
+  'gradlew',
   'build.gradle',
   'build.gradle.kts',
+  -- Use git directory as last resort for multi-module maven projects
+  -- In multi-module maven projects it is not really possible to determine what is the parent directory
+  -- and what is submodule directory. And jdtls do not breaks if the parent directory is at higher level than
+  -- actual parent pom.xml so propagating all the way to root git directory is fine
+  '.git',
+}
+local root_markers2 = {
   -- Single-module projects
   'build.xml', -- Ant
   'pom.xml', -- Maven
   'settings.gradle', -- Gradle
   'settings.gradle.kts', -- Gradle
-}
-local root_markers2 = {
-  '.git',
 }
 
 ---@type vim.lsp.Config

--- a/lsp/jdtls.lua
+++ b/lsp/jdtls.lua
@@ -71,7 +71,7 @@ local root_markers1 = {
   'build.gradle.kts',
   -- Use git directory as last resort for multi-module maven projects
   -- In multi-module maven projects it is not really possible to determine what is the parent directory
-  -- and what is submodule directory. And jdtls do not breaks if the parent directory is at higher level than
+  -- and what is submodule directory. And jdtls does not break if the parent directory is at higher level than
   -- actual parent pom.xml so propagating all the way to root git directory is fine
   '.git',
 }


### PR DESCRIPTION
Using git directory as last resort before defaulting to pom.xml is important for multi module maven projects. Example of structure:

pom.xml
submodule-a/pom.xml
submodule-b/pom.xml

If sumbodule-b depends on submodule-a (common pattern for dto/impl), the parent usually has info about linking the 2 projects (and without that go to definition etc will jump to compiled source that might not be present/up t date).

This structure is also fine and do not breaks jdtls:

my-project/pom.xml

e.g its fine if working directory is git repo root (and this pattern is also much less common than multi module maven projects that without this change break always).

Closes #4102