### PR TITLE
feat(csharp_ls): runs csharp-ls where sln, slnx or csproj file exists

### DIFF
--- a/lsp/csharp_ls.lua
+++ b/lsp/csharp_ls.lua
@@ -13,6 +13,14 @@ local util = require 'lspconfig.util'
 ---@type vim.lsp.Config
 return {
   cmd = { 'csharp-ls' },
+  cmd_cwd = vim.fs.root(0, {
+    function(name, _)
+      return name:match '%.slnx?$' ~= nil
+    end,
+    function(name, _)
+      return name:match '%.csproj$' ~= nil
+    end,
+  }),
   root_dir = function(bufnr, on_dir)
     local fname = vim.api.nvim_buf_get_name(bufnr)
     on_dir(util.root_pattern '*.sln'(fname) or util.root_pattern '*.slnx'(fname) or util.root_pattern '*.csproj'(fname))


### PR DESCRIPTION
Currently csharp-language-server starts to find solution file or project file from current directly, and just ignore rootPath and rootUri as metioned in razzmatazz/csharp-language-server#272.

Also, legacy style of configuration[ set cmd_cwd to root_dir](https://github.com/neovim/nvim-lspconfig/blob/2b52bc2190c8efde2e4de02d829a138666774c7c/lua/lspconfig/manager.lua#L118-L120), but not currently.
So, as mentioned in #3849, the server cannot find solution file or project file as the server is launched in cwd not in the directory root_dir find out.

This problem will be solved in future version of language server, but I think it would be better to set cmd_cwd the place same as root_dir, as currently it's one solution for this problem, and in future, it will help users who using old version of server.