### PR TITLE
Fix some issues with the oxlint config

### DIFF
--- a/lsp/oxlint.lua
+++ b/lsp/oxlint.lua
@@ -34,10 +34,8 @@ return {
   filetypes = {
     'javascript',
     'javascriptreact',
-    'javascript.jsx',
     'typescript',
     'typescriptreact',
-    'typescript.tsx',
     'vue',
     'svelte',
     'astro',


### PR DESCRIPTION
This branch originally had a couple more fixes, but they conflicted with other fixes on rebase.

The current version:

- Adds help text for the `:LspOxlintFixAll` command
- Automatically enables type-aware linting when appropriate
- Copies the `settings` table to initialization options, if it exists
- Stops checking `package.json` for an `oxlint` section when searching for a root directory, since Oxlint has never supported that type of configuration