### PR TITLE
fix(ltex_plus): asciidoc is added to enabled languages

### DIFF
--- a/lsp/ltex_plus.lua
+++ b/lsp/ltex_plus.lua
@@ -36,6 +36,7 @@ local language_id_mapping = {
 return {
   cmd = { 'ltex-ls-plus' },
   filetypes = {
+    'asciidoc',
     'bib',
     'context',
     'gitcommit',
@@ -62,6 +63,7 @@ return {
   settings = {
     ltex = {
       enabled = {
+        'asciidoc',
         'bib',
         'context',
         'gitcommit',


### PR DESCRIPTION
Problem:
LTEX+ LS supports Asciidoc but it is not enabled by default. Suggested way of extending configuration overrides the values, since `filetypes` and `ltex.enabled` are Lua list.

Solution:
Add Asciidoc to the default list of enabled languages.

https://ltex-plus.github.io/ltex-plus/supported-languages.html