### PR TITLE
fix(roslyn_ls): fix lsp attachment on decompiled code

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -159,6 +159,11 @@ return {
       if root_dir then
         cb(root_dir)
       end
+    else
+      local existing_client = vim.lsp.get_clients({ name = 'roslyn_ls' })[1]
+      if existing_client and existing_client.config.root_dir then
+        cb(existing_client.config.root_dir)
+      end
     end
   end,
   on_init = {


### PR DESCRIPTION
This fix allows us to gd into decompiled code with the lsp attached, and allows nested decompilation