### PR TITLE
feat(lua_ls): enable codelens and inlay hints

### DIFF
--- a/lsp/lua_ls.lua
+++ b/lsp/lua_ls.lua
@@ -83,4 +83,10 @@ return {
     'selene.yml',
     '.git',
   },
+  settings = {
+    Lua = {
+      codeLens = { enable = true },
+      hint = { enable = true, semicolon = 'Disable' },
+    },
+  },
 }


### PR DESCRIPTION
Problem: Current lua_ls config does not enable codelens and inlay hints

Solution: Add enable for both of them