### PR TITLE
fix(roslyn_ls): navigation in macos decompiled files

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -121,6 +121,12 @@ return {
     fs.joinpath(uv.os_tmpdir(), 'roslyn_ls/logs'),
     '--stdio',
   },
+
+  cmd_env = {
+    -- Fixes LSP navigation in decompiled files for systems with symlinked TMPDIR (macOS)
+    TMPDIR = vim.env.TMPDIR and vim.env.TMPDIR ~= '' and vim.fn.resolve(vim.env.TMPDIR) or nil,
+  },
+
   filetypes = { 'cs' },
   handlers = roslyn_handlers(),
 


### PR DESCRIPTION
Fixes LSP navigation in decompiled files for systems with symlinked TMPDIR (macOS)