### PR TITLE
fix(termux_language_server): do not call `on_dir()` unconditionally

### DIFF
--- a/lsp/termux_language_server.lua
+++ b/lsp/termux_language_server.lua
@@ -26,6 +26,8 @@ return {
     }
     local fname = vim.api.nvim_buf_get_name(bufnr)
     local match = util.root_pattern(patterns)(fname)
-    on_dir(match and (vim.fs.root(match, '.git') or match))
+    if match then
+      on_dir(vim.fs.root(match, '.git') or match)
+    end
   end,
 }


### PR DESCRIPTION
- This PR is a followup to a logic error I inadvertently introduced with #4161.

I should have caught this in testing, but I didn't.
Ironically enough this is the exact opposite problem as before #4161.

It wasn't attaching to any buffers before, now it's attaching to every buffer.