### PR TITLE
Change tab width from 8 to 2 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 indent_style = space
 indent_size = 2
-tab_width = 8
+tab_width = 2
 end_of_line = lf
 insert_final_newline = true
 


### PR DESCRIPTION
for lsp/*.lua the tab should be set to 2
if I use indent highlight plugin

set tabstop = 8 cause

<img width="567" height="623" alt="截屏2026-03-19 18 19 27" src="https://github.com/user-attachments/assets/639d6907-a260-4c89-bbd2-319c189e0327" />
