### PR TITLE
fix: drop invalid filetypes from legacy configs

### DIFF
--- a/lua/lspconfig/configs/angularls.lua
+++ b/lua/lspconfig/configs/angularls.lua
@@ -56,7 +56,7 @@ return {
       '--angularCoreVersion',
       default_angular_core_version,
     },
-    filetypes = { 'typescript', 'html', 'typescriptreact', 'typescript.tsx', 'htmlangular' },
+    filetypes = { 'typescript', 'html', 'typescriptreact', 'htmlangular' },
     -- Check for angular.json since that is the root of the project.
     -- Don't check for tsconfig.json or package.json since there are multiple of these
     -- in an angular monorepo setup.

--- a/lua/lspconfig/configs/biome.lua
+++ b/lua/lspconfig/configs/biome.lua
@@ -20,7 +20,6 @@ return {
       'jsonc',
       'svelte',
       'typescript',
-      'typescript.tsx',
       'typescriptreact',
       'vue',
     },

--- a/lua/lspconfig/configs/denols.lua
+++ b/lua/lspconfig/configs/denols.lua
@@ -76,10 +76,8 @@ return {
     filetypes = {
       'javascript',
       'javascriptreact',
-      'javascript.jsx',
       'typescript',
       'typescriptreact',
-      'typescript.tsx',
     },
     root_dir = util.root_pattern('deno.json', 'deno.jsonc', '.git'),
     settings = {

--- a/lua/lspconfig/configs/eslint.lua
+++ b/lua/lspconfig/configs/eslint.lua
@@ -60,10 +60,8 @@ return {
     filetypes = {
       'javascript',
       'javascriptreact',
-      'javascript.jsx',
       'typescript',
       'typescriptreact',
-      'typescript.tsx',
       'vue',
       'svelte',
       'astro',

--- a/lua/lspconfig/configs/flow.lua
+++ b/lua/lspconfig/configs/flow.lua
@@ -10,7 +10,7 @@ local util = require 'lspconfig.util'
 return {
   default_config = {
     cmd = { 'npx', '--no-install', 'flow', 'lsp' },
-    filetypes = { 'javascript', 'javascriptreact', 'javascript.jsx' },
+    filetypes = { 'javascript', 'javascriptreact' },
     root_dir = util.root_pattern '.flowconfig',
   },
   docs = {

--- a/lua/lspconfig/configs/oxlint.lua
+++ b/lua/lspconfig/configs/oxlint.lua
@@ -16,7 +16,6 @@ return {
       'javascriptreact',
       'svelte',
       'typescript',
-      'typescript.tsx',
       'typescriptreact',
       'vue',
     },

--- a/lua/lspconfig/configs/relay_lsp.lua
+++ b/lua/lspconfig/configs/relay_lsp.lua
@@ -23,10 +23,8 @@ return {
     filetypes = {
       'javascript',
       'javascriptreact',
-      'javascript.jsx',
       'typescript',
       'typescriptreact',
-      'typescript.tsx',
     },
     root_dir = util.root_pattern('relay.config.*', 'package.json'),
     on_new_config = function(config, root_dir)

--- a/lua/lspconfig/configs/rome.lua
+++ b/lua/lspconfig/configs/rome.lua
@@ -13,7 +13,6 @@ return {
       'javascriptreact',
       'json',
       'typescript',
-      'typescript.tsx',
       'typescriptreact',
     },
     root_dir = function(fname)

--- a/lua/lspconfig/configs/ts_ls.lua
+++ b/lua/lspconfig/configs/ts_ls.lua
@@ -14,10 +14,8 @@ return {
     filetypes = {
       'javascript',
       'javascriptreact',
-      'javascript.jsx',
       'typescript',
       'typescriptreact',
-      'typescript.tsx',
     },
     root_dir = util.root_pattern('tsconfig.json', 'jsconfig.json', 'package.json', '.git'),
     single_file_support = true,

--- a/lua/lspconfig/configs/vtsls.lua
+++ b/lua/lspconfig/configs/vtsls.lua
@@ -13,10 +13,8 @@ return {
     filetypes = {
       'javascript',
       'javascriptreact',
-      'javascript.jsx',
       'typescript',
       'typescriptreact',
-      'typescript.tsx',
     },
     root_dir = util.root_pattern('tsconfig.json', 'package.json', 'jsconfig.json', '.git'),
     single_file_support = true,


### PR DESCRIPTION
## Problem

78596b61 removed `javascript.jsx` and `typescript.tsx` from the `lsp/` configs but these same invalid filetypes remain in the legacy `lua/lspconfig/configs/` files. Annoyingly these still surface in `checkhealth vim.lsp` warnings when _not_ using the old configs:

<img width="954" height="217" alt="image" src="https://github.com/user-attachments/assets/72b204e8-a493-4c77-89f9-431ed7f5da73" />

## Solution

Remove `javascript.jsx` and `typescript.tsx` from all legacy config filetype lists from all affected LSPs.

***NOTE***: the CI will NOT pass because it checks that old LSP configs are NOT modified. Of course, this PR will not pass that check.

I argue that these changes _should_ be affected because default opt-out functionality (using old configs) ought _not_ affected your "correct" setup. Waiting for the old configs to be removed will take too long and needlessly pollute nearly everyone's `:checkhealth` in the meantime. 