### PR TITLE
fix(ci): noisy version changes in generated docs

### DIFF
--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -242,12 +242,20 @@ local function make_lsp_sections(is_markdown)
         end,
       })
 
+      -- HACK: Avoid noisy "0.12.0-dev+…" version string (which changes often).
+      local old_version = vim.version
+      local v = vim.version()
+      vim.version = function()
+        return vim.version.parse(('%d.%d.%d'):format(v.major, v.minor, v.patch))
+      end
+
       make_lsp_section(config_sections, config_name, config_file, is_markdown)
 
       -- Reset.
       -- vim.env.HOME = old_home
       -- vim.env.XDG_CACHE_HOME = old_cache_home
       vim.fn = old_fn
+      vim.version = old_version
     end
   end
 


### PR DESCRIPTION
Problem:
The docgen script makes unwanted noise changes like this:

    diff --git a/doc/configs.md b/doc/configs.md
    index 25e2bc71d1..d8822ef0f4 100644
    --- a/doc/configs.md
    +++ b/doc/configs.md
    @@ -2481,11 +2481,11 @@ Default config:
       {
         editorInfo = {
           name = "Neovim",
    -      version = "0.12.0-dev+gc9e961994b"
    +      version = "0.12.0-dev+g925e9e8722"
         },
         editorPluginInfo = {
           name = "Neovim",
    -      version = "0.12.0-dev+gc9e961994b"
    +      version = "0.12.0-dev+g925e9e8722"
         }
       }
       ```

Solution:
During doc generation, patch vim.version to be less noisy.