### PR TITLE
docs(neocmake): update GitHub repository URL

### DIFF
--- a/lsp/neocmake.lua
+++ b/lsp/neocmake.lua
@@ -1,6 +1,6 @@
 ---@brief
 ---
---- https://github.com/Decodetalkers/neocmakelsp
+--- https://github.com/neocmakelsp/neocmakelsp
 ---
 --- CMake LSP Implementation
 ---

--- a/lua/lspconfig/configs/neocmake.lua
+++ b/lua/lspconfig/configs/neocmake.lua
@@ -11,7 +11,7 @@ return {
   },
   docs = {
     description = [[
-https://github.com/neocmakelsp/neocmakelsp
+https://github.com/Decodetalkers/neocmakelsp
 
 CMake LSP Implementation
 

--- a/lua/lspconfig/configs/neocmake.lua
+++ b/lua/lspconfig/configs/neocmake.lua
@@ -11,7 +11,7 @@ return {
   },
   docs = {
     description = [[
-https://github.com/Decodetalkers/neocmakelsp
+https://github.com/neocmakelsp/neocmakelsp
 
 CMake LSP Implementation
 


### PR DESCRIPTION
The GitHub repository has changed owners. The old URL redirects to the new repository but updating it makes it clearer which project is referenced by the documentation.