### PR TITLE
fix(copilot): use correct error variable

### DIFF
--- a/lsp/copilot.lua
+++ b/lsp/copilot.lua
@@ -65,7 +65,7 @@ local function sign_in(bufnr, client)
         if continue == 1 then
           client:exec_cmd(command, { bufnr = bufnr }, function(cmd_err, cmd_result)
             if cmd_err then
-              vim.notify(err.message, vim.log.levels.ERROR)
+              vim.notify(cmd_err.message, vim.log.levels.ERROR)
               return
             end
             if cmd_result.status == 'OK' then


### PR DESCRIPTION
Problem:
The `client:exec_cmd` callback was incorrectly referencing to `err` variable from the outer scope instead of the `cmd_err` variable from its on scope. Could cause problems when `err` is nil but the `cmd_err` is not.

Solution:
Changed the reference from `err` to `cmd_err`