### PR TITLE
feat: rumdl 

### DIFF
--- a/lsp/rumdl.lua
+++ b/lsp/rumdl.lua
@@ -1,0 +1,12 @@
+---@brief
+---
+--- https://github.com/rvben/rumdl
+---
+--- Markdown Linter and Formatter written in Rust.
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'rumdl', 'server' },
+  filetypes = { 'markdown' },
+  root_markers = { '.git' },
+}


### PR DESCRIPTION
This PR adds support for the [`rumdl`](https://github.com/rvben/rumdl) language server for Markdown files.

As its MDX support is [questionable](https://github.com/rvben/rumdl/issues/123), the configuration is applied to only pure Markdown files.