### PR TITLE
fix(ts_ls): fix ts_ls load when not in a Deno repository

### DIFF
--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -64,8 +64,8 @@ return {
       or vim.list_extend(root_markers, { '.git' })
     -- exclude deno
     local deno_path = vim.fs.root(bufnr, { 'deno.json', 'deno.lock' })
-    local project_root = vim.fs.root(bufnr, { root_markers })
-    if deno_path and not project_root or #deno_path >= #project_root then
+    local project_root = vim.fs.root(bufnr, root_markers)
+    if deno_path and (not project_root or #deno_path >= #project_root) then
       return
     end
     -- We fallback to the current working directory if no project root is found


### PR DESCRIPTION
- Fixes double-wrapping of `root_markers` in a list
- Fixes referencing length of `#deno_path` when `deno_path` is nil

I had this pretty much done when #4197 was submitted, but since it got some blocking feedback I'm submitting mine here in case it helps gets the fix merged more quickly.

fix #4197