### PR TITLE
fix(roslyn_ls): add roslyn.client.fixAllCodeAction command handler

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -108,6 +108,59 @@ local function is_decompiled(bufname)
   return vim.fn.finddir(bufname:sub(1, endpos), uv.os_tmpdir()) ~= ''
 end
 
+---@param client vim.lsp.Client
+---@param action table
+local function apply_action(client, action)
+  if action.edit then
+    vim.lsp.util.apply_workspace_edit(action.edit, client.offset_encoding)
+  end
+  if action.command then
+    client:exec_cmd(action.command)
+  end
+end
+
+---@param client vim.lsp.Client
+---@param command table
+---@param bufnr integer
+local function handle_fix_all_action(client, command, bufnr)
+  local arg = command.arguments and command.arguments[1]
+  if type(arg) ~= 'table' then
+    vim.notify('roslyn_ls: invalid fixAllCodeAction arguments', vim.log.levels.ERROR)
+    return
+  end
+
+  local flavors = arg.FixAllFlavors
+  if type(flavors) ~= 'table' or vim.tbl_isempty(flavors) then
+    vim.notify('roslyn_ls: fixAllCodeAction has no FixAllFlavors', vim.log.levels.WARN)
+    return
+  end
+
+  vim.ui.select(flavors, {
+    prompt = 'Fix All Scope:',
+  }, function(chosen_scope)
+    if not chosen_scope then
+      return
+    end
+
+    client:request('codeAction/resolveFixAll', {
+      title = command.title,
+      data = arg,
+      scope = chosen_scope,
+    }, function(err, resolved)
+      if err then
+        vim.notify(
+          'roslyn_ls: fixAllCodeAction resolve error: ' .. (err.message or tostring(err)),
+          vim.log.levels.ERROR
+        )
+        return
+      end
+      if resolved then
+        apply_action(client, resolved)
+      end
+    end, bufnr)
+  end)
+end
+
 ---@type vim.lsp.Config
 return {
   name = 'roslyn_ls',
@@ -163,20 +216,6 @@ return {
         return
       end
 
-      local function apply_action(action)
-        if not action then
-          return
-        end
-
-        if action.edit then
-          vim.lsp.util.apply_workspace_edit(action.edit, client.offset_encoding)
-        end
-
-        if action.command then
-          client:exec_cmd(action.command)
-        end
-      end
-
       local function handle(action)
         if not action then
           return
@@ -188,18 +227,16 @@ return {
               vim.notify(err.message or tostring(err), vim.log.levels.ERROR)
               return
             end
-
             if resolved then
               handle(resolved)
             end
           end, ctx.bufnr)
-
           return
         end
 
         local nested = vim.islist(action) and action or action.NestedCodeActions
         if type(nested) ~= 'table' or vim.tbl_isempty(nested) then
-          apply_action(action)
+          apply_action(client, action)
           return
         end
 
@@ -225,46 +262,7 @@ return {
 
     ['roslyn.client.fixAllCodeAction'] = function(command, ctx)
       local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
-      local arg = command.arguments and command.arguments[1]
-
-      if type(arg) ~= 'table' then
-        vim.notify('roslyn_ls: invalid fixAllCodeAction arguments', vim.log.levels.ERROR)
-        return
-      end
-
-      local flavors = arg.FixAllFlavors
-      if type(flavors) ~= 'table' or vim.tbl_isempty(flavors) then
-        vim.notify('roslyn_ls: fixAllCodeAction has no FixAllFlavors', vim.log.levels.WARN)
-        return
-      end
-
-      vim.ui.select(flavors, {
-        prompt = 'Fix All Scope:',
-      }, function(chosen_scope)
-        if not chosen_scope then
-          return
-        end
-
-        client:request('codeAction/resolveFixAll', {
-          title = command.title,
-          data = arg,
-          scope = chosen_scope,
-        }, function(err, resolved)
-          if err then
-            vim.notify(
-              'roslyn_ls: fixAllCodeAction resolve error: ' .. (err.message or tostring(err)),
-              vim.log.levels.ERROR
-            )
-            return
-          end
-          if resolved and resolved.edit then
-            vim.lsp.util.apply_workspace_edit(resolved.edit, client.offset_encoding)
-          end
-          if resolved and resolved.command then
-            client:exec_cmd(resolved.command)
-          end
-        end, ctx.bufnr)
-      end)
+      handle_fix_all_action(client, command, ctx.bufnr)
     end,
   },
 


### PR DESCRIPTION
## Problem

When a `roslyn.client.fixAllCodeAction` command is sent by the Roslyn
language server, Neovim would display a warning:

    Language server `roslyn_ls` does not support command
    `roslyn.client.fixAllCodeAction`. This command may require a
    client extension.

This is because nvim-lspconfig had no handler registered for this command.

## Solution

Add a `roslyn.client.fixAllCodeAction` command handler that:

1. Presents the user with a `vim.ui.select` scope picker populated from
   the `FixAllFlavors` field sent by the server (`Document`, `Project`,
   `Solution`, `ContainingMember`, `ContainingType`).
2. Calls Roslyn's custom `codeAction/resolveFixAll` endpoint (not the
   standard `codeAction/resolve`) with the original action data untouched
   and the chosen scope as a top-level `scope` field, which is what the
   server's `CodeActionFixAllResolveHandler` expects.
3. Applies the resulting `workspace/edit` via `vim.lsp.util.apply_workspace_edit`.
