### PR TITLE
feat: gn_language_server

### DIFF
--- a/lsp/gn_language_server.lua
+++ b/lsp/gn_language_server.lua
@@ -1,0 +1,13 @@
+---@brief
+---
+--- https://github.com/google/gn-language-server
+---
+--- A language server for GN, the build configuration language used in Chromium,
+--- Fuchsia, and other projects.
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'gn-language-server', '--stdio' },
+  filetypes = { 'gn' },
+  root_markers = { '.gn', '.git' },
+}


### PR DESCRIPTION
This patch adds support for [gn-language-server](https://github.com/google/gn-language-server), a language server for GN (the build configuration language used in Chromium, Fuchsia, and other projects).

While `nvim-lspconfig` already includes a configuration for [`gnls`](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/gnls.lua) by Microsoft, this is a separate implementation written from scratch in Rust. Unlike the Microsoft version, which primarily focuses on single-file analysis, this server analyzes the entire workspace for definitions and references. To my knowledge, it is currently the most powerful GN language server available.

Although this implementation is relatively new (first published in March 2025) and does not yet meet the GitHub star requirement mentioned in CONTRIBUTING.md, it is the officially recommended language server for Chromium and Fuchsia.

- Chromium: https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/vscode.md#recommended-extensions
- Fuchsia: https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/fuchsia.code-workspace#63

Since there have been requests from Chromium developers using Neovim, it would be greatly appreciated if you could consider adding this configuration.

Disclaimer: I am a Chromium committer and the developer of this language server.