### PR TITLE
fix(ruby_lsp): prevent duplicate clients on second buffer

### DIFF
--- a/lsp/ruby_lsp.lua
+++ b/lsp/ruby_lsp.lua
@@ -20,8 +20,7 @@ return {
   init_options = {
     formatter = 'auto',
   },
-  reuse_client = function(client, config)
+  before_init = function(_, config)
     config.cmd_cwd = config.root_dir
-    return client.config.cmd_cwd == config.cmd_cwd
   end,
 }


### PR DESCRIPTION
Problem: When opening multiple Ruby buffers, a second LSP client is spawned instead of reusing the first client, even though they share the same root directory.

Root cause: The `reuse_client` function sets `cmd_cwd` as a side effect during reuse checks. This means the first client is created without `cmd_cwd` set, causing the reuse check to fail for the second buffer.

Solution: Use `before_init` to ensure `cmd_cwd` is set for every client before initialization. Remove the custom `reuse_client` function to use Neovim's default reuse logic (compare name + root_dir).

Testing: Tested with Neovim 0.11.4 by opening 3 Ruby files. All buffers now correctly reuse the first client.

Note: `lsp/ast_grep.lua` has the identical pattern and likely has the same issue.