### PR TITLE
fix: deprecate systemd_ls in future version

### DIFF
--- a/lsp/systemd_ls.lua
+++ b/lsp/systemd_ls.lua
@@ -2,7 +2,7 @@
 ---
 --- Renamed to [systemd_lsp](#systemd_lsp)
 
-vim.deprecate('systemd_ls', 'systemd_lsp', '2.0.0', 'nvim-lspconfig', false)
+vim.deprecate('systemd_ls', 'systemd_lsp', '3.0.0', 'nvim-lspconfig', false)
 
 ---@type vim.lsp.Config
 return vim.lsp.config.systemd_lsp


### PR DESCRIPTION
Fixes an issue [@Arnie97](https://github.com/neovim/nvim-lspconfig/pull/4262#pullrequestreview-3650153228) reported: make the deprecation notice make sense by setting the version to the next major version :-)