### PR TITLE
fix(ruby_lsp): specify cmd_cwd to ruby-lsp spawn at root directory

### DIFF
--- a/lsp/ruby_lsp.lua
+++ b/lsp/ruby_lsp.lua
@@ -14,7 +14,13 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'ruby-lsp' },
+  cmd = function(dispatchers, config)
+    return vim.lsp.rpc.start(
+      { 'ruby-lsp' },
+      dispatchers,
+      config.root_dir and { cwd = config.cmd_cwd or config.root_dir }
+    )
+  end,
   filetypes = { 'ruby', 'eruby' },
   root_markers = { 'Gemfile', '.git' },
   init_options = {


### PR DESCRIPTION
Problem:
Ruby-lsp spawn in cwd even lsp detect root directory correctly

Solution:
Specify cmd_cwd to spawn cmd at root directory