### PR TITLE
docs: add short description to doc title

### DIFF
--- a/doc/lspconfig.txt
+++ b/doc/lspconfig.txt
@@ -1,6 +1,5 @@
-*lspconfig.txt*         For Nvim version 0.10+
-
-nvim-lspconfig provides user-contributed configs for the Nvim |lsp| client.
+*lspconfig.txt*            User-contributed configs for the Nvim |lsp| client
+                                                       For Nvim version 0.10+
 
                                       Type |gO| to see the table of contents.
 

--- a/scripts/docs_template.txt
+++ b/scripts/docs_template.txt
@@ -1,4 +1,4 @@
-*lspconfig-all*
+*lspconfig-all*                     All configurations provided by |lspconfig|
 
 LSP configurations provided by nvim-lspconfig are listed below.
 


### PR DESCRIPTION
### Problem
Vimdocs didn't have a short description that shows up in `:h local-additions`.

### Solution
Add it to both docs.
