### PR TITLE
Add 'terraform' to supported filetypes

### DIFF
--- a/lsp/tofu_ls.lua
+++ b/lsp/tofu_ls.lua
@@ -6,6 +6,6 @@
 ---@type vim.lsp.Config
 return {
   cmd = { 'tofu-ls', 'serve' },
-  filetypes = { 'opentofu', 'opentofu-vars' },
+  filetypes = { 'opentofu', 'opentofu-vars', 'terraform' },
   root_markers = { '.terraform', '.git' },
 }


### PR DESCRIPTION
Does it make sense to specify "terraform" as filetype when using tofu_ls? By default .tf files get identified as "terraform", even if they are opentofu.