### PR TITLE
fix(clangd): send correct languageIds for filetypes objc, objcpp and cuda

### DIFF
--- a/lsp/clangd.lua
+++ b/lsp/clangd.lua
@@ -74,6 +74,10 @@ return {
     'configure.ac', -- AutoTools
     '.git',
   },
+  get_language_id = function(_, ftype)
+    local t = { objc = 'objective-c', objcpp = 'objective-cpp', cuda = 'cuda-cpp' }
+    return t[ftype] or ftype
+  end,
   capabilities = {
     textDocument = {
       completion = {


### PR DESCRIPTION
Adds [correct languageId mappings](https://code.visualstudio.com/docs/languages/identifiers) for filetypes `objc`, `objcpp` and `cuda` similar to what we currently do for [sourcekit](https://github.com/neovim/nvim-lspconfig/blob/5a855bcfec7973767a1a472335684bbd71d2fa2b/lsp/sourcekit.lua#L23).

