### PR TITLE
fix(tblgen_lsp_server): also search build dir for db

### DIFF
--- a/lsp/tblgen_lsp_server.lua
+++ b/lsp/tblgen_lsp_server.lua
@@ -8,10 +8,13 @@
 
 local function get_command()
   local cmd = { 'tblgen-lsp-server' }
-  local files = vim.fs.find('tablegen_compile_commands.yml', { path = vim.fn.expand('%:p:h'), upward = true })
+  local files = vim.fs.find(
+    { 'tablegen_compile_commands.yml', 'build/tablegen_compile_commands.yml' },
+    { path = vim.fn.expand('%:p:h'), upward = true, type = 'file' }
+  )
   if #files > 0 then
     local file = files[1]
-    table.insert(cmd, '--tablegen-compilation-database=' .. vim.fs.dirname(file) .. '/tablegen_compile_commands.yml')
+    table.insert(cmd, '--tablegen-compilation-database=' .. file)
   end
 
   return cmd


### PR DESCRIPTION
cmake will generate `tablegen_compile_commands.yml` in the build dir by default, so the current config will miss it in pretty much every case.
I guess a better approach might be to scan recursively from the root dir, but i think this will work for most cases.