### PR TITLE
feat: make oxfmt support oxfmt.config.ts root marker

### DIFF
--- a/lsp/oxfmt.lua
+++ b/lsp/oxfmt.lua
@@ -48,8 +48,9 @@ return {
 
     -- Oxfmt resolves configuration by walking upward and using the nearest config file
     -- to the file being processed. We therefore compute the root directory by locating
-    -- the closest `.oxfmtrc.json` / `.oxfmtrc.jsonc` (or `package.json` fallback) above the buffer.
-    local root_markers = util.insert_package_json({ '.oxfmtrc.json', '.oxfmtrc.jsonc' }, 'oxfmt', fname)
+    -- the closest `.oxfmtrc.json` / `.oxfmtrc.jsonc` / `oxfmt.config.ts` (or `package.json` fallback) above the buffer.
+    local root_markers =
+      util.insert_package_json({ '.oxfmtrc.json', '.oxfmtrc.jsonc', 'oxfmt.config.ts' }, 'oxfmt', fname)
     on_dir(vim.fs.dirname(vim.fs.find(root_markers, { path = fname, upward = true })[1]))
   end,
 }


### PR DESCRIPTION
## Summary
Add `oxfmt.config.ts` to the `oxfmt` root markers used by `lsp/oxfmt.lua`

## Why
The Oxfmt formatter docs state that Oxfmt automatically looks for these config files when walking up the directory tree:
- `.oxfmtrc.json`
- `.oxfmtrc.jsonc`
- `oxfmt.config.ts`
At the moment, the `oxfmt` config in `nvim-lspconfig` only considers the two `.oxfmtrc.*` files when resolving `root_dir`. That means projects configured with `oxfmt.config.ts` may fail to resolve the correct workspace root.
Reference:
https://oxc.rs/docs/guide/usage/formatter/config.html