### PR TITLE
feat(fortls): add alternative config names to root_markers

### DIFF
--- a/lsp/fortls.lua
+++ b/lsp/fortls.lua
@@ -22,6 +22,6 @@ return {
     '--use_signature_help',
   },
   filetypes = { 'fortran' },
-  root_markers = { '.fortls', '.git' },
+  root_markers = { '.fortls', '.fortlsrc', '.fortls.json', '.git' },
   settings = {},
 }


### PR DESCRIPTION
Add `.fortlsrc` & `.fortls.json` to `root_markers`. See https://fortls.fortran-lang.org/options.html#fortls-cli-named-arguments