### PR TITLE
fix(buf_ls): remove beta in comments

### DIFF
--- a/lsp/buf_ls.lua
+++ b/lsp/buf_ls.lua
@@ -1,13 +1,13 @@
 --- @brief
 --- https://github.com/bufbuild/buf
 ---
---- buf beta lsp included in the cli itself
+--- buf lsp included in the cli itself
 ---
---- buf beta lsp is a Protobuf language server compatible with Buf modules and workspaces
+--- buf lsp is a Protobuf language server compatible with Buf modules and workspaces
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'buf', 'lsp', 'serve', '--timeout=0', '--log-format=text' },
+  cmd = { 'buf', 'lsp', 'serve', '--log-format=text' },
   filetypes = { 'proto' },
   root_markers = { 'buf.yaml', '.git' },
   reuse_client = function(client, config)


### PR DESCRIPTION
Also removes the timeout option, which is unnecessary with the latest version of the LSP.