### PR TITLE
fix(jdtls): swap settings.gradle and build.gradle in root markers

### DIFF
--- a/lsp/jdtls.lua
+++ b/lsp/jdtls.lua
@@ -52,10 +52,10 @@ end
 
 local root_markers1 = {
   -- Multi-module projects
-  'mvnw',
-  'gradlew',
-  'build.gradle',
-  'build.gradle.kts',
+  'mvnw', -- Maven
+  'gradlew', -- Gradle
+  'settings.gradle', -- Gradle
+  'settings.gradle.kts', -- Gradle
   -- Use git directory as last resort for multi-module maven projects
   -- In multi-module maven projects it is not really possible to determine what is the parent directory
   -- and what is submodule directory. And jdtls does not break if the parent directory is at higher level than
@@ -66,8 +66,8 @@ local root_markers2 = {
   -- Single-module projects
   'build.xml', -- Ant
   'pom.xml', -- Maven
-  'settings.gradle', -- Gradle
-  'settings.gradle.kts', -- Gradle
+  'build.gradle', -- Gradle
+  'build.gradle.kts', -- Gradle
 }
 
 ---@type vim.lsp.Config


### PR DESCRIPTION
settings.gradle is marker for multi-module Gradle projects.

See: https://docs.gradle.org/current/userguide/multi_project_builds.html
Closes: #4137