### PR TITLE
docs: update omnisharp's doc

### DIFF
--- a/lsp/omnisharp.lua
+++ b/lsp/omnisharp.lua
@@ -8,8 +8,6 @@
 ---
 --- OmniSharp requires the [dotnet-sdk](https://dotnet.microsoft.com/download) to be installed.
 ---
---- **By default, omnisharp-roslyn doesn't have a `cmd` set.** This is because nvim-lspconfig does not make assumptions about your path. You must add the following to your init.vim or init.lua to set `cmd` to the absolute path ($HOME and ~ are not expanded) of the unzipped run script or binary.
----
 --- For `go_to_definition` to work fully, extended `textDocument/definition` handler is needed, for example see [omnisharp-extended-lsp.nvim](https://github.com/Hoffs/omnisharp-extended-lsp.nvim)
 ---
 ---


### PR DESCRIPTION
Contrarily to what the doc says, this LS does have a default (dynamic) `cmd` set.
