### PR TITLE
docs: fix the vala_ls link

### DIFF
--- a/lsp/vala_ls.lua
+++ b/lsp/vala_ls.lua
@@ -1,6 +1,6 @@
 ---@brief
 ---
---- https://github.com/Prince781/vala-language-server
+--- https://github.com/vala-lang/vala-language-server
 
 local meson_matcher = function(path)
   local pattern = 'meson.build'


### PR DESCRIPTION
vala_ls is now at https://github.com/vala-lang/vala-language-server