### PR TITLE
feat: zizmor

### DIFF
--- a/lsp/zizmor.lua
+++ b/lsp/zizmor.lua
@@ -1,0 +1,53 @@
+---@brief
+---
+--- https://github.com/zizmorcore/zizmor
+---
+--- Zizmor language server.
+---
+--- `zizmor` can be installed by following the instructions [here](https://docs.zizmor.sh/installation/).
+---
+--- The default `cmd` assumes that the `zizmor` binary can be found in `$PATH`.
+---
+--- See `zizmor`'s [documentation](https://docs.zizmor.sh/) for additional documentation.
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'zizmor', '--lsp' },
+  filetypes = { 'yaml' },
+
+  -- `root_dir` ensures that the LSP does not attach to all yaml files
+  root_dir = function(bufnr, on_dir)
+    local parent = vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr))
+    if
+      vim.endswith(parent, '/.github/workflows')
+      or vim.endswith(parent, '/.forgejo/workflows')
+      or vim.endswith(parent, '/.gitea/workflows')
+    then
+      on_dir(parent)
+    end
+  end,
+  handlers = {
+    ['actions/readFile'] = function(_, result)
+      if type(result.path) ~= 'string' then
+        return nil, nil
+      end
+      local file_path = vim.uri_to_fname(result.path)
+      if vim.fn.filereadable(file_path) == 1 then
+        local f = assert(io.open(file_path, 'r'))
+        local text = f:read('*a')
+        f:close()
+
+        return text, nil
+      end
+      return nil, nil
+    end,
+  },
+  init_options = {}, -- needs to be present https://github.com/neovim/nvim-lspconfig/pull/3713#issuecomment-2857394868
+  capabilities = {
+    workspace = {
+      didChangeWorkspaceFolders = {
+        dynamicRegistration = true,
+      },
+    },
+  },
+}

--- a/lsp/zizmor.lua
+++ b/lsp/zizmor.lua
@@ -17,31 +17,18 @@ return {
 
   -- `root_dir` ensures that the LSP does not attach to all yaml files
   root_dir = function(bufnr, on_dir)
-    local parent = vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr))
+    local bufname = vim.api.nvim_buf_get_name(bufnr)
+    local parent = vim.fs.dirname(bufname)
     if
       vim.endswith(parent, '/.github/workflows')
       or vim.endswith(parent, '/.forgejo/workflows')
       or vim.endswith(parent, '/.gitea/workflows')
+      or (vim.endswith(bufname, "/.github/dependabot.yml") or vim.endswith(bufname, "/.github/dependabot.yaml"))
+      or vim.endswith(bufname, 'actions.yml') -- Composite actions can live in any repository subdirectory
     then
       on_dir(parent)
     end
   end,
-  handlers = {
-    ['actions/readFile'] = function(_, result)
-      if type(result.path) ~= 'string' then
-        return nil, nil
-      end
-      local file_path = vim.uri_to_fname(result.path)
-      if vim.fn.filereadable(file_path) == 1 then
-        local f = assert(io.open(file_path, 'r'))
-        local text = f:read('*a')
-        f:close()
-
-        return text, nil
-      end
-      return nil, nil
-    end,
-  },
   init_options = {}, -- needs to be present https://github.com/neovim/nvim-lspconfig/pull/3713#issuecomment-2857394868
   capabilities = {
     workspace = {

--- a/lsp/zizmor.lua
+++ b/lsp/zizmor.lua
@@ -23,7 +23,7 @@ return {
       vim.endswith(parent, '/.github/workflows')
       or vim.endswith(parent, '/.forgejo/workflows')
       or vim.endswith(parent, '/.gitea/workflows')
-      or (vim.endswith(bufname, "/.github/dependabot.yml") or vim.endswith(bufname, "/.github/dependabot.yaml"))
+      or (vim.endswith(bufname, '/.github/dependabot.yml') or vim.endswith(bufname, '/.github/dependabot.yaml'))
       or vim.endswith(bufname, 'action.yml') -- Composite actions can live in any repository subdirectory
     then
       on_dir(parent)

--- a/lsp/zizmor.lua
+++ b/lsp/zizmor.lua
@@ -24,7 +24,7 @@ return {
       or vim.endswith(parent, '/.forgejo/workflows')
       or vim.endswith(parent, '/.gitea/workflows')
       or (vim.endswith(bufname, "/.github/dependabot.yml") or vim.endswith(bufname, "/.github/dependabot.yaml"))
-      or vim.endswith(bufname, 'actions.yml') -- Composite actions can live in any repository subdirectory
+      or vim.endswith(bufname, 'action.yml') -- Composite actions can live in any repository subdirectory
     then
       on_dir(parent)
     end


### PR DESCRIPTION
This PR adds support for [zizmor](https://github.com/zizmorcore/zizmor), a static analysis tool for GitHub Actions.

There have been a number of supply chain attacks recently that have me thinking about security, and some colleagues have recommended zizmor for catching some of the more common things (like pinning action versions). I saw that it has an experimental LSP mode, so I've added it here.

This is basically a copy of what is already in https://github.com/neovim/nvim-lspconfig/blob/master/lsp/gh_actions_ls.lua, except the docs and cmd have been updated to refer to zizmor rather than the github actions language server. That means that only github actions files are targeted, using the same machinery as `gh_actions_ls` already uses. For clarity, github actions LS provides completion, definitions, etc for github actions files while zizmor [focuses on security-related concerns](https://docs.zizmor.sh/audits/), so they cover different use cases.

Right now, the project has 4.1k stars and is very active, so it meets the criteria for being added as a supported language server here, but I will note that zizmor's LSP mode is experimental. There's a [meta-issue tracking LSP work here](https://github.com/zizmorcore/zizmor/issues/986) for anyone interested.