### PR TITLE
feat(roslyn_ls): use official roslyn binary name as fallback

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -113,7 +113,8 @@ return {
   name = 'roslyn_ls',
   offset_encoding = 'utf-8',
   cmd = {
-    vim.fn.executable('Microsoft.CodeAnalysis.LanguageServer') == 1 and 'Microsoft.CodeAnalysis.LanguageServer' or 'roslyn-language-server',
+    vim.fn.executable('Microsoft.CodeAnalysis.LanguageServer') == 1 and 'Microsoft.CodeAnalysis.LanguageServer'
+      or 'roslyn-language-server',
     '--logLevel',
     'Information',
     '--extensionLogDirectory',


### PR DESCRIPTION
As mentioned here (https://github.com/mason-org/mason-registry/pull/6330#issuecomment-3971724747), there is a change (https://github.com/dotnet/roslyn/pull/82201/changes) that the official language server can be easily installed via `dotnet` cli.

This change uses it's binary name per default.