### PR TITLE
fix(angularls): replace non-existant config.root with config.root_dir

### DIFF
--- a/lsp/angularls.lua
+++ b/lsp/angularls.lua
@@ -66,7 +66,7 @@ end
 ---@type vim.lsp.Config
 return {
   cmd = function(dispatchers, config)
-    local root_dir = (config and config.root) or fn.getcwd()
+    local root_dir = (config and config.root_dir) or fn.getcwd()
     local node_paths = collect_node_modules(root_dir)
 
     local ts_probe = table.concat(node_paths, ',')


### PR DESCRIPTION
Problem:
`config.root` is not defined in the documentation

Solution
Replace it by `config.root_dir`