### PR TITLE
fix: skip buffers with URI schemes in root_dir

### DIFF
--- a/lsp/matlab_ls.lua
+++ b/lsp/matlab_ls.lua
@@ -20,6 +20,9 @@ return {
   cmd = { 'matlab-language-server', '--stdio' },
   filetypes = { 'matlab' },
   root_dir = function(bufnr, on_dir)
+    if vim.api.nvim_buf_get_name(bufnr):match('^%a+://') then
+      return
+    end
     local root_dir = vim.fs.root(bufnr, '.git')
     on_dir(root_dir or vim.fn.getcwd())
   end,

--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -84,6 +84,9 @@ return {
     'typescriptreact',
   },
   root_dir = function(bufnr, on_dir)
+    if vim.api.nvim_buf_get_name(bufnr):match('^%a+://') then
+      return
+    end
     -- The project root is where the LSP can be started from
     -- As stated in the documentation above, this LSP supports monorepos and simple projects.
     -- We select then from the project root, which is identified by the presence of a package

--- a/lsp/tsgo.lua
+++ b/lsp/tsgo.lua
@@ -61,6 +61,9 @@ return {
     'typescriptreact',
   },
   root_dir = function(bufnr, on_dir)
+    if vim.api.nvim_buf_get_name(bufnr):match('^%a+://') then
+      return
+    end
     -- The project root is where the LSP can be started from
     -- As stated in the documentation above, this LSP supports monorepos and simple projects.
     -- We select then from the project root, which is identified by the presence of a package

--- a/lsp/vtsls.lua
+++ b/lsp/vtsls.lua
@@ -80,6 +80,9 @@ return {
     'typescriptreact',
   },
   root_dir = function(bufnr, on_dir)
+    if vim.api.nvim_buf_get_name(bufnr):match('^%a+://') then
+      return
+    end
     -- The project root is where the LSP can be started from
     -- As stated in the documentation above, this LSP supports monorepos and simple projects.
     -- We select then from the project root, which is identified by the presence of a package


### PR DESCRIPTION
## Problem

Some LSP configs implement a custom `root_dir` function that unconditionally
calls `on_dir(project_root or vim.fn.getcwd())`. When no project root is found,
this falls back to `getcwd()`, causing the LSP to attach to _any_ buffer of a
matching filetype including buffers with non-file URI schemes such as
`fugitive://` (vim-fugitive).

Once attached, the LSP sends requests using the `fugitive://` URI, which is not
a valid `file://` URI and causes errors.

The affected configs are `ts_ls`, `tsgo`, `vtsls`, and `matlab_ls`.

Configs that use `root_markers` only (e.g. `lua_ls`, `ruby_lsp`) are naturally
safe because `vim.fs.root()` returns `nil` for non-file buffers, so `on_dir` is
never called.

## Solution

Add a guard at the top of each affected `root_dir` function that returns early
when the buffer name starts with a URI scheme:

```lua
if vim.api.nvim_buf_get_name(bufnr):match('^%a+://') then
    return
end
```

From my understanding, neovim buffer names are always plain paths (e.g.
/home/user/file.ts) for real files, never file:// URIs, so this guard only
skips genuinely non-file buffers.

I don't think the early returns trigger false positives but for sure let me know if they do.
