### PR TITLE
fix(harper_ls): add `.harper-dictionary.txt` as root marker

### DIFF
--- a/lsp/harper_ls.lua
+++ b/lsp/harper_ls.lua
@@ -48,5 +48,5 @@ return {
     'clojure',
     'sh',
   },
-  root_markers = { '.git' },
+  root_markers = { '.harper-dictionary.txt', '.git' },
 }


### PR DESCRIPTION
The file `.harper-dictionary.txt` stores the workspace-specific dictionary, thus making it a root marker.

https://writewithharper.com/docs/integrations/language-server#Workspace-Dictionary