### PR TITLE
feat: faustlsp

### DIFF
--- a/lsp/faustlsp.lua
+++ b/lsp/faustlsp.lua
@@ -1,0 +1,13 @@
+---@brief
+---
+--- https://github.com/carn181/faustlsp
+---
+--- Faust language server protocol (LSP) support.
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'faustlsp' },
+  filetypes = { 'faust' },
+  workspace_required = true,
+  root_markers = { '.faustcfg.json' },
+}


### PR DESCRIPTION
This adds [faustlsp](https://github.com/carn181/faustlsp), a language server for the [Faust](https://faust.grame.fr/) programming language.

The contribution guidelines state popularity (star count) guidelines that faustlsp doesn't meet right now, but given the language itself is well-established (in active development since 2002), I thought it would still be worth adding. If you'd prefer to wait for faustlsp to meet the contribution guidelines, that's understandable too.