### PR TITLE
fix(tsgo): prefer local node_modules binary over global

### DIFF
--- a/lsp/tsgo.lua
+++ b/lsp/tsgo.lua
@@ -16,7 +16,14 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'tsgo', '--lsp', '--stdio' },
+  cmd = function(dispatchers, config)
+    local cmd = 'tsgo'
+    local local_cmd = (config or {}).root_dir and config.root_dir .. '/node_modules/.bin/tsgo'
+    if local_cmd and vim.fn.executable(local_cmd) == 1 then
+      cmd = local_cmd
+    end
+    return vim.lsp.rpc.start({ cmd, '--lsp', '--stdio' }, dispatchers)
+  end,
   filetypes = {
     'javascript',
     'javascriptreact',


### PR DESCRIPTION
Convert the `cmd` from a static array to a function that checks for a locally installed tsgo binary in `node_modules/.bin/` before falling back to the global installation.

This ensures projects using `@typescript/native-preview` as a local dependency will use the correct version, matching the pattern already used by biome.