### PR TITLE
chore(jdtls): use config.root_dir instead of config.root_markers

### DIFF
--- a/lsp/jdtls.lua
+++ b/lsp/jdtls.lua
@@ -73,16 +73,13 @@ local root_markers2 = {
 ---@type vim.lsp.Config
 return {
   ---@param dispatchers? vim.lsp.rpc.Dispatchers
-  ---@param config vim.lsp.Config
+  ---@param config vim.lsp.ClientConfig
   cmd = function(dispatchers, config)
     local workspace_dir = get_jdtls_workspace_dir()
     local data_dir = workspace_dir
 
-    if config.root_markers then
-      local root_dir = vim.fs.root(0, config.root_markers)
-      if root_dir then
-        data_dir = data_dir .. '/' .. vim.fn.fnamemodify(root_dir, ':p:h:t')
-      end
+    if config.root_dir then
+      data_dir = data_dir .. '/' .. vim.fn.fnamemodify(config.root_dir, ':p:h:t')
     end
 
     local config_cmd = {


### PR DESCRIPTION
The root dir is already pre-resolved when the config is being passed (when changing the code originally i looked and used wrong config type so i missed this). So use the pre-resolved value instead of resolving it again.