### PR TITLE
fix(buf_ls): reuse client across workspaces

### DIFF
--- a/lsp/buf_ls.lua
+++ b/lsp/buf_ls.lua
@@ -11,6 +11,7 @@ return {
   filetypes = { 'proto' },
   root_markers = { 'buf.yaml', '.git' },
   reuse_client = function()
+    -- `buf lsp serve` is meant to be used with multiple workspaces.
     return true
   end,
 }


### PR DESCRIPTION
This updates the buf LSP config to always reuse the client. The `buf lsp serve` is meant to be used with multiple workspaces. This fixes goto definition with cached modules.