### PR TITLE
feat: add Lateralus language server configuration

### DIFF
--- a/lsp/lateralus_ls.lua
+++ b/lsp/lateralus_ls.lua
@@ -1,0 +1,81 @@
+---@brief
+---
+--- https://github.com/bad-antics/lateralus-lang
+---
+--- Lateralus Language Server, providing IDE features for the Lateralus programming language.
+---
+--- The language server can be installed via:
+--- ```sh
+--- curl -fsSL https://lateralus.dev/install.sh | sh
+--- ```
+---
+--- Or via cargo:
+--- ```sh
+--- cargo install lateralus-lsp
+--- ```
+---
+--- Configuration:
+--- ```lua
+--- vim.lsp.config('lateralus_ls', {
+---   settings = {
+---     lateralus = {
+---       inlayHints = {
+---         enable = true,
+---         typeHints = true,
+---         parameterHints = true,
+---       },
+---       diagnostics = {
+---         enable = true,
+---       },
+---       completion = {
+---         autoImport = true,
+---       }
+---     }
+---   }
+--- })
+--- ```
+
+return {
+  cmd = { 'lateralus-lsp' },
+  filetypes = { 'lateralus' },
+  root_markers = { 'lateralus.toml', '.git' },
+  settings = {
+    lateralus = {
+      inlayHints = {
+        enable = true,
+        typeHints = true,
+        parameterHints = true,
+      },
+      diagnostics = {
+        enable = true,
+      },
+      completion = {
+        autoImport = true,
+      }
+    }
+  },
+  docs = {
+    description = [[
+https://github.com/bad-antics/lateralus-lang
+
+Lateralus Language Server provides full IDE support for the Lateralus programming language,
+including semantic highlighting, code completion, go-to-definition, hover documentation,
+rename refactoring, and inlay hints.
+
+Features:
+- Semantic syntax highlighting
+- Code completion with auto-import
+- Go to definition/references
+- Hover documentation
+- Rename refactoring
+- Inlay type hints
+- Code actions and quick fixes
+- Workspace symbol search
+
+Installation:
+```sh
+curl -fsSL https://lateralus.dev/install.sh | sh
+```
+]],
+  },
+}


### PR DESCRIPTION
## Add Lateralus Language Server

This PR adds configuration for the [Lateralus Language Server](https://github.com/bad-antics/lateralus-lang), the official LSP implementation for the Lateralus programming language.

### Language Server Info

- **Name**: lateralus-lsp
- **Repository**: https://github.com/bad-antics/lateralus-lang
- **Protocol**: LSP 3.17
- **Registered on langserver.org**: [Yes](https://langserver.org/#lateralus-lsp)

### Installation

```sh
curl -fsSL https://lateralus.dev/install.sh | sh
# or
cargo install lateralus-lsp
```

### Supported Features

- ✅ Semantic syntax highlighting
- ✅ Code completion with auto-import
- ✅ Go to definition/references
- ✅ Hover documentation
- ✅ Rename refactoring
- ✅ Inlay hints (type hints, parameter hints)
- ✅ Code actions and quick fixes
- ✅ Workspace symbol search
- ✅ Formatting

### Configuration

```lua
vim.lsp.config('lateralus_ls', {
  settings = {
    lateralus = {
      inlayHints = { enable = true },
      diagnostics = { enable = true },
      completion = { autoImport = true }
    }
  }
})
```

### Files

| Filetype | Extensions |
|----------|------------|
| lateralus | .ltl |

### Root Markers

- `lateralus.toml` (project manifest)
- `.git`
