### PR TITLE
fix: include deno in biome

### DIFF
--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -44,15 +44,17 @@ return {
     -- As stated in the documentation above, this LSP supports monorepos and simple projects.
     -- We select then from the project root, which is identified by the presence of a package
     -- manager lock file.
-    local root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock' }
+    local root_markers = {
+      'package-lock.json',
+      'yarn.lock',
+      'pnpm-lock.yaml',
+      'bun.lockb',
+      'bun.lock',
+      'deno.lock',
+    }
     -- Give the root markers equal priority by wrapping them in a table
     root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers, { '.git' } }
       or vim.list_extend(root_markers, { '.git' })
-
-    -- exclude deno
-    if vim.fs.root(bufnr, { 'deno.json', 'deno.jsonc', 'deno.lock' }) then
-      return
-    end
 
     -- We fallback to the current working directory if no project root is found
     local project_root = vim.fs.root(bufnr, root_markers) or vim.fn.getcwd()


### PR DESCRIPTION
#4130 prevents a bunch of lsps to start in a deno project, including biome. However I think the biome lsp should indeed be active in deno projects with a `biome.json`.

I could of course just supply my own lsp config in my neovim config, but I would like to challenge the "defaults" here.