### PR TITLE
feat: `systemd_lsp`

### DIFF
--- a/lsp/systemd_lsp.lua
+++ b/lsp/systemd_lsp.lua
@@ -16,5 +16,5 @@
 ---@type vim.lsp.Config
 return {
   cmd = { 'systemd-lsp' },
-  filetypes = { 'systemd' }
+  filetypes = { 'systemd' },
 }


### PR DESCRIPTION
This adds a new language server config for systemd files. The
language server in question (`systemd-lsp`) seems very promising, its more
up-to-date than `systemd-language-server` and should perform a lot faster
considering it's written in Rust.