### PR TITLE
feat(tinymist): add pinMain command for tinymist

### DIFF
--- a/lsp/tinymist.lua
+++ b/lsp/tinymist.lua
@@ -17,10 +17,7 @@
 local function create_tinymist_command(command_name, client, bufnr)
   local export_type = command_name:match 'tinymist%.export(%w+)'
   local info_type = command_name:match 'tinymist%.(%w+)'
-  if info_type and info_type:match '^get' then
-    info_type = info_type:gsub('^get', 'Get')
-  end
-  local cmd_display = export_type or info_type
+  local cmd_display = export_type or info_type:gsub('^get', 'Get'):gsub('^pin', 'Pin')
   ---@return nil
   local function run_tinymist_command()
     local arguments = { vim.api.nvim_buf_get_name(bufnr) }
@@ -64,6 +61,7 @@ return {
       'tinymist.getDocumentTrace',
       'tinymist.getWorkspaceLabels',
       'tinymist.getDocumentMetrics',
+      'tinymist.pinMain',
     } do
       local cmd_func, cmd_name, cmd_desc = create_tinymist_command(command, client, bufnr)
       vim.api.nvim_buf_create_user_command(bufnr, 'Lsp' .. cmd_name, cmd_func, { nargs = 0, desc = cmd_desc })


### PR DESCRIPTION
This LSP command is very useful for typst project split across multiple files. It allows pinning the main file to allow cross-references in included files to work properly.

Basically allows fixing https://forum.typst.app/t/how-can-i-make-label-references-work-across-multiple-files-with-neovim-tinymist/2275 . 

Related: https://github.com/Myriad-Dreamin/tinymist/issues/321#issuecomment-2485941136