### PR TITLE
fix(angularls): add nil check for config parameter

### DIFF
--- a/lsp/angularls.lua
+++ b/lsp/angularls.lua
@@ -66,7 +66,7 @@ end
 ---@type vim.lsp.Config
 return {
   cmd = function(dispatchers, config)
-    local root_dir = config.root or fn.getcwd()
+    local root_dir = (config and config.root) or fn.getcwd()
     local node_paths = collect_node_modules(root_dir)
 
     local ts_probe = table.concat(node_paths, ',')


### PR DESCRIPTION
### Description

Fixes a nil pointer warning in the `angularls` cmd function where the `config` parameter can sometimes be nil.

### Changes

- Added nil check for `config` parameter before accessing `config.root` in `lsp/angularls.lua:69`

### Before

```lua
local root_dir = config.root or fn.getcwd()
```

### After

```lua
local root_dir = (config and config.root) or fn.getcwd()
```

### Testing

- Verified the warning no longer appears when opening TypeScript/HTML files in Angular projects

Closes #4180