### PR TITLE
fix(csharp_ls): set cwd when lsp starts, not during configuration

### DIFF
--- a/lsp/csharp_ls.lua
+++ b/lsp/csharp_ls.lua
@@ -12,15 +12,15 @@ local util = require 'lspconfig.util'
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'csharp-ls' },
-  cmd_cwd = vim.fs.root(0, {
-    function(name, _)
-      return name:match '%.slnx?$' ~= nil
-    end,
-    function(name, _)
-      return name:match '%.csproj$' ~= nil
-    end,
-  }),
+  cmd = function(dispatchers, config)
+    return vim.lsp.rpc.start({ 'csharp-ls' }, dispatchers, {
+      -- csharp-ls attempt to locate sln, slnx or csproj files from cwd, so set cwd to root directory.
+      -- If cmd_cwd is provided, use it instead.
+      cwd = config.cmd_cwd or config.root_dir,
+      env = config.cmd_env,
+      detached = config.detached,
+    })
+  end,
   root_dir = function(bufnr, on_dir)
     local fname = vim.api.nvim_buf_get_name(bufnr)
     on_dir(util.root_pattern '*.sln'(fname) or util.root_pattern '*.slnx'(fname) or util.root_pattern '*.csproj'(fname))


### PR DESCRIPTION
In #4166 I tried to launch csharp-ls in directory where sln, slnx or csproj file exists, but this implementation cannot properly handle multiple solution: if I open file a.cs in directory a, then open b.cs, the server launches twice as a.cs and b.cs has different root directory, but the cmd_cwd is fixed to ./a therefore these server uses same a.sln file.

```text
.
├── a <- here
│   ├── a.sln
│   └── a.cs
└── b
    ├── b.sln
    └── b.cs
```

Also, I found current implementation cannot launch server in proper directory if neovim is executed outside of the project without opening file, then open a file in project.
I think it's because previously used `vim.fs.root(0, ...)` cannot find sln, slnx and csproj so that returns nil, and it leads cmd_cwd become nil, and finally the server launched in the directory neovim executed.

So, in this PR, I set cwd when lsp starts, not during configuration, so that I can use the directory path which root_dir found.
Now I can open multiple project from anywhere.

@justinmk I believe the issue mentioned in #4166 has been resolved in this PR. However, if there are any overlooked considerations or strange points, please let me know so I can fix them.