### PR TITLE
fix(biome): avoid false-positive root_dir matches

### DIFF
--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -61,7 +61,7 @@ return {
     -- in its directory tree.
     local filename = vim.api.nvim_buf_get_name(bufnr)
     local biome_config_files = { 'biome.json', 'biome.jsonc' }
-    biome_config_files = util.insert_package_json(biome_config_files, 'biome', filename)
+    biome_config_files = util.insert_package_json(biome_config_files, 'biomejs', filename)
     local is_buffer_using_biome = vim.fs.find(biome_config_files, {
       path = filename,
       type = 'file',


### PR DESCRIPTION
Problem:
Biome server becomes active if biome appears as a substring in package.json, even when biome is not being used.

Solution:
Since biome is behind the `@biomejs` namespace we can narrow its activation by appending `js` in the searched term.