### PR TITLE
ci: disable docgen in forks

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   docgen:
+    if: github.repository == 'neovim/nvim-lspconfig'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Problem:
docgen runs on PRs:
https://github.com/neovim/nvim-lspconfig/pull/4351#issuecomment-4114995138

Solution:
Check the org + repo name.