### PR TITLE
fix(neocmake): use subcommand instead of flag

### DIFF
--- a/lsp/neocmake.lua
+++ b/lsp/neocmake.lua
@@ -18,7 +18,7 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'neocmakelsp', '--stdio' },
+  cmd = { 'neocmakelsp', 'stdio' },
   filetypes = { 'cmake' },
   root_markers = { '.git', 'build', 'cmake' },
 }


### PR DESCRIPTION
Old versions accept both, however starting with v0.9.0 only subcommands will be recognized.