### PR TITLE
fix: prevent file leak in `root_markers_with_field()`

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -63,12 +63,14 @@ function M.root_markers_with_field(root_files, new_names, field, fname)
 
   for _, f in ipairs(found or {}) do
     -- Match the given `field`.
-    for line in io.lines(f) do
+    local file = assert(io.open(f, 'r'))
+    for line in file:lines() do
       if line:find(field) then
         root_files[#root_files + 1] = vim.fs.basename(f)
         break
       end
     end
+    file:close()
   end
 
   return root_files


### PR DESCRIPTION
Problem:
Files related to language servers would stay locked (for me, `package.json` would be locked by the `tailwindcss` language server until it was killed).

Solution:
I'm pretty sure there is a file leak in the `root_markers_with_field()` function because the `io:lines` loop is broken if the field is found and the file is not closed properly. Explicitly closing the file fixed it for me...