### PR TITLE
feat: stan_ls

### DIFF
--- a/lsp/stan_ls.lua
+++ b/lsp/stan_ls.lua
@@ -1,0 +1,13 @@
+---@brief
+---
+--- https://github.com/tomatitito/stan-language-server
+---
+--- Language server for the Stan probabilistic programming language.
+---
+---@type vim.lsp.Config
+return {
+  cmd = { 'stan-language-server', '--stdio' },
+  filetypes = { 'stan' },
+  root_markers = { '.git' },
+  settings = {},
+}


### PR DESCRIPTION
This PR adds the [Stan language server](https://github.com/tomatitito/stan-language-server) config. 

While the language server linked here does not meet the typical 100 star threshold, the [Stan](https://github.com/stan-dev) organization is well-established, the [Stan paper](https://www.jstatsoft.org/article/view/v076i01/0) has many thousands of citations, and the community has had an active [forum](https://discourse.mc-stan.org/) for years.

This language server is [supported](https://discourse.mc-stan.org/t/now-available-a-stan-language-server/40448) by members of the core development team.