### PR TITLE
fix(docs): rename misleading argument name

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ Most of the time, the reason for failure is present in the logs.
 
 * `:LspInfo` (alias to `:checkhealth vim.lsp`) shows the status of active and configured language servers.
 * `:lsp enable [<config_name>]` (`:LspStart` for Nvim 0.11 or older) Start the requested server name. Will only successfully start if the command detects a root directory matching the current config.
-* `:lsp disable [<client_id_or_name>]` (`:LspStop` for Nvim 0.11 or older) Stops the given server. Defaults to stopping all servers active on the current buffer. To force stop use `:LspStop!`
-* `:lsp restart [<client_id_or_name>]` (`:LspRestart` for Nvim 0.11 or older) Restarts the given client, and attempts to reattach to all previously attached buffers. Defaults to restarting all active servers.
+* `:lsp disable [<config_name>]` (`:LspStop` for Nvim 0.11 or older) Stops the given server. Defaults to stopping all servers active on the current buffer. To force stop use `:LspStop!`
+* `:lsp restart [<client_name>]` (`:LspRestart` for Nvim 0.11 or older) Restarts the given client, and attempts to reattach to all previously attached buffers. Defaults to restarting all active servers.
 
 ## Contributions
 


### PR DESCRIPTION
Fixes the following issues:
- `:lsp disable` operates on configs, not clients.
- `:lsp restart` cannot restart clients by id.