### PR TITLE
fix(eslint): don't implicitly enable `experimental.useFlatConfig`

### DIFF
--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -38,6 +38,24 @@
 --- You can use a different version of ESLint in each package, but it is recommended to use the same version of ESLint in all packages. The location of the ESLint binary will be determined automatically.
 ---
 --- /!\ When using flat config files, you need to use them across all your packages in your monorepo, as it's a global setting for the server.
+---
+--- ### Flat config in ESLint versions prior to 10.0
+---
+--- If you're using a ESLint version that supports both flat config and eslintrc (>= 8.21, < 10.0) and want to change
+--- the [default behavior](https://eslint.org/blog/2023/10/flat-config-rollout-plans/), you'll need to set
+--- `experimental.useFlatConfig` accordingly:
+--- ```lua
+--- vim.lsp.config("eslint", {
+---   settings = {
+---     experimental = {
+---       -- If you want to use flat config on >= 8.21, < 9.0
+---       useFlatConfig = true,
+---       -- Or if you want to use eslintrc on 9.*
+---       -- useFlatConfig = false,
+---     }
+---   }
+--- })
+--- ```
 
 local util = require 'lspconfig.util'
 local lsp = vim.lsp
@@ -129,9 +147,7 @@ return {
     ---@diagnostic disable-next-line: assign-type-mismatch
     packageManager = nil,
     useESLintClass = false,
-    experimental = {
-      useFlatConfig = false,
-    },
+    experimental = {},
     codeActionOnSave = {
       enable = false,
       mode = 'all',
@@ -171,30 +187,6 @@ return {
         uri = root_dir,
         name = vim.fn.fnamemodify(root_dir, ':t'),
       }
-
-      -- Support flat config files
-      -- They contain 'config' in the file name
-      local flat_config_files = vim.tbl_filter(function(file)
-        return file:match('config')
-      end, eslint_config_files)
-
-      for _, file in ipairs(flat_config_files) do
-        local found_files = vim.fn.globpath(root_dir, file, true, true)
-
-        -- Filter out files inside node_modules
-        local filtered_files = {}
-        for _, found_file in ipairs(found_files) do
-          if string.find(found_file, '[/\\]node_modules[/\\]') == nil then
-            table.insert(filtered_files, found_file)
-          end
-        end
-
-        if #filtered_files > 0 then
-          config.settings.experimental = config.settings.experimental or {}
-          config.settings.experimental.useFlatConfig = true
-          break
-        end
-      end
 
       -- Support Yarn2 (PnP) projects
       local pnp_cjs = root_dir .. '/.pnp.cjs'


### PR DESCRIPTION
Fixes #4318

Problem: `experimental.useFlatConfig` forcefully turns on the logic to use a separate programmatic interface for flat config usage in ESLint. That interface was removed in ESLint v10 where flat config format is the only supported config format. But when the setting is turned on the language server still looks for that interface and fails when it can't find it. The end result is that language server turns off it's validation/diagnostics when used with ESLint v10.

Solution: do not turn on `experimental.useFlatConfig` setting based on the presence of flat config files. Instead use the default behavior of the language server which matches the ESLint's default behavior and let the user explicitly override it via config when necessary.