### PR TITLE
fix(julials): Update julials to accomodate julia 1.12

### DIFF
--- a/lsp/julials.lua
+++ b/lsp/julials.lua
@@ -2,12 +2,12 @@
 ---
 --- https://github.com/julia-vscode/julia-vscode
 ---
---- LanguageServer.jl can be installed with `julia` and `Pkg`:
+--- LanguageServer.jl, SymbolServer.jl and StaticLint.jl can be installed with `julia` and `Pkg`:
 --- ```sh
 --- julia --project=~/.julia/environments/nvim-lspconfig -e 'using Pkg; Pkg.add("LanguageServer#main"); Pkg.add("SymbolServer#master"); Pkg.add("StaticLint#master")'
 --- ```
 --- where `~/.julia/environments/nvim-lspconfig` is the location where
---- the default configuration expects LanguageServer.jl to be installed.
+--- the default configuration expects LanguageServer.jl, SymbolServer.jl and StaticLint.jl to be installed.
 ---
 --- To update an existing install, use the following command:
 --- ```sh


### PR DESCRIPTION
According to https://github.com/julia-vscode/LanguageServer.jl/issues/1366, we need SymbolServer and StaticLint on the latest commits. I got it to work locally with each of them on their latest commits. Thought this might help others. 

Although it might be good to wait for the appropriate releases. At least until then this might help someone find the right info.