### PR TITLE
fix(roslyn_ls): detect correct lsp client for decompiled code

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -160,7 +160,7 @@ return {
         cb(root_dir)
       end
     else
-      -- decompiled code
+      -- Decompiled code (example: "/tmp/MetadataAsSource/f2bfba/DecompilationMetadataAsSourceFileProvider/d5782a/Console.cs")
       local prev_buf = vim.fn.bufnr('#')
       local client = vim.lsp.get_clients({
         name = 'roslyn_ls',


### PR DESCRIPTION
Follow up from https://github.com/neovim/nvim-lspconfig/pull/4254 @justinmk

This change resolves the LSP root_dir more reliably by first checking the previous buffer’s attached client and reusing its root_dir when available. If no matching client is found, it falls back to any existing client’s root_dir. As a final fall-back, it sets the root_dir to the decompilation root, which intentionally forces a new LSP client to be created.