### PR TITLE
docs(roslyn_ls): format codeblock

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -7,6 +7,7 @@
 -- replace `<platform>` with one of the following `linux-x64`, `osx-x64`, `win-x64`, `neutral` (for more info on the download location see https://github.com/dotnet/roslyn/issues/71474#issuecomment-2177303207).
 -- Download and extract it (nuget's are zip files).
 -- - if you chose `neutral` nuget version, then you have to change the `cmd` like so:
+--   ```lua
 --   cmd = {
 --     'dotnet',
 --     '<my_folder>/Microsoft.CodeAnalysis.LanguageServer.dll',
@@ -16,6 +17,7 @@
 --     fs.joinpath(uv.os_tmpdir(), 'roslyn_ls/logs'),
 --     '--stdio',
 --   },
+--   ```
 --   where `<my_folder>` has to be the folder you extracted the nuget package to.
 -- - for all other platforms put the extracted folder to neovim's PATH (`vim.env.PATH`)
 


### PR DESCRIPTION
Current one is hard to read due to the continuous string of lua config and comments.