### PR TITLE
feat: resupport force stop language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Most of the time, the reason for failure is present in the logs.
 
 * `:LspInfo` (alias to `:checkhealth vim.lsp`) shows the status of active and configured language servers.
 * `:LspStart <config_name>` Start the requested server name. Will only successfully start if the command detects a root directory matching the current config.
-* `:LspStop [<client_id_or_name>]` Stops the given server. Defaults to stopping all servers active on the current buffer.
+* `:LspStop [<client_id_or_name>]` Stops the given server. Defaults to stopping all servers active on the current buffer. To force stop use `:LspStop!`
 * `:LspRestart [<client_id_or_name>]` Restarts the given client, and attempts to reattach to all previously attached buffers. Defaults to restarting all active servers.
 
 ## Contributions

--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -87,12 +87,15 @@ the current buffer filetype.
 
 :LspStop [client_id] or [config_name]                            *:LspStop*
 Stops the server with the given client-id or config name. Defaults to
-stopping all servers active on the current buffer.
+stopping all servers active on the current buffer. To force stop language
+servers: >vim
+    :LspStop!
 
 :LspRestart [client_id] or [config_name]                         *:LspRestart*
 Restarts the client with the given client-id or config name, and attempts
 to reattach to all previously attached buffers. Defaults to restarting all
-active servers.
+active servers. To force stop language servers when restarting: >vim
+    :LspRestart!
 
 ==============================================================================
 SERVER CONFIGS                                        *lspconfig-configurations*

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -128,33 +128,31 @@ if vim.fn.has('nvim-0.11.2') == 1 then
 
     -- Default to restarting all active servers
     if #clients == 0 then
-      clients = vim
-        .iter(vim.lsp.get_clients())
-        :map(function(client)
-          return client.name
-        end)
-        :totable()
+      clients = vim.lsp.get_clients()
     end
 
-    for _, name in ipairs(clients) do
+    for client in vim.iter(clients) do
+      local name = client.name
       if vim.lsp.config[name] == nil then
         vim.notify(("Invalid server name '%s'"):format(name))
       else
         vim.lsp.enable(name, false)
+        if info.bang then
+          client:stop(true)
+        end
       end
     end
 
     local timer = assert(vim.uv.new_timer())
     timer:start(500, 0, function()
-      for _, name in ipairs(clients) do
-        vim.schedule_wrap(function(x)
-          vim.lsp.enable(x)
-        end)(name)
+      for client in vim.iter(clients) do
+        vim.schedule_wrap(vim.lsp.enable)(client.name)
       end
     end)
   end, {
     desc = 'Restart the given client',
     nargs = '?',
+    bang = true,
     complete = complete_client,
   })
 
@@ -163,24 +161,24 @@ if vim.fn.has('nvim-0.11.2') == 1 then
 
     -- Default to disabling all servers on current buffer
     if #clients == 0 then
-      clients = vim
-        .iter(vim.lsp.get_clients({ bufnr = vim.api.nvim_get_current_buf() }))
-        :map(function(client)
-          return client.name
-        end)
-        :totable()
+      clients = vim.lsp.get_clients({ bufnr = vim.api.nvim_get_current_buf() })
     end
 
-    for _, name in ipairs(clients) do
+    for client in vim.iter(clients) do
+      local name = client.name
       if vim.lsp.config[name] == nil then
         vim.notify(("Invalid server name '%s'"):format(name))
       else
         vim.lsp.enable(name, false)
+        if info.bang then
+          client:stop(true)
+        end
       end
     end
   end, {
     desc = 'Disable and stop the given client',
     nargs = '?',
+    bang = true,
     complete = complete_client,
   })
 


### PR DESCRIPTION
Reintroduces behavior added in #2294. See #4136 for discussion.

Differences from the old implementation:
- Uses `:LspStop!` instead of `:LspStop ++force`. If this is an undesirable change, I can implement it the original way.
- Supports the same behavior for `:LspRestart`.