### PR TITLE
fix(csharp_ls): use the correct language id

### DIFF
--- a/lsp/csharp_ls.lua
+++ b/lsp/csharp_ls.lua
@@ -29,4 +29,10 @@ return {
   init_options = {
     AutomaticWorkspaceInit = true,
   },
+  get_language_id = function(_, ft)
+    if ft == 'cs' then
+      return 'csharp'
+    end
+    return ft
+  end,
 }


### PR DESCRIPTION
In (not very) [recent commit](https://github.com/razzmatazz/csharp-language-server/commit/f51cd9dec8b10b7fd8f475dac3a904e1da2c7217), `csharp-language-server` started checking the language id due to the support of Razor documents. Since vim's file type for C# is `cs` so all things like hover documentation, go-to-definition etc. stopped working after this commit when using the default config. This PR fixes that by adding `get_language_id` to `csharp_ls.lua`.

Before this commit `csharp-language-server` doesn't check for language id, so theoretically this PR should not affect users that are using older versions.
