### PR TITLE
fix(buf_ls): restrict `reuse_client` to buf_ls clients only

### DIFF
--- a/lsp/buf_ls.lua
+++ b/lsp/buf_ls.lua
@@ -10,8 +10,8 @@ return {
   cmd = { 'buf', 'lsp', 'serve', '--timeout=0', '--log-format=text' },
   filetypes = { 'proto' },
   root_markers = { 'buf.yaml', '.git' },
-  reuse_client = function()
+  reuse_client = function(client, config)
     -- `buf lsp serve` is meant to be used with multiple workspaces.
-    return true
+    return client.name == config.name
   end,
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue introduced in #4179 where `buf_ls` fails to attach when
other LSP clients (notably **Copilot**) are already active in the buffer.

The root cause is the implementation of:

```lua
reuse_client = function()
  return true
end
```

`reuse_client` is evaluated against **all running clients**, not only buf_ls.
Returning `true` unconditionally causes Neovim to reuse the *first available*
client — often Copilot — instead of spawning a new buf_ls client. As a result,
`buf_ls` never starts and silently fails to attach to `.proto` buffers.

---

## What this PR changes

This PR restricts reuse to buf_ls clients only:

```lua
reuse_client = function(client, config)
  return client.name == config.name
end
```

This preserves the intended multi-workspace reuse behavior for buf_ls while
avoiding accidental reuse of unrelated LSP clients.

---

## Reproduction

### Environment

- Neovim 0.11.x
- nvim-lspconfig ≥ `07f4e93`
- buf CLI ≥ 1.59
- Copilot language server enabled

### Steps

1. Enable both Copilot and buf_ls:

   ```lua
   vim.lsp.enable({ "copilot", "buf_ls" })
   ```

2. Open a `.proto` file in a directory containing `buf.yaml`

### Expected behavior

Both Copilot and buf_ls attach successfully.

### Actual behavior (regression)

Only Copilot attaches.  
`buf_ls` does **not** start, and no errors appear in `:LspLog`.

---

## Verified Fix

- Removing the previous `reuse_client` implementation resolves the issue.
- Restricting reuse to matching client names (`client.name == config.name`)
  also resolves the issue.
- This PR implements the correct restriction.
