### PR TITLE
docs(lua_ls): correct nested table workspace.library setting

### DIFF
--- a/lsp/lua_ls.lua
+++ b/lsp/lua_ls.lua
@@ -41,25 +41,23 @@
 ---       workspace = {
 ---         checkThirdParty = false,
 ---         library = {
----           vim.env.VIMRUNTIME
+---           vim.env.VIMRUNTIME,
 ---           -- Depending on the usage, you might want to add additional paths
 ---           -- here.
----           -- '${3rd}/luv/library'
----           -- '${3rd}/busted/library'
----         }
+---           -- '${3rd}/luv/library',
+---           -- '${3rd}/busted/library',
+---         },
 ---         -- Or pull in all of 'runtimepath'.
 ---         -- NOTE: this is a lot slower and will cause issues when working on
 ---         -- your own configuration.
 ---         -- See https://github.com/neovim/nvim-lspconfig/issues/3189
----         -- library = {
----         --   vim.api.nvim_get_runtime_file('', true),
----         -- }
----       }
+---         -- library = vim.api.nvim_get_runtime_file('', true),
+---       },
 ---     })
 ---   end,
 ---   settings = {
----     Lua = {}
----   }
+---     Lua = {},
+---   },
 --- })
 --- ```
 ---


### PR DESCRIPTION
Correct nested table `workspace.library` setting.

`lua_ls` `workspace.library` setting expects an *1D string array* `Array<string>` but the suggested documentation example sets a **2D string array**, a nested table, instead.

https://github.com/neovim/nvim-lspconfig/blob/92ee7d42320edfbb81f3cad851314ab197fa324a/lua/lspconfig/configs/lua_ls.lua https://luals.github.io/wiki/settings/#workspacelibrary