### PR TITLE
fix(rust_analyzer): recognize std lib sources in sysroot

### DIFF
--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -35,6 +35,33 @@ local function reload_workspace(bufnr)
   end
 end
 
+local function user_sysroot_src()
+  return vim.tbl_get(vim.lsp.config['rust_analyzer'], 'settings', 'rust-analyzer', 'cargo', 'sysrootSrc')
+end
+
+local function default_sysroot_src()
+  local sysroot = vim.tbl_get(vim.lsp.config['rust_analyzer'], 'settings', 'rust-analyzer', 'cargo', 'sysroot')
+  if not sysroot then
+    local rustc = os.getenv 'RUSTC' or 'rustc'
+    local result = vim.system({ rustc, '--print', 'sysroot' }, { text = true }):wait()
+
+    local stdout = result.stdout
+    if result.code == 0 and stdout then
+      if string.sub(stdout, #stdout) == '\n' then
+        if #stdout > 1 then
+          sysroot = string.sub(stdout, 1, #stdout - 1)
+        else
+          sysroot = ''
+        end
+      else
+        sysroot = stdout
+      end
+    end
+  end
+
+  return sysroot and vim.fs.joinpath(sysroot, 'lib/rustlib/src/rust/library') or nil
+end
+
 local function is_library(fname)
   local user_home = vim.fs.normalize(vim.env.HOME)
   local cargo_home = os.getenv 'CARGO_HOME' or user_home .. '/.cargo'
@@ -44,8 +71,10 @@ local function is_library(fname)
   local rustup_home = os.getenv 'RUSTUP_HOME' or user_home .. '/.rustup'
   local toolchains = rustup_home .. '/toolchains'
 
-  for _, item in ipairs { toolchains, registry, git_registry } do
-    if vim.fs.relpath(item, fname) then
+  local sysroot_src = user_sysroot_src() or default_sysroot_src()
+
+  for _, item in ipairs { toolchains, registry, git_registry, sysroot_src } do
+    if item and vim.fs.relpath(item, fname) then
       local clients = vim.lsp.get_clients { name = 'rust_analyzer' }
       return #clients > 0 and clients[#clients].config.root_dir or nil
     end


### PR DESCRIPTION
Problem:
System installed sources of Rust standard library are not detected as library sources.

Solution:
Add sources location to paths used for library check. See also: https://rust-analyzer.github.io/book/configuration.html#cargo.sysrootSrc

Fixes #4337