### PR TITLE
feat: hylo_ls

### DIFF
--- a/lsp/hylo_ls.lua
+++ b/lsp/hylo_ls.lua
@@ -1,0 +1,13 @@
+---@brief
+---
+--- https://github.com/hylo-lang/hylo-language-server
+---
+--- A language server for the Hylo programming language.
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'hylo-language-server', '--stdio' },
+  filetypes = { 'hylo' },
+  root_markers = { '.git' },
+  settings = {},
+}


### PR DESCRIPTION
This commit aims to introduce support for the [Hylo](https://hylo-lang.org/) language server protocol.

The corresponding PR in the mason registry is here: https://github.com/mason-org/mason-registry/pull/12749



### Evidence on requirement fulfillment (new package)
- The Hylo language has 1.4K stars on Github: https://github.com/hylo-lang/hylo/
- The language server is developed under the hylo-lang organization: https://github.com/hylo-lang/hylo-language-server
- See Hylo's website at https://hylo-lang.org/
