### PR TITLE
fix(buf_ls): update serve command for buf > v1.59.0

### DIFF
--- a/lsp/buf_ls.lua
+++ b/lsp/buf_ls.lua
@@ -7,7 +7,7 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'buf', 'beta', 'lsp', '--timeout=0', '--log-format=text' },
+  cmd = { 'buf', 'lsp', 'serve', '--timeout=0', '--log-format=text' },
   filetypes = { 'proto' },
   root_markers = { 'buf.yaml', '.git' },
 }


### PR DESCRIPTION
This updates the buf_ls command post [v1.59.0](https://github.com/bufbuild/buf/releases/tag/v1.59.0), where the command was promoted out of beta to general availability. The command was changed from `buf beta lsp` to `buf lsp serve`.