### PR TITLE
fix(lsp): also detect deno.jsonc as Deno project for biome/eslint/ts_ls/tsgo/vtsls

### DIFF
--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -50,7 +50,7 @@ return {
       or vim.list_extend(root_markers, { '.git' })
 
     -- exclude deno
-    if vim.fs.root(bufnr, { 'deno.json', 'deno.lock' }) then
+    if vim.fs.root(bufnr, { 'deno.json', 'deno.jsonc', 'deno.lock' }) then
       return
     end
 

--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -97,7 +97,7 @@ return {
       or vim.list_extend(root_markers, { '.git' })
 
     -- exclude deno
-    if vim.fs.root(bufnr, { 'deno.json', 'deno.lock' }) then
+    if vim.fs.root(bufnr, { 'deno.json', 'deno.jsonc', 'deno.lock' }) then
       return
     end
 

--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -63,7 +63,7 @@ return {
     root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers, { '.git' } }
       or vim.list_extend(root_markers, { '.git' })
     -- exclude deno
-    local deno_path = vim.fs.root(bufnr, { 'deno.json', 'deno.lock' })
+    local deno_path = vim.fs.root(bufnr, { 'deno.json', 'deno.jsonc', 'deno.lock' })
     local project_root = vim.fs.root(bufnr, root_markers)
     if deno_path and (not project_root or #deno_path >= #project_root) then
       return

--- a/lsp/tsgo.lua
+++ b/lsp/tsgo.lua
@@ -36,7 +36,7 @@ return {
       or vim.list_extend(root_markers, { '.git' })
 
     -- exclude deno
-    if vim.fs.root(bufnr, { 'deno.json', 'deno.lock' }) then
+    if vim.fs.root(bufnr, { 'deno.json', 'deno.jsonc', 'deno.lock' }) then
       return
     end
 

--- a/lsp/vtsls.lua
+++ b/lsp/vtsls.lua
@@ -90,7 +90,7 @@ return {
       or vim.list_extend(root_markers, { '.git' })
 
     -- exclude deno
-    if vim.fs.root(bufnr, { 'deno.json', 'deno.lock' }) then
+    if vim.fs.root(bufnr, { 'deno.json', 'deno.jsonc', 'deno.lock' }) then
       return
     end
 


### PR DESCRIPTION
The config file **deno.jsonc** was not being considered to prevent biome/eslint/ts_ls/tsgo/vtsls to run in Deno projects.

Fixes #4202