### PR TITLE
docs: update :LspStop and :LspRestart commands

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -91,22 +91,21 @@ Launches the requested (configured) client, but only if it successfully
 resolves a root directory. Note: Defaults to all configured servers matching
 the current buffer filetype.
 
-:LspStop [client_id] or [config_name]                            *:LspStop*
+:LspStop [config_name]                                              *:LspStop*
 
 Note: Use `:lsp disable` with Nvim 0.12+. |:lsp-disable|
 
-Stops the server with the given client-id or config name. Defaults to
-stopping all servers active on the current buffer. To force stop language
-servers: >vim
+Stops the server with the given config name. Defaults to stopping all servers
+active on the current buffer. To force stop language servers: >vim
     :LspStop!
 
-:LspRestart [client_id] or [config_name]                         *:LspRestart*
+:LspRestart [config_name]                                        *:LspRestart*
 
 Note: Use `:lsp restart` with Nvim 0.12+. |:lsp-restart|
 
-Restarts the client with the given client-id or config name, and attempts
-to reattach to all previously attached buffers. Defaults to restarting all
-active servers. To force stop language servers when restarting: >vim
+Restarts the client with the given config name, and attempts to reattach to
+all previously attached buffers. Defaults to restarting all active servers. To
+force stop language servers when restarting: >vim
     :LspRestart!
 
 ==============================================================================


### PR DESCRIPTION
`:LspStop` and `:LspRestart` commands now only accept `config_name` and no longer support `client_id`.

fix #4291