### PR TITLE
fix(pyrefly): schedule vim.notify in on_exit

### DIFF
--- a/lsp/pyrefly.lua
+++ b/lsp/pyrefly.lua
@@ -21,6 +21,8 @@ return {
     '.git',
   },
   on_exit = function(code, _, _)
-    vim.notify('Closing Pyrefly LSP exited with code: ' .. code, vim.log.levels.INFO)
+    vim.schedule(function()
+      vim.notify('Closing Pyrefly LSP exited with code: ' .. code, vim.log.levels.INFO)
+    end)
   end,
 }


### PR DESCRIPTION
This fixes the following error

> E5560: nvim_echo must not be called in a fast event context

when LspDetach triggered for pyrefly

Similar to https://github.com/neovim/nvim-lspconfig/pull/3860