### PR TITLE
fix(hls): typo in the provided formatter makes the lsp crash when trying to format

### DIFF
--- a/lsp/hls.lua
+++ b/lsp/hls.lua
@@ -25,7 +25,7 @@ return {
   settings = {
     haskell = {
       formattingProvider = 'ormolu',
-      cabalFormattingProvider = 'cabalfmt',
+      cabalFormattingProvider = 'cabal-fmt',
     },
   },
 }


### PR DESCRIPTION
As stated in the title there is a small typo in the config that makes the lsp crash the moment it tries to format.
https://github.com/phadej/cabal-fmt