### PR TITLE
fix(slangd): slangd.exe not executable error on windows

### DIFF
--- a/lsp/slangd.lua
+++ b/lsp/slangd.lua
@@ -23,15 +23,9 @@
 --- Available options are documented [here](https://github.com/shader-slang/slang-vscode-extension/tree/main?tab=readme-ov-file#configurations)
 --- or in more detail [here](https://github.com/shader-slang/slang-vscode-extension/blob/main/package.json#L70).
 
-local bin_name = 'slangd'
-
-if vim.fn.has 'win32' == 1 then
-  bin_name = 'slangd.exe'
-end
-
 ---@type vim.lsp.Config
 return {
-  cmd = { bin_name },
+  cmd = { 'slangd' },
   filetypes = { 'hlsl', 'shaderslang' },
   root_markers = { '.git' },
 }


### PR DESCRIPTION
## Problem
Neovim not finding slangd when installed via Mason on Windows eventhough running `:!slangd` is fine.
No error if included in PATH

## Solution
Use `slangd` instead of `slangd.exe` even on windows.
This allows Neovim to find slangd when installed via Mason or manually by adding to PATH

## Testing
Neovim: v0.11.5
OS: Fedora 43 and Windows 11 (cmd & git bash)
Tested with slangd installed either via Mason or manually.
Runs fine in both cases.

### Note
I'm a bit *unsure* whether there is an edge case or not.
The if clause is there from the first commit 2 years ago (`/lua/lspconfig/configs`) and I also saw a couple of configs with the same conditional committed around the same time.