### PR TITLE
feat(ty): add a few more appropriate root markers

### DIFF
--- a/lsp/ty.lua
+++ b/lsp/ty.lua
@@ -10,5 +10,5 @@
 return {
   cmd = { 'ty', 'server' },
   filetypes = { 'python' },
-  root_markers = { 'ty.toml', 'pyproject.toml', '.git' },
+  root_markers = { 'ty.toml', 'pyproject.toml', 'setup.py', 'setup.cfg', 'requirements.txt', '.git' },
 }


### PR DESCRIPTION
Issue: `ty` by default only comes with a few `root_markers` that are set. Using `ty` with older python projects that still use `setup.{py,cfg}` causes the LSP to be initialized with incorrect roots.

Fix: Add a few `root_markers` to support legacy python projects.