### PR TITLE
feat: vimdoc_ls config

### DIFF
--- a/lsp/vimdoc_ls.lua
+++ b/lsp/vimdoc_ls.lua
@@ -1,0 +1,18 @@
+---@brief
+---
+--- https://github.com/barrettruth/vimdoc-language-server
+---
+--- Language server for vim help files (vimdoc).
+---
+--- `vimdoc-language-server` can be installed via `cargo`:
+--- ```sh
+--- cargo install vimdoc-language-server
+--- ```
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'vimdoc-language-server' },
+  filetypes = { 'help' },
+  root_markers = { 'doc', '.git' },
+  workspace_required = false,
+}


### PR DESCRIPTION
## Problem

No LSP config exists for vimdoc (vim help) files.

## Solution

Add config for [`vimdoc-language-server`](https://github.com/barrettruth/vimdoc-language-server), an LSP for vim help files that provides formatting, diagnostics, document symbols, go-to-definition, and more.