### PR TITLE
fix(css_variables): update root directory

### DIFF
--- a/lsp/css_variables.lua
+++ b/lsp/css_variables.lua
@@ -14,7 +14,19 @@
 return {
   cmd = { 'css-variables-language-server', '--stdio' },
   filetypes = { 'css', 'scss', 'less' },
-  root_markers = { 'package.json', '.git' },
+
+  -- Taken from lsp/ts_ls.lua to handle simple projects and monorepos.
+  root_dir = function(bufnr, on_dir)
+    local root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
+    -- Give the root markers equal priority by wrapping them in a table
+    root_markers = vim.fn.has 'nvim-0.11.3' == 1 and { root_markers, { '.git' } }
+      or vim.list_extend(root_markers, { '.git' })
+    -- We fallback to the current working directory if no project root is found
+    local project_root = vim.fs.root(bufnr, root_markers) or vim.fn.getcwd()
+
+    on_dir(project_root)
+  end,
+
   -- Same as inlined defaults that don't seem to work without hardcoding them in the lua config
   -- https://github.com/vunguyentuan/vscode-css-variables/blob/763a564df763f17aceb5f3d6070e0b444a2f47ff/packages/css-variables-language-server/src/CSSVariableManager.ts#L31-L50
   settings = {


### PR DESCRIPTION
### Problem
Root directory is incorrect for projects containing a `package.json` file in subdirectories.

For a project with a given file structure:

```
my-monorepo/
├── package.json
├── yarn.lock
├── css/
│   └── css-variables/
│       ├── color.css
│       └── typography.css
└── components/
    └── core/
        └── my-feature/
            ├── package.json           ← 2. causes LSP root to stop here
            ├── feature-component-a/
            │   └── feature-component-a.module.css           ← 1. current open buffer 
            └── feature-component-b/
                └── feature-component-b.module.css

```

The LSP is using `my-feature` as the root directory. This directory is not the one where the css variables are defined. It leads to an issue where the css variables are not indexed, and from `feature-component-a.module.css` auto-completion and jump to definition are not working.

### Solution

Using the same `root_dir` logic as `ts_ls` (which prefers lockfiles like yarn.lock or .git as root markers) correctly sets the project root to `my-monorepo/`, allowing `css/css-variables/` to be discoverable for the LSP.
