### PR TITLE
fix(ngserver): pull version from devDependencies too

### DIFF
--- a/lsp/angularls.lua
+++ b/lsp/angularls.lua
@@ -85,7 +85,7 @@ local function get_angular_core_version(root_dir)
 
   local json = vim.json.decode(content) or {}
 
-  local version = (json.dependencies or {})['@angular/core'] or ''
+  local version = (json.dependencies or {})['@angular/core'] or (json.devDependencies or {})['@angular/core'] or ''
   return version:match('%d+%.%d+%.%d+') or ''
 end
 


### PR DESCRIPTION
Its not uncommon to have angular/core in devDependencies in libs and monorepos and this would have saved me from confusion and further hatred towards angular