### PR TITLE
chore(postgres_lsp): accomodate renaming

### DIFF
--- a/lsp/postgres_lsp.lua
+++ b/lsp/postgres_lsp.lua
@@ -1,14 +1,14 @@
 ---@brief
 ---
---- https://pgtools.dev
+--- https://pg-language-server.com
 ---
 --- A collection of language tools and a Language Server Protocol (LSP) implementation for Postgres, focusing on developer experience and reliable SQL tooling.
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'postgrestools', 'lsp-proxy' },
+  cmd = { 'postgres-language-server', 'lsp-proxy' },
   filetypes = {
     'sql',
   },
-  root_markers = { 'postgrestools.jsonc' },
+  root_markers = { 'postgres-language-server.jsonc' },
 }


### PR DESCRIPTION
Starting with `0.16.0`, we are (finally) renaming the project to `postgres-language-server`. This PR updates the lsp config to use the new name. We are dual-publishing for a while to not break the users workflow, so no hurry.

Release Notes: https://github.com/supabase-community/postgres-language-server/releases/tag/0.16.0

