### PR TITLE
feat(postgres_lsp): require workspace

### DIFF
--- a/lsp/postgres_lsp.lua
+++ b/lsp/postgres_lsp.lua
@@ -11,4 +11,5 @@ return {
     'sql',
   },
   root_markers = { 'postgres-language-server.jsonc' },
+  workspace_required = true,
 }


### PR DESCRIPTION
This is kinda related to https://github.com/neovim/nvim-lspconfig/pull/3980#issuecomment-3587776862, but a little different: for some languages, like SQL, there are many "eligible" LSPs to attach to a given buffer - in a scenario where the user has configured LSPs for more than one SQL "flavor". This may lead to "unnecessary" servers being started.

The proposed change abuses the semantics of `workspace_required` a bit: technically, the server _does work_ without a workspace (albeit with _extremely limited capabilities_; I could only get diagnostics working, and only for syntax errors).

Prior to opening this PR, I opened a [discussion](https://github.com/supabase-community/postgres-language-server/discussions/606) on their repo, but I got no answer so far (we could wait).

Not touching other SQL LSPs because I don't use them.