### PR TITLE
fix(rust_analyzer): pass environment in rust-analyzer.runSingle

### DIFF
--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -144,7 +144,7 @@ return {
         vim.list_extend(cmd, { '--', unpack(r.args.executableArgs) })
       end
 
-      local proc = vim.system(cmd, { cwd = r.args.cwd })
+      local proc = vim.system(cmd, { cwd = r.args.cwd, env = r.args.environment })
 
       local result = proc:wait()
 


### PR DESCRIPTION
When rust-analyzer wants to invoke cargo (eg, when the user uses code lenses), it sends a Command to nvim. this Command contains environment info that we're currently ignoring (ie, RUSTC_TOOLCHAIN). With this change, we forward the environment variables that rust-analyzer wants to set to the spawned process.