### PR TITLE
feat: mpls

### DIFF
--- a/lsp/mpls.lua
+++ b/lsp/mpls.lua
@@ -21,6 +21,7 @@ return {
       pattern = { '*.md' },
       group = vim.api.nvim_create_augroup('lspconfig.mpls.focus', { clear = true }),
       callback = function(ctx)
+        ---@diagnostic disable-next-line:param-type-mismatch
         client:notify('mpls/editorDidChangeFocus', { uri = ctx.match })
       end,
       desc = 'mpls: notify buffer focus changed',


### PR DESCRIPTION
This PR adds the [mpls](https://github.com/mhersson/mpls) (Markdown Preview Language Server) config.
The project meet the criteria for a new config with 180+ GitHub stars.

Regarding the config itself:

- The `LspMplsOpenPreview` command open the Markdown preview in the default browser.
- The autocmd ensures the preview focus the correct buffer when entering a new buffer.