### PR TITLE
fix(eslint): use on_attach bufnr instead of current buf to create buf user command

### DIFF
--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -74,7 +74,7 @@ return {
   },
   workspace_required = true,
   on_attach = function(client, bufnr)
-    vim.api.nvim_buf_create_user_command(0, 'LspEslintFixAll', function()
+    vim.api.nvim_buf_create_user_command(bufnr, 'LspEslintFixAll', function()
       client:request_sync('workspace/executeCommand', {
         command = 'eslint.applyAllFixes',
         arguments = {


### PR DESCRIPTION
Fix LspEslintFixAll to register against the buffer being attached instead of the current buffer. Right now it would override the command in the current buffer.