### PR TITLE
feat(kakehashi): add kakehashi lsp config

### DIFF
--- a/lsp/kakehashi.lua
+++ b/lsp/kakehashi.lua
@@ -1,0 +1,41 @@
+--- @brief
+---
+--- https://github.com/atusy/kakehashi
+---
+--- Tree-sitter-based language server that provides semantic tokens, selection ranges,
+--- and LSP bridging for embedded languages (e.g., code blocks in Markdown).
+---
+--- kakehashi works with any language that has a Tree-sitter grammar.
+--- Parsers and queries are automatically installed on first use
+--- when `autoInstall` is enabled (the default). This requires the
+--- `tree-sitter` CLI, a C compiler, and Git.
+---
+--- **You must specify `filetypes` in your call to `vim.lsp.config`** to
+--- restrict which files activate the server:
+---
+--- ```lua
+--- vim.lsp.config('kakehashi', {
+---   filetypes = { 'markdown', 'lua', 'rust', 'python' },
+---   init_options = {
+---     autoInstall = true,
+---     -- Optional: bridge LSP requests in injection regions
+---     languageServers = {
+---       ['lua_ls'] = {
+---         cmd = { 'lua-language-server' },
+---         languages = { 'lua' },
+---       },
+---     },
+---     languages = {
+---       markdown = {
+---         bridge = { lua_ls = { enabled = true } },
+---       },
+---     },
+---   },
+--- })
+--- ```
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'kakehashi' },
+  root_markers = { 'kakehashi.toml', '.git' },
+}


### PR DESCRIPTION
## Summary

- Add configuration for [kakehashi](https://github.com/atusy/kakehashi), a Tree-sitter-based language server that provides semantic tokens, selection ranges, and LSP bridging for embedded languages.
- kakehashi works with any language that has a Tree-sitter grammar and can delegate LSP requests to external language servers for injection regions (e.g., code blocks in Markdown).

## Evidence of popularity

171 stars as of 2026-02-19


<img width="837" height="191" alt="image" src="https://github.com/user-attachments/assets/e6491296-2dcf-4602-ab25-97d08bf99566" />

## Appendix

To see a demo, visit my reddit post

https://www.reddit.com/r/neovim/comments/1quwcp8/new_language_server_kakehashi_%E6%9E%B6%E3%81%91%E6%A9%8B_bridge_that/
