### PR TITLE
fix(roslyn_ls): make test if file is decompiled or not os agnostic

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -108,6 +108,16 @@ local function roslyn_handlers()
   }
 end
 
+---@param bufname string
+---@return boolean
+local function is_decompiled(bufname)
+  local _, endpos = bufname:find('[/\\]MetadataAsSource[/\\]')
+  if endpos == nil then
+    return false
+  end
+  return vim.fn.finddir(bufname:sub(1, endpos), vim.env.TMP or vim.env.TEMP) ~= ''
+end
+
 ---@type vim.lsp.Config
 return {
   name = 'roslyn_ls',


### PR DESCRIPTION
At the moment the path which is used to test if a file is decompiled or not is hardcoded and incorrect (at least for windows users). It doesn't respect `\` as path separator and makes wrong assumptions about the temp path.  Hence why `vim.lsp.buf.definition` is not working in decompiled files. 