### PR TITLE
fix(golangci_lint_ls): disable all output formats except JSON

### DIFF
--- a/lsp/golangci_lint_ls.lua
+++ b/lsp/golangci_lint_ls.lua
@@ -18,7 +18,22 @@ return {
   cmd = { 'golangci-lint-langserver' },
   filetypes = { 'go', 'gomod' },
   init_options = {
-    command = { 'golangci-lint', 'run', '--output.json.path=stdout', '--show-stats=false' },
+    command = {
+      'golangci-lint',
+      'run',
+      -- disable all output formats that might be enabled by the users .golangci.yml
+      '--output.text.path=',
+      '--output.tab.path=',
+      '--output.html.path=',
+      '--output.checkstyle.path=',
+      '--output.junit-xml.path=',
+      '--output.teamcity.path=',
+      '--output.sarif.path=',
+      -- disable stats output
+      '--show-stats=false',
+      -- enable JSON output to be used by the language server
+      '--output.json.path=stdout',
+    },
   },
   root_markers = {
     '.golangci.yml',

--- a/lua/lspconfig/configs/golangci_lint_ls.lua
+++ b/lua/lspconfig/configs/golangci_lint_ls.lua
@@ -12,7 +12,22 @@ return {
     cmd = { 'golangci-lint-langserver' },
     filetypes = { 'go', 'gomod' },
     init_options = {
-      command = { 'golangci-lint', 'run', '--output.json.path=stdout', '--show-stats=false' },
+      command = {
+        'golangci-lint',
+        'run',
+        -- disable all output formats that might be enabled by the users .golangci.yml
+        '--output.text.path=',
+        '--output.tab.path=',
+        '--output.html.path=',
+        '--output.checkstyle.path=',
+        '--output.junit-xml.path=',
+        '--output.teamcity.path=',
+        '--output.sarif.path=',
+        -- disable stats output
+        '--show-stats=false',
+        -- enable JSON output to be used by the language server
+        '--output.json.path=stdout',
+      },
     },
     root_dir = function(fname)
       return util.root_pattern(


### PR DESCRIPTION
This change set enables all possible output formats that exist for golangci-lint. This is necessary because if a user configures output formats in their `.golangci.yml` configuration (for example for CI) then this is always in addition to the ones enabled on the command line. Therefore, we manually disable all possible output formats.

Currently, there doesn't exist a `golangci-lint` option to exclusively enable an output format or disable all from the config.