### PR TITLE
fix(tsgo): prevent attaching to non file buffers

### DIFF
--- a/lsp/tsgo.lua
+++ b/lsp/tsgo.lua
@@ -47,6 +47,12 @@ return {
       return
     end
 
+    -- prevent from attaching to non file buffers
+    local fname = vim.api.nvim_buf_get_name(bufnr)
+    if not vim.uv.fs_stat(fname) then
+      return
+    end
+
     -- We fallback to the current working directory if no project root is found
     local project_root = vim.fs.root(bufnr, root_markers) or vim.fn.getcwd()
 


### PR DESCRIPTION
Hey,

`tsgo` is still a rather experimental server. While testing, I ran into numerous crashes related to attaching to non file buffers (from plugins, etc).

I believe this will eventually get fixed on the server side. In the meantime, we could have this...