### PR TITLE
feat(harper-ls): enable harper-ls for asciidoc

### DIFF
--- a/lsp/harper_ls.lua
+++ b/lsp/harper_ls.lua
@@ -21,6 +21,7 @@
 return {
   cmd = { 'harper-ls', '--stdio' },
   filetypes = {
+    'asciidoc',
     'c',
     'cpp',
     'cs',


### PR DESCRIPTION
Similar to https://github.com/neovim/nvim-lspconfig/pull/4100
It makes sense to enable a grammar language server for asciidoc (a documentation language)