### PR TITLE
feat(lexical): add default value for cmd

### DIFF
--- a/lsp/lexical.lua
+++ b/lsp/lexical.lua
@@ -4,13 +4,12 @@
 ---
 --- Lexical is a next-generation language server for the Elixir programming language.
 ---
---- Follow the [Detailed Installation Instructions](https://github.com/lexical-lsp/lexical/blob/main/pages/installation.md)
----
---- **By default, `lexical` doesn't have a `cmd` set.**
---- This is because nvim-lspconfig does not make assumptions about your path.
+--- To install from source, follow the [Detailed Installation Instructions](https://github.com/lexical-lsp/lexical/blob/main/pages/installation.md).
+--- Ensure to point `cmd` to the generated `_build/dev/package/lexical/start_lexical.sh` executable.
 
 ---@type vim.lsp.Config
 return {
+  cmd = { 'lexical' },
   filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
   root_markers = { 'mix.exs', '.git' },
 }


### PR DESCRIPTION
Same motivation as in #4178 and #4229: this LS is packaged on both [the AUR](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=lexical-bin#n28) and [nixpkgs](https://github.com/NixOS/nixpkgs/blob/de8efc1c6e7c3cf774a41a075cff70da009b4e9a/pkgs/by-name/le/lexical/package.nix#L39) which both provide a `lexical` executable.

This PR adds `{ 'lexical' }` as a default value, which would work (at least) on these two platforms.
