### PR TITLE
feat: add cmd for java-language-server

### DIFF
--- a/lsp/java_language_server.lua
+++ b/lsp/java_language_server.lua
@@ -8,6 +8,7 @@
 
 ---@type vim.lsp.Config
 return {
+  cmd = { 'java-language-server' },
   filetypes = { 'java' },
   root_markers = { 'build.gradle', 'build.gradle.kts', 'pom.xml', '.git' },
   settings = {},


### PR DESCRIPTION
Same motivation as in #4178: both [the AUR](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=java-language-server#n35) and [nixpkgs](https://github.com/NixOS/nixpkgs/blob/de8efc1c6e7c3cf774a41a075cff70da009b4e9a/pkgs/by-name/ja/java-language-server/package.nix#L64) package this LS and expose an executable named `java-language-server`.
Hence, I suggest to set a sensible default for `cmd`.
