### PR TITLE
fix(roslyn_ls): use uv.os_tmpdir() instead of vim.env.TMP

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -105,7 +105,7 @@ local function is_decompiled(bufname)
   if endpos == nil then
     return false
   end
-  return vim.fn.finddir(bufname:sub(1, endpos), vim.env.TMP or vim.env.TEMP) ~= ''
+  return vim.fn.finddir(bufname:sub(1, endpos), uv.os_tmpdir()) ~= ''
 end
 
 ---@type vim.lsp.Config


### PR DESCRIPTION
With the latest change in roslyn_ls i broke go to definition in decompiled files for linux users. This fixes the mess i caused. I tested the fix on Ubuntu (WSL).