### PR TITLE
docs(readme): mention after/lsp/

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,7 @@ Configs are sourced in this order:
 2. `after/lsp/` in 'runtimepath'
 3. `vim.lsp.config()`
 
-If you install nvim-lspconfig or similar plugins, the `lsp/` level
-will be occupied by default configs. To avoid conflicts, use `after/lsp/`
-and/or `vim.lsp.config()` to override/extend the defaults.
+If you install nvim-lspconfig or similar plugins, the order that configs are applied depends on the load order. To ensure that your own config "wins" and overrides the others, use `after/lsp/` and/or `vim.lsp.config()` to override/extend the defaults.
 
 ## Creating a config
 


### PR DESCRIPTION
This PR addresses the confusion people have when `lsp/` configs don't override the plugin's `lsp/` by encouraging the use of `after/lsp/`. See <https://github.com/neovim/neovim/issues/36658> and <https://github.com/neovim/neovim/issues/36540>.

### Added "Config priority"

Inside this subsection, it would be better to say "merged" instead of "sourced" to convey the concept of layering. But that would be more appropriate after <https://github.com/neovim/neovim/issues/33577> is resolved (`nil`, `on_attach`, and other caveats).

### Changed `lsp/` into `after/lsp/` in Examples

Since "Config priority" exists, the example now focuses on the safest option, not to add complexity.