### PR TITLE
docs: add `root_dir` instructions to nvim 0.11 migration guide

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -64,6 +64,24 @@ nvim-lspconfig interface:
 - `on_new_config` is currently missing, see https://github.com/neovim/neovim/issues/32287
   - However, defining `root_dir` as a function is very flexible and may fit
     your use-case instead. https://github.com/neovim/neovim/issues/32037#issuecomment-2825599872
+- `root_dir` usages akin to >lua
+
+      root_dir  = require'lspconfig.util'.root_pattern(...)
+<
+
+  should be updated:
+  - If the patterns passed to `root_pattern` contain no wildcards, then 
+    `root_markers` (see |lsp-root_markers|) is likely sufficient.
+  - Otherwise, `root_pattern` can still be employed (for the time being,
+    see https://github.com/neovim/nvim-lspconfig/issues/3768), but the usage
+    should be as follows (see |lsp-root_dir|): >lua
+
+        root_dir = function(bufnr, on_dir)
+            local fname = vim.api.nvim_buf_get_name(bufnr)
+            on_dir(require'lspconfig.util'.root_pattern(...)(fname))
+        end
+<
+
 
 ==============================================================================
 COMMANDS                                                    *lspconfig-commands*


### PR DESCRIPTION
When migrating my personal config, I had to manually look for new usages of `root_dir` in `lsp/*` (found a good example in [`lsp/ols.lua`](https://github.com/neovim/nvim-lspconfig/blob/ac04ec3c2af08e9821b4eb64ede86072b9b213bf/lsp/ols.lua)), as the function signature for `root_dir` in `vim.lsp.config` differs from the old `lspconfig` `root_dir`. So I thought some instructions for this in the docs couldn't hurt :).

Arguably, this could be in another part of the docs instead of just the migration guide, as it should be relevant to new users as well. However, if https://github.com/neovim/nvim-lspconfig/issues/3768 is solved soon, e.g. if https://github.com/neovim/neovim/pull/33771 gets merged, this will most likely be irrelevant anyway, in favor of wildcards in `root_markers`; I'll leave it up to you :).