### PR TITLE
fix(util): root_markers_with_field erroring when encountering encountering dirs

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -59,7 +59,7 @@ end
 --- @param fname string Full path of the current buffer name to start searching upwards from.
 function M.root_markers_with_field(root_files, new_names, field, fname)
   local path = vim.fn.fnamemodify(fname, ':h')
-  local found = vim.fs.find(new_names, { path = path, upward = true })
+  local found = vim.fs.find(new_names, { path = path, upward = true, type = 'file' })
 
   for _, f in ipairs(found or {}) do
     -- Match the given `field`.


### PR DESCRIPTION
I was getting the below error in a repo that had `package.json` as a directory (@sveltejs/kit). 

This limits the file search in root_markers_with_field to only look for matching files. 

```log
03:12:06 msg_show Error executing vim.schedule lua callback: ...cal/share/bob/v0.11.5/share/nvim/runtime/lua/vim/lsp.lua:636: FileType Autocommands for "*": Vim(append):Error executing lua callback: ...al/share/nvim/lazy/nvim-lspconfig/lua/lspconfig/util.lua:66: Is a directory
stack traceback:
	[C]: in function '(for generator)'
	...al/share/nvim/lazy/nvim-lspconfig/lua/lspconfig/util.lua:66: in function 'insert_package_json'
	...hmnd/.local/share/nvim/lazy/nvim-lspconfig/lsp/biome.lua:64: in function 'root_dir'
	...cal/share/bob/v0.11.5/share/nvim/runtime/lua/vim/lsp.lua:558: in function 'lsp_enable_callback'
	...cal/share/bob/v0.11.5/share/nvim/runtime/lua/vim/lsp.lua:628: in function <...cal/share/bob/v0.11.5/share/nvim/runtime/lua/vim/lsp.lua:627>
	[C]: in function 'doautoall'
	...cal/share/bob/v0.11.5/share/nvim/runtime/lua/vim/lsp.lua:636: in function 'enable'
	...g.nvim/lua/mason-lspconfig/features/automatic_enable.lua:47: in function 'fn'
	.../nvim/lazy/mason.nvim/lua/mason-core/functional/list.lua:116: in function 'each'
	...g.nvim/lua/mason-lspconfig/features/automatic_enable.lua:56: in function 'init'
	...m/lazy/mason-lspconfig.nvim/lua/mason-lspconfig/init.lua:43: in function 'setup'
	...share/nvim/lazy/LazyVim/lua/lazyvim/plugins/lsp/init.lua:257: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
stack traceback:
	[C]: in function 'doautoall'
	...cal/share/bob/v0.11.5/share/nvim/runtime/lua/vim/lsp.lua:636: in function 'enable'
	...g.nvim/lua/mason-lspconfig/features/automatic_enable.lua:47: in function 'fn'
	.../nvim/lazy/mason.nvim/lua/mason-core/functional/list.lua:116: in function 'each'
	...g.nvim/lua/mason-lspconfig/features/automatic_enable.lua:56: in function 'init'
	...m/lazy/mason-lspconfig.nvim/lua/mason-lspconfig/init.lua:43: in function 'setup'
	...share/nvim/lazy/LazyVim/lua/lazyvim/plugins/lsp/init.lua:257: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>

```