### PR TITLE
feat(fsautocomplete): support slnx

### DIFF
--- a/lsp/fsautocomplete.lua
+++ b/lsp/fsautocomplete.lua
@@ -24,7 +24,7 @@ return {
   cmd = { 'fsautocomplete', '--adaptive-lsp-server-enabled' },
   root_dir = function(bufnr, on_dir)
     local fname = vim.api.nvim_buf_get_name(bufnr)
-    on_dir(util.root_pattern('*.sln', '*.fsproj', '.git')(fname))
+    on_dir(util.root_pattern('*.sln', '*.slnx', '*.fsproj', '.git')(fname))
   end,
   filetypes = { 'fsharp' },
   init_options = {


### PR DESCRIPTION
Add support for [the new slnx format](https://devblogs.microsoft.com/dotnet/introducing-slnx-support-dotnet-cli/) in the `fsautocomplete` config.

`FsAutoComplete` uses `Ionide.ProjInfo`, which added support for slnx files [in January last year](https://github.com/ionide/proj-info/pull/222).