### PR TITLE
fix(basedpyright): remove explicit useLibraryCodeForTypes setting

### DIFF
--- a/lsp/basedpyright.lua
+++ b/lsp/basedpyright.lua
@@ -38,8 +38,11 @@ return {
     basedpyright = {
       analysis = {
         autoSearchPaths = true,
-        useLibraryCodeForTypes = true,
         diagnosticMode = 'openFilesOnly',
+        -- https://docs.basedpyright.com/latest/configuration/language-server-settings/
+        -- Explicitly setting `basedpyright.analysis.useLibraryCodeForTypes` is **discouraged** by the official docs.
+        -- Because it will override per-project configurations like `pyproject.toml`.
+        -- If left unset, its default value is `true`, and it can be correctly overridden by project config files.
       },
     },
   },


### PR DESCRIPTION
Explicitly setting `basedpyright.analysis.useLibraryCodeForTypes` is **discouraged** by the official docs, because it will override per-project configurations like `pyproject.toml`.

If left unset, its default value is still `true`, and it can be correctly overridden by project config files.

See: https://docs.basedpyright.com/latest/configuration/language-server-settings/