### PR TITLE
Add swift to codebook filetype list

### DIFF
--- a/doc/configs.md
+++ b/doc/configs.md
@@ -2310,7 +2310,7 @@ Default config:
   ```
 - `filetypes` :
   ```lua
-  { "c", "css", "gitcommit", "go", "haskell", "html", "java", "javascript", "javascriptreact", "lua", "markdown", "php", "python", "ruby", "rust", "toml", "text", "typescript", "typescriptreact" }
+  { "c", "css", "gitcommit", "go", "haskell", "html", "java", "javascript", "javascriptreact", "lua", "markdown", "php", "python", "ruby", "rust", "swift", "toml", "text", "typescript", "typescriptreact" }
   ```
 - `root_markers` :
   ```lua


### PR DESCRIPTION
Hello,

As of v0.3.23, codebook-lsp supports the swift programming language.
This PR adds swift to the filetype list for the codebook lspconfig

Let me know if there are any issues or questions about this draft request. Thank you!