### PR TITLE
fix(tailwindcss_ls): automatic add tailwind global css file to experimental.configFile in order to support Tailwind v4

### DIFF
--- a/lsp/tailwindcss.lua
+++ b/lsp/tailwindcss.lua
@@ -146,9 +146,10 @@ return {
     if not config.settings.editor.tabSize then
       config.settings.editor.tabSize = vim.lsp.util.get_effective_tabstop()
     end
-    config.settings.tailwindCSS.experimental = {
-      configFile = find_tailwind_global_css(),
-    }
+    config.settings.tailwindCSS = config.settings.tailwindCSS or {}
+    config.settings.tailwindCSS.experimental = config.settings.tailwindCSS.experimental or {}
+    config.settings.tailwindCSS.experimental.configFile = config.settings.tailwindCSS.experimental.configFile
+      or find_tailwind_global_css()
   end,
   workspace_required = true,
   root_dir = function(bufnr, on_dir)


### PR DESCRIPTION
## Summary
- Tailwind v4 no longer requires a `tailwind.config.js` file, but the LSP still expects a global stylesheet to be provided via `experimental.configFile`. This PR automatically locates a stylesheet in the project root that contains `@import 'tailwindcss';` and assigns its path to `experimental.configFile`. This ensures proper Tailwind v4 support without requiring a manual config file.
- Trying to close #4204 