### PR TITLE
New versions of nextflow_ls moving from nextflow-language-server-all.jar to nextflow-language-server

### DIFF
--- a/lsp/nextflow_ls.lua
+++ b/lsp/nextflow_ls.lua
@@ -11,7 +11,7 @@
 ---
 --- ```lua
 --- vim.lsp.config('nextflow_ls', {
----     cmd = { 'java', '-jar', 'nextflow-language-server-all.jar' },
+---     cmd = { 'nextflow-language-server' },
 ---     filetypes = { 'nextflow' },
 ---     settings = {
 ---       nextflow = {
@@ -25,7 +25,7 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'java', '-jar', 'nextflow-language-server-all.jar' },
+  cmd = { 'nextflow-language-server' },
   filetypes = { 'nextflow' },
   root_markers = { 'nextflow.config', '.git' },
   settings = {


### PR DESCRIPTION
They recently moved to use a `nextflow-language-server` (actually a wrapper that runs a jar). This way, it ensures lsp continues with minimal user intervention. /cc https://github.com/nextflow-io/language-server/issues/56