### PR TITLE
fix: exclude deno from biome/eslint/ts_ls/tsgo/vtsls

### DIFF
--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -48,6 +48,12 @@ return {
     -- Give the root markers equal priority by wrapping them in a table
     root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers, { '.git' } }
       or vim.list_extend(root_markers, { '.git' })
+
+    -- exclude deno
+    if vim.fs.root(bufnr, { 'deno.json', 'deno.lock' }) then
+      return
+    end
+
     -- We fallback to the current working directory if no project root is found
     local project_root = vim.fs.root(bufnr, root_markers) or vim.fn.getcwd()
 

--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -95,6 +95,12 @@ return {
     -- Give the root markers equal priority by wrapping them in a table
     root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers, { '.git' } }
       or vim.list_extend(root_markers, { '.git' })
+
+    -- exclude deno
+    if vim.fs.root(bufnr, { 'deno.json', 'deno.lock' }) then
+      return
+    end
+
     -- We fallback to the current working directory if no project root is found
     local project_root = vim.fs.root(bufnr, root_markers) or vim.fn.getcwd()
 

--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -62,6 +62,12 @@ return {
     -- Give the root markers equal priority by wrapping them in a table
     root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers, { '.git' } }
       or vim.list_extend(root_markers, { '.git' })
+
+    -- exclude deno
+    if vim.fs.root(bufnr, { 'deno.json', 'deno.lock' }) then
+      return
+    end
+
     -- We fallback to the current working directory if no project root is found
     local project_root = vim.fs.root(bufnr, root_markers) or vim.fn.getcwd()
 

--- a/lsp/tsgo.lua
+++ b/lsp/tsgo.lua
@@ -34,6 +34,12 @@ return {
     -- Give the root markers equal priority by wrapping them in a table
     root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers, { '.git' } }
       or vim.list_extend(root_markers, { '.git' })
+
+    -- exclude deno
+    if vim.fs.root(bufnr, { 'deno.json', 'deno.lock' }) then
+      return
+    end
+
     -- We fallback to the current working directory if no project root is found
     local project_root = vim.fs.root(bufnr, root_markers) or vim.fn.getcwd()
 

--- a/lsp/vtsls.lua
+++ b/lsp/vtsls.lua
@@ -88,6 +88,12 @@ return {
     -- Give the root markers equal priority by wrapping them in a table
     root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers, { '.git' } }
       or vim.list_extend(root_markers, { '.git' })
+
+    -- exclude deno
+    if vim.fs.root(bufnr, { 'deno.json', 'deno.lock' }) then
+      return
+    end
+
     -- We fallback to the current working directory if no project root is found
     local project_root = vim.fs.root(bufnr, root_markers) or vim.fn.getcwd()
 


### PR DESCRIPTION
Close https://github.com/neovim/nvim-lspconfig/issues/4129

Since cwd is a necessity for many JavaScript project (see discussions in https://github.com/neovim/nvim-lspconfig/issues/4015), this fix takes an alternative approach to manually exclude Deno projects from biome/eslint/ts_ls/tsgo/vtsls 's `root_dir` detection logic. There is no need to change svelte since it has a different filetype.