### PR TITLE
Remove improper offset encoding in roslyn_ls default config.

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -111,7 +111,6 @@ end
 ---@type vim.lsp.Config
 return {
   name = 'roslyn_ls',
-  offset_encoding = 'utf-8',
   cmd = {
     vim.fn.executable('Microsoft.CodeAnalysis.LanguageServer') == 1 and 'Microsoft.CodeAnalysis.LanguageServer'
       or 'roslyn-language-server',


### PR DESCRIPTION
Setting `offset_encoding` to `utf-8` is causing problem. See discussion at https://github.com/neovim/neovim/discussions/38375.

According to LSP specification 3.17, when `positionEncoding` is not specified in server capability, it's value should be assumed to be `utf-16`, see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#serverCapabilities.

roslyn_ls does not response `positionEncoding` in initialize result (version `5.4.0-2.26162.5+e11fbc2bc8292680a92d731e5d9a6c7ee229262d`). One can verify this by setting LSP log level to debug, and read LSP log.

So, setting `offset_encoding` in default config is a mistake.