### PR TITLE
feat: add cmd for elixir-ls

### DIFF
--- a/lsp/elixirls.lua
+++ b/lsp/elixirls.lua
@@ -26,6 +26,7 @@
 ---
 --- 'root_dir' is chosen like this: if two or more directories containing `mix.exs` were found when searching directories upward, the second one (higher up) is chosen, with the assumption that it is the root of an umbrella app. Otherwise the directory containing the single mix.exs that was found is chosen.
 return {
+  cmd = { 'elixir-ls' },
   filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
   root_dir = function(bufnr, on_dir)
     local fname = vim.api.nvim_buf_get_name(bufnr)


### PR DESCRIPTION
Upstream distributes this as `language_server.sh` in their [release](https://github.com/elixir-lsp/elixir-ls/releases/download/v0.29.3/elixir-ls-v0.29.3.zip).
In the [AUR](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=elixir-ls#n40), [nixpkgs](https://github.com/NixOS/nixpkgs/blob/7c1cd03aec4cb13be98471376202668eda6019b4/pkgs/development/beam-modules/elixir-ls/default.nix#L44) and [mason-registry](https://github.com/mason-org/mason-registry/blob/cb98d90349580e343fedaf831effe11d7e804c11/packages/elixir-ls/package.yaml#L62) it's distributed as `elixir-ls`.

Does this justify adding it as a default command, or upstream's distribution is preferred, where probably users extract it to an [arbitrary place](https://github.com/neovim/nvim-lspconfig/blob/2010fc6ec03e2da552b4886fceb2f7bc0fc2e9c0/lsp/elixirls.lua#L15-L26)?

This would solve https://github.com/nix-community/nixvim/issues/3909.