### PR TITLE
ci: disable gen-annotations in forks

### DIFF
--- a/.github/workflows/gen-annotations.yml
+++ b/.github/workflows/gen-annotations.yml
@@ -2,6 +2,8 @@ name: gen-annotations
 
 on:
   push:
+    branches:
+      - master
     paths:
       - lsp/**
       - scripts/gen_json_schemas.lua
@@ -11,7 +13,7 @@ on:
 
 jobs:
   gen-annotations:
-    if: github.actor != 'github-actions[bot]'
+    if: github.actor != 'github-actions[bot]' && github.repository == 'neovim/nvim-lspconfig'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Problem:
gen-annotations runs on PRs.

Solution:
- Check the org + repo name.
- Trigger on "master" branch only.

related: d7c25c54406af9483edeab7e783d01f80e4f05e5 #4357