### PR TITLE
fix(tailwindcss): add dynamic registration for `didWatchChangedFiles`

### DIFF
--- a/lsp/tailwindcss.lua
+++ b/lsp/tailwindcss.lua
@@ -66,6 +66,13 @@ return {
     'svelte',
     'templ',
   },
+  capabilities = {
+    workspace = {
+      didChangeWatchedFiles = {
+        dynamicRegistration = true,
+      },
+    },
+  },
   settings = {
     tailwindCSS = {
       validate = true,


### PR DESCRIPTION
Not having this was leading to the lsp falling back to watching *all* files in my repo and causing nasty side effects such as https://github.com/DopplerHQ/cli/issues/502