### PR TITLE
feat(flow): use flow executable for cmd if available in PATH

### DIFF
--- a/lsp/flow.lua
+++ b/lsp/flow.lua
@@ -14,7 +14,16 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'npx', '--no-install', 'flow', 'lsp' },
+  cmd = function(dispatchers)
+    local cmd = nil
+    if vim.fn.executable('flow') then
+      cmd = { 'flow', 'lsp' }
+    else
+      cmd = { 'npx', '--no-install', 'flow', 'lsp' }
+    end
+
+    return vim.lsp.rpc.start(cmd, dispatchers)
+  end,
   filetypes = { 'javascript', 'javascriptreact', 'javascript.jsx' },
   root_markers = { '.flowconfig' },
 }


### PR DESCRIPTION
**Note: I'm not sure if this is overkilled and/or overreaching. Feel free to close the PR if irrelevant.**

This PR dynamically sets `cmd` for [flow](https://flow.org/) depending on `flow`'s presence on the `$PATH`.
