### PR TITLE
fix(ts_ls): fix root_dir for Neovim 0.11.5+

### DIFF
--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -59,13 +59,15 @@ return {
     -- We select then from the project root, which is identified by the presence of a package
     -- manager lock file.
     local root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
-    -- Give the root markers equal priority by wrapping them in a table
-    root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers, { '.git' } }
-      or vim.list_extend(root_markers, { '.git' })
+    if vim.fn.has('nvim-0.11') == 1 then
+      root_markers = { root_markers, { '.git' } }
+    else
+      vim.list_extend(root_markers, { '.git' })
+    end
     -- exclude deno
     local deno_path = vim.fs.root(bufnr, { 'deno.json', 'deno.lock' })
-    local project_root = vim.fs.root(bufnr, { root_markers })
-    if deno_path and not project_root or #deno_path >= #project_root then
+    local project_root = vim.fs.root(bufnr, root_markers)
+    if deno_path and (not project_root or #deno_path >= #project_root) then
       return
     end
     -- We fallback to the current working directory if no project root is found


### PR DESCRIPTION
Fix multiple issues in ts_ls root_dir detection:

1. Version check: has('nvim-0.11.3') returns 0 on Neovim 0.11.5 because vim.fn.has() only matches exact versions. Changed to has('nvim-0.11') to properly detect all 0.11.x versions that support nested marker groups in vim.fs.root().

2. Remove extra table wrapping: root_markers is already in the correct format (nested or flat) and shouldn't be wrapped again when passed to vim.fs.root().

3. Fix nil check: Add parentheses to prevent evaluating #deno_path when deno_path is nil.

Fixes errors on Neovim 0.11.5:
  - invalid value (table) at index 2 in table for 'concat'
  - attempt to get length of local 'deno_path' (a nil value)

fix #4196