### PR TITLE
fix: Set biome root for projects without package managers

### DIFF
--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -50,6 +50,8 @@ return {
       'bun.lockb',
       'bun.lock',
       'deno.lock',
+      'biome.json',
+      'biome.jsonc',
     }
     -- Give the root markers equal priority by wrapping them in a table
     root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers, { '.git' } }


### PR DESCRIPTION
Heyo,

First up, thanks for lspconfig :). Much appreciated!

The current biome project root logic uses JS package manager lockfiles to get the project root in mono repos.

If one is not using any JS (wasm) and raw CSS, that doesn't work out. In those cases, only a biome.json exists as a marker on where the frontend's project root inside the mono repo may be located.

Cheers