### PR TITLE
docs(astro): add an example to fix the tsdk path not found error

### DIFF
--- a/lsp/astro.lua
+++ b/lsp/astro.lua
@@ -6,6 +6,42 @@
 --- ```sh
 --- npm install -g @astrojs/language-server
 --- ```
+---
+--- If typescript is installed globally, you might get the `\`typescript.tsdk\` init option is required` error.
+--- You will need to manually pass the typescript SDK path. Here is an example of a Nix configuration where typescript is installed via Nix's Home-manager:
+---
+--- ```nix
+--- { config, pkgs, ... }:
+---
+--- {
+---   home.packages = with pkgs; [
+---     typescript
+---   ];
+---
+---   programs.neovim = {
+---     plugins = with pkgs.vimPlugins; [
+---       nvim-lspconfig
+---     ];
+---     extraPackages = with pkgs; [
+---       astro-language-server
+---     ];
+---     initLua = ''
+---       vim.lsp.config['astro'] = {
+---         init_options = {
+---           typescript = {
+---             tsdk = ${pkgs.typescript}/lib/node_modules/typescript/lib,
+---           },
+---         },
+---       }
+---
+---       vim.lsp.enable('astro')
+---
+---       -- ...
+---     '';
+---   };
+--- }
+--- ```
+--- The path can also be passed via a variable, like `vim.g.tsdk = "${pkgs.typescript}/lib/node_modules/typescript/lib"` and then used in the Lua Neovim config.
 
 local util = require 'lspconfig.util'
 


### PR DESCRIPTION
Added instructions for configuring TypeScript SDK in Neovim with Nix.

Lint ✅ 

fix #4101