### PR TITLE
fix(slangd): add slangd specific root markers

### DIFF
--- a/lsp/slangd.lua
+++ b/lsp/slangd.lua
@@ -27,5 +27,5 @@
 return {
   cmd = { 'slangd' },
   filetypes = { 'hlsl', 'shaderslang' },
-  root_markers = { '.git' },
+  root_markers = { 'slangdconfig.json', '.clang-format', '.git' },
 }


### PR DESCRIPTION
Problem:
Currently the only root marker for slangd is .git

Solution:
As mentioned [here](https://github.com/shader-slang/slang-vs-extension?tab=readme-ov-file#configurations), slangdconfig.json and .clangformat could be used as root markers