### PR TITLE
fix(roslyn_ls): make test if decompiled os agnostic

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -98,6 +98,16 @@ local function roslyn_handlers()
   }
 end
 
+---@param bufname string
+---@return boolean
+local function is_decompiled(bufname)
+  local _, endpos = bufname:find('[/\\]MetadataAsSource[/\\]')
+  if endpos == nil then
+    return false
+  end
+  return vim.fn.finddir(bufname:sub(1, endpos), vim.env.TMP or vim.env.TEMP) ~= ''
+end
+
 ---@type vim.lsp.Config
 return {
   name = 'roslyn_ls',
@@ -143,7 +153,7 @@ return {
     local bufname = vim.api.nvim_buf_get_name(bufnr)
     -- don't try to find sln or csproj for files from libraries
     -- outside of the project
-    if not bufname:match('^' .. fs.joinpath('/tmp/MetadataAsSource/')) then
+    if not is_decompiled(bufname) then
       -- try find solutions root first
       local root_dir = fs.root(bufnr, function(fname, _)
         return fname:match('%.sln[x]?$') ~= nil


### PR DESCRIPTION
At the moment hard coded assumptions about decompiled path are made. That is why `vim.lsp.buf.definition` is not working in decompiled files on windows.