### PR TITLE
fix(pony_lsp)!: rename `pony_language_server` to `pony_lsp`

### DIFF
--- a/lsp/pony_language_server.lua
+++ b/lsp/pony_language_server.lua
@@ -1,12 +1,13 @@
 ---@brief
 ---
---- https://github.com/ponylang/pony-language-server
----
---- Language server for the Pony programming language
+--- Renamed to [pony_lsp](#pony_lsp)
 
 ---@type vim.lsp.Config
-return {
-  cmd = { 'pony-lsp' },
-  filetypes = { 'pony' },
-  root_markers = { 'corral.json', '.git' },
-}
+return vim.tbl_extend('force', vim.lsp.config.pony_lsp, {
+  on_init = function(...)
+    vim.deprecate('pony_language_server', 'pony_lsp', '3.0.0', 'nvim-lspconfig', false)
+    if vim.lsp.config.pony_lsp.on_init then
+      vim.lsp.config.pony_lsp.on_init(...)
+    end
+  end,
+})

--- a/lsp/pony_lsp.lua
+++ b/lsp/pony_lsp.lua
@@ -1,0 +1,24 @@
+---@brief
+---
+--- https://github.com/ponylang/ponyc/tree/main/tools/pony-lsp
+---
+--- Language server for the Pony programming language
+
+--- default settings for pony-lsp
+local function default_settings()
+  ---@type table{ defines: string[], ponypath: string[] }
+  return {
+    defines = {},
+    ponypath = {},
+  }
+end
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'pony-lsp' },
+  filetypes = { 'pony' },
+  root_markers = { 'corral.json', '.git' },
+  settings = {
+    ['pony-lsp'] = default_settings(),
+  },
+}


### PR DESCRIPTION
The pony_language_server has been moved into the main ponyc repository and has been called `pony-lsp` in there https://github.com/ponylang/ponyc/tree/main/tools/pony-lsp

This PR adapts the lspconfig entry to the same effect. It is considered less confusing for people to find the pony-lsp under `pony_lsp`, rather than `pony_language_server`