### PR TITLE
feat(nextls): add default value for cmd

### DIFF
--- a/lsp/nextls.lua
+++ b/lsp/nextls.lua
@@ -2,10 +2,11 @@
 ---
 --- https://github.com/elixir-tools/next-ls
 ---
---- **By default, next-ls does not set its `cmd`. Please see the following [detailed instructions](https://www.elixir-tools.dev/docs/next-ls/installation/) for possible installation methods.**
+--- **Please see the following [detailed instructions](https://www.elixir-tools.dev/docs/next-ls/installation/) for possible installation methods.**
 
 ---@type vim.lsp.Config
 return {
+  cmd = { 'nextls', '--stdio' },
   filetypes = { 'elixir', 'eelixir', 'heex', 'surface' },
   root_markers = { 'mix.exs', '.git' },
 }


### PR DESCRIPTION
[No matter the installation method](https://www.elixir-tools.dev/docs/next-ls/installation/), it seems like `nextls` should be run with the `nextls --stdio` command.
I suggest to set this as a default value for `cmd`.

This is what [mason-lspconfig.nvim does FWIW](https://github.com/mason-org/mason-lspconfig.nvim/blob/c55bd8a8fb191e24176c206a7af1dd51ce7276a5/lua/mason-lspconfig/lsp/nextls.lua).
