### PR TITLE
Add zig and swift to codebook filetypes

### DIFF
--- a/lsp/codebook.lua
+++ b/lsp/codebook.lua
@@ -28,10 +28,12 @@ return {
     'python',
     'ruby',
     'rust',
+    'swift',
     'toml',
     'text',
     'typescript',
     'typescriptreact',
+    'zig',
   },
   root_markers = { '.git', 'codebook.toml', '.codebook.toml' },
 }


### PR DESCRIPTION
Hello,

As of v0.3.23, codebook-lsp supports the swift programming language.  Zig was also added in recent versions.
This PR adds both swift and zig to the filetype list for the codebook lspconfig

Let me know if there are any issues or questions about this draft request. Thank you!