### PR TITLE
fix(omnisharp): add '*.slnx' to root detection

### DIFF
--- a/lsp/omnisharp.lua
+++ b/lsp/omnisharp.lua
@@ -30,7 +30,8 @@ return {
   root_dir = function(bufnr, on_dir)
     local fname = vim.api.nvim_buf_get_name(bufnr)
     on_dir(
-      util.root_pattern '*.sln'(fname)
+      util.root_pattern '*.slnx'(fname)
+        or util.root_pattern '*.sln'(fname)
         or util.root_pattern '*.csproj'(fname)
         or util.root_pattern 'omnisharp.json'(fname)
         or util.root_pattern 'function.json'(fname)


### PR DESCRIPTION
Problem:
Root detection doesn't support the new solution file format which is now the default in .NET 10.

Solution:
Add '*.slnx' to root_dir function.