### PR TITLE
feat(ocamllsp): `:LspOcamllspSwitchImplIntf` command

### DIFF
--- a/lsp/ocamllsp.lua
+++ b/lsp/ocamllsp.lua
@@ -9,6 +9,41 @@
 --- opam install ocaml-lsp-server
 --- ```
 
+-- https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/docs/ocamllsp/switchImplIntf-spec.md
+local function switch_impl_intf(bufnr, client)
+  local method_name = 'ocamllsp/switchImplIntf'
+  ---@diagnostic disable-next-line:param-type-mismatch
+  if not client or not client:supports_method(method_name) then
+    return vim.notify(('method %s is not supported by any servers active on the current buffer'):format(method_name))
+  end
+  local uri = vim.lsp.util.make_given_range_params(nil, nil, bufnr, client.offset_encoding).textDocument.uri
+  if not uri then
+    return vim.notify('could not get URI for current buffer')
+  end
+  local params = { uri }
+  ---@diagnostic disable-next-line:param-type-mismatch
+  client:request(method_name, params, function(err, result)
+    if err then
+      error(tostring(err))
+    end
+    if not result or #result == 0 then
+      vim.notify('corresponding file cannot be determined')
+    elseif #result == 1 then
+      vim.cmd.edit(vim.uri_to_fname(result[1]))
+    else
+      vim.ui.select(
+        result,
+        { prompt = 'Select an implementation/interface:', format_item = vim.uri_to_fname },
+        function(choice)
+          if choice then
+            vim.cmd.edit(vim.uri_to_fname(choice))
+          end
+        end
+      )
+    end
+  end, bufnr)
+end
+
 local language_id_of = {
   menhir = 'ocaml.menhir',
   ocaml = 'ocaml',
@@ -45,4 +80,9 @@ return {
   root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers1, root_markers2, root_markers3 }
     or vim.list_extend(vim.list_extend(root_markers1, root_markers2), root_markers3),
   get_language_id = get_language_id,
+  on_attach = function(client, bufnr)
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspOcamllspSwitchImplIntf', function()
+      switch_impl_intf(bufnr, client)
+    end, { desc = 'Switch between implementation/interface' })
+  end,
 }


### PR DESCRIPTION
Change based on [lsp/clangd.lua](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/clangd.lua), and capability documented here: https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/docs/ocamllsp/switchImplIntf-spec.md.

The capability is enabled by default so no config change is needed.