### PR TITLE
fix(systemd_ls): fix broken deprecation

### DIFF
--- a/lsp/systemd_ls.lua
+++ b/lsp/systemd_ls.lua
@@ -5,4 +5,4 @@
 vim.deprecate('systemd_ls', 'systemd_lsp', '2.0.0', 'nvim-lspconfig', false)
 
 ---@type vim.lsp.Config
-return vim.lsp.config.systemd_ls
+return vim.lsp.config.systemd_lsp


### PR DESCRIPTION
Problem:
The deprecated `systemd_ls` references itself instead of the new `systemd_lsp`.

Solution:
Fix.