### PR TITLE
fix(termux_language_server): replace broken `filetypes` field

### DIFF
--- a/lsp/termux_language_server.lua
+++ b/lsp/termux_language_server.lua
@@ -4,9 +4,28 @@
 ---
 --- Language server for various bash scripts such as Arch PKGBUILD, Gentoo ebuild, Termux build.sh, etc.
 
+local util = require('lspconfig').util
+
 ---@type vim.lsp.Config
 return {
   cmd = { 'termux-language-server' },
-  filetypes = { 'PKGBUILD' },
-  root_markers = { '.git' },
+  root_dir = function(bufnr, on_dir)
+    local patterns = {
+      -- Termux
+      'build.sh',
+      '*.subpackage.sh',
+      -- Arch/MSYS2
+      'PKGBUILD',
+      'makepkg.conf',
+      '*.install',
+      -- Gentoo
+      'make.conf',
+      'color.map',
+      '*.ebuild',
+      '*.eclass',
+    }
+    local fname = vim.api.nvim_buf_get_name(bufnr)
+    local match = util.root_pattern(patterns)(fname)
+    on_dir(match and (vim.fs.root(match, '.git') or match))
+  end,
 }


### PR DESCRIPTION
- This PR is a follow up to https://github.com/neovim/nvim-lspconfig/pull/3947#issuecomment-3453964022

When `termux_language_server` replaced `‎pkgbuild_language_server` it's `filetypes` field of `'PKGBUILD'` was copied over verbatim.
Since no such filetype exists in Neovim by default the LSP never attempts to attach to any buffer when using the default configuration.

To rectify this I have replaced the `filetypes` and `root_markers` fields with a `root_dir` function.
The file patterns it matches are taken from the upstream suggested setup.
https://termux-language-server.readthedocs.io/en/latest/resources/configure.html#neovim

##### This is my first time contributing to this repository, if I have made any procedural errors, or this fix requires some further changes please let me know so I can correct them.