### PR TITLE
feat: tclsp

### DIFF
--- a/lsp/tclsp.lua
+++ b/lsp/tclsp.lua
@@ -1,0 +1,22 @@
+---@brief
+---
+--- https://github.com/nmoroze/tclint
+---
+--- `tclsp`, a language server for Tcl
+---
+--- `tclsp` can be installed via `pipx`:
+--- ```sh
+--- pipx install tclint
+--- ```
+---
+--- Or via `pip`:
+--- ```sh
+--- pip install tclint
+--- ```
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'tclsp' },
+  filetypes = { 'tcl', 'sdc', 'xdc', 'upf' },
+  root_markers = { 'tclint.toml', '.tclint', 'pyproject.toml', '.git' },
+}


### PR DESCRIPTION
This PR adds support for the Tcl language server [`tclsp`](https://github.com/nmoroze/tclint/blob/main/docs/lsp.md) provided by the [`tclint`](https://github.com/nmoroze/tclint/tree/main) project.

#### Criteria in CONTRIBUTING.md
1. The project does not have 100 stars quite yet (73 as of writing this). However, there is also a [VSCode plugin](https://marketplace.visualstudio.com/items?itemName=nmoroze.tclint) with some users marking usage
1. Tcl is a well-established language still used in many electronic design automation tools, see https://wiki.tcl-lang.org/page/EDA for more details