### PR TITLE
fix(ci): retry generator jobs

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -30,4 +30,11 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add doc/configs.md doc/configs.txt
         # Only commit and push if we have changes
-        git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push)
+        git diff --quiet && git diff --staged --quiet || (
+          git commit -m "${COMMIT_MSG}"
+          for i in 1 2 3; do
+            git pull --rebase && git push && break
+            echo "Push failed (attempt $i), retrying..."
+            sleep 5
+          done
+        )

--- a/.github/workflows/gen-annotations.yml
+++ b/.github/workflows/gen-annotations.yml
@@ -37,4 +37,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add README.md
           git add -A lua/lspconfig/types
-          git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push)
+          git diff --quiet && git diff --staged --quiet || (
+            git commit -m "${COMMIT_MSG}"
+            for i in 1 2 3; do
+              git pull --rebase && git push && break
+              echo "Push failed (attempt $i), retrying..."
+              sleep 5
+            done
+          )


### PR DESCRIPTION
Problem:
docgen fails if gen-annotations pushes before it:

    [master c2804a4] docs: update configs.md skip-checks: true
     2 files changed, 24 insertions(+), 20 deletions(-)
    To https://github.com/neovim/nvim-lspconfig
     ! [rejected]        master -> master (fetch first)
    error: failed to push some refs to 'https://github.com/neovim/nvim-lspconfig'
    hint: Updates were rejected because the remote contains work that you do not
    hint: have locally. This is usually caused by another repository pushing to

Solution:
If push fails, rebase and retry. The two workflows touch disjoint files so the rebase should alway resolve.