### PR TITLE
feat(oxlint, oxfmt): check for local binaries in node_modules

### DIFF
--- a/lsp/oxfmt.lua
+++ b/lsp/oxfmt.lua
@@ -15,7 +15,14 @@ local util = require 'lspconfig.util'
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'oxfmt', '--lsp' },
+  cmd = function(dispatchers, config)
+    local cmd = 'oxfmt'
+    local local_cmd = (config or {}).root_dir and config.root_dir .. '/node_modules/.bin/oxfmt'
+    if local_cmd and vim.fn.executable(local_cmd) == 1 then
+      cmd = local_cmd
+    end
+    return vim.lsp.rpc.start({ cmd, '--lsp' }, dispatchers)
+  end,
   filetypes = {
     'javascript',
     'javascriptreact',

--- a/lsp/oxlint.lua
+++ b/lsp/oxlint.lua
@@ -30,7 +30,14 @@ end
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'oxlint', '--lsp' },
+  cmd = function(dispatchers, config)
+    local cmd = 'oxlint'
+    local local_cmd = (config or {}).root_dir and config.root_dir .. '/node_modules/.bin/oxlint'
+    if local_cmd and vim.fn.executable(local_cmd) == 1 then
+      cmd = local_cmd
+    end
+    return vim.lsp.rpc.start({ cmd, '--lsp' }, dispatchers)
+  end,
   filetypes = {
     'javascript',
     'javascriptreact',


### PR DESCRIPTION
`oxlint` and `oxfmt` now check for local binaries at `{root_dir}/node_modules/.bin/` before falling back to global executables.