### PR TITLE
fix(denols): prevent detecting non-deno TypeScript projects

### DIFF
--- a/lsp/denols.lua
+++ b/lsp/denols.lua
@@ -75,7 +75,24 @@ return {
     'typescriptreact',
     'typescript.tsx',
   },
-  root_markers = { 'deno.json', 'deno.jsonc', '.git' },
+  root_dir = function(bufnr, on_dir)
+    -- The project root is where the LSP can be started from
+    local root_markers = { 'deno.lock' }
+    -- Give the root markers equal priority by wrapping them in a table
+    root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers, { '.git' } }
+      or vim.list_extend(root_markers, { '.git' })
+    -- exclude non-deno projects (npm, yarn, pnpm, bun)
+    local non_deno_path = vim.fs.root(
+      bufnr,
+      { 'package.json', 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
+    )
+    local project_root = vim.fs.root(bufnr, root_markers)
+    if non_deno_path and (not project_root or #non_deno_path >= #project_root) then
+      return
+    end
+    -- We fallback to the current working directory if no project root is found
+    on_dir(project_root or vim.fn.getcwd())
+  end,
   settings = {
     deno = {
       enable = true,


### PR DESCRIPTION
### Problem
Currently, non-Deno TypeScript LSPs (`ts_ls`, `tsgo`, `vtsls`) have mechanisms to prevent conflicts by not activating `on_dir` when a Deno project is detected.

https://github.com/neovim/nvim-lspconfig/blob/e0fae251f8459940331960106d4bd9457cec23de/lsp/ts_ls.lua#L56-L73
However, `denols` lacks such a mechanism. As a result, when a non-Deno project is opened with `denols` enabled, both LSPs become attached.

### Solution
We will add conflict prevention logic to `denols`, similar to what non-Deno TypeScript LSPs have.
Currently, [Deno has a workspace feature](https://docs.deno.com/runtime/fundamentals/workspaces/), so we will detect the workspace root using `deno.lock` in the same way non-Deno TypeScript LSPs do. If `deno.lock` is not present and only `deno.json(c)` exists, we will handle it with a fallback.

<br />

### Testing
I confirmed that the expected LSP launched with the expected `root_dir` in the following situations:
- Deno monorepo project
- A single Deno project with a deno.lock file in the root
- A single Deno project without a deno.lock file in the root
- npm monorepo project
- A single npm project with a package-lock.json file in the root
- A single npm project without a package-lock.json (or any other non-Deno lock file) in the root