### PR TITLE
fix: drop invalid filetypes javascript.jsx, typescript.tsx

### DIFF
--- a/lsp/angularls.lua
+++ b/lsp/angularls.lua
@@ -118,6 +118,6 @@ return {
     return vim.lsp.rpc.start(cmd, dispatchers)
   end,
 
-  filetypes = { 'typescript', 'html', 'typescriptreact', 'typescript.tsx', 'htmlangular' },
+  filetypes = { 'typescript', 'html', 'typescriptreact', 'htmlangular' },
   root_markers = { 'angular.json', 'nx.json' },
 }

--- a/lsp/denols.lua
+++ b/lsp/denols.lua
@@ -101,10 +101,8 @@ return {
   filetypes = {
     'javascript',
     'javascriptreact',
-    'javascript.jsx',
     'typescript',
     'typescriptreact',
-    'typescript.tsx',
   },
   root_dir = function(bufnr, on_dir)
     -- The project root is where the LSP can be started from

--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -63,10 +63,8 @@ return {
   filetypes = {
     'javascript',
     'javascriptreact',
-    'javascript.jsx',
     'typescript',
     'typescriptreact',
-    'typescript.tsx',
     'vue',
     'svelte',
     'astro',

--- a/lsp/flow.lua
+++ b/lsp/flow.lua
@@ -24,6 +24,6 @@ return {
 
     return vim.lsp.rpc.start(cmd, dispatchers)
   end,
-  filetypes = { 'javascript', 'javascriptreact', 'javascript.jsx' },
+  filetypes = { 'javascript', 'javascriptreact' },
   root_markers = { '.flowconfig' },
 }

--- a/lsp/rome.lua
+++ b/lsp/rome.lua
@@ -18,7 +18,6 @@ return {
     'javascriptreact',
     'json',
     'typescript',
-    'typescript.tsx',
     'typescriptreact',
   },
   root_markers = { 'package.json', 'node_modules', '.git' },

--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -80,10 +80,8 @@ return {
   filetypes = {
     'javascript',
     'javascriptreact',
-    'javascript.jsx',
     'typescript',
     'typescriptreact',
-    'typescript.tsx',
   },
   root_dir = function(bufnr, on_dir)
     -- The project root is where the LSP can be started from

--- a/lsp/vtsls.lua
+++ b/lsp/vtsls.lua
@@ -76,10 +76,8 @@ return {
   filetypes = {
     'javascript',
     'javascriptreact',
-    'javascript.jsx',
     'typescript',
     'typescriptreact',
-    'typescript.tsx',
   },
   root_dir = function(bufnr, on_dir)
     -- The project root is where the LSP can be started from


### PR DESCRIPTION
Problem:

When enabling configs with these filetypes, `checkhealth vim.lsp` reports the following warnings for each config:
- ⚠️ WARNING Unknown filetype 'javascript.jsx'.
- ⚠️ WARNING Unknown filetype 'typescript.tsx'.

Solution:

Remove them (#4253, #4299, #4325).