### PR TITLE
feat: use node_modules local executable if available

### DIFF
--- a/lsp/astro.lua
+++ b/lsp/astro.lua
@@ -47,7 +47,16 @@ local util = require 'lspconfig.util'
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'astro-ls', '--stdio' },
+  cmd = function(dispatchers, config)
+    local cmd = 'astro-ls'
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
+    end
+    return vim.lsp.rpc.start({ cmd, '--stdio' }, dispatchers)
+  end,
   filetypes = { 'astro' },
   root_markers = { 'package.json', 'tsconfig.json', 'jsconfig.json', '.git' },
   init_options = {

--- a/lsp/biome.lua
+++ b/lsp/biome.lua
@@ -17,9 +17,11 @@ local util = require 'lspconfig.util'
 return {
   cmd = function(dispatchers, config)
     local cmd = 'biome'
-    local local_cmd = (config or {}).root_dir and config.root_dir .. '/node_modules/.bin/biome'
-    if local_cmd and vim.fn.executable(local_cmd) == 1 then
-      cmd = local_cmd
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
     end
     return vim.lsp.rpc.start({ cmd, 'lsp-proxy' }, dispatchers)
   end,

--- a/lsp/cssls.lua
+++ b/lsp/cssls.lua
@@ -22,7 +22,16 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'vscode-css-language-server', '--stdio' },
+  cmd = function(dispatchers, config)
+    local cmd = 'vscode-css-language-server'
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
+    end
+    return vim.lsp.rpc.start({ cmd, '--stdio' }, dispatchers)
+  end,
   filetypes = { 'css', 'scss', 'less' },
   init_options = { provideFormatter = true }, -- needed to enable formatting capabilities
   root_markers = { 'package.json', '.git' },

--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -77,7 +77,16 @@ local eslint_config_files = {
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'vscode-eslint-language-server', '--stdio' },
+  cmd = function(dispatchers, config)
+    local cmd = 'vscode-eslint-language-server'
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
+    end
+    return vim.lsp.rpc.start({ cmd, '--stdio' }, dispatchers)
+  end,
   filetypes = {
     'javascript',
     'javascriptreact',

--- a/lsp/glint.lua
+++ b/lsp/glint.lua
@@ -25,10 +25,15 @@
 ---@type vim.lsp.Config
 return {
   cmd = function(dispatchers, config)
+    local cmd = 'glint-language-server'
     ---@diagnostic disable-next-line: undefined-field
-    local cmd = (config.init_options.glint.useGlobal or not config.root_dir) and { 'glint-language-server' }
-      or { config.root_dir .. '/node_modules/.bin/glint-language-server' }
-    return vim.lsp.rpc.start(cmd, dispatchers)
+    if not config.init_options.glint.useGlobal and (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
+    end
+    return vim.lsp.rpc.start({ cmd }, dispatchers)
   end,
   init_options = {
     glint = {

--- a/lsp/html.lua
+++ b/lsp/html.lua
@@ -24,7 +24,16 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'vscode-html-language-server', '--stdio' },
+  cmd = function(dispatchers, config)
+    local cmd = 'vscode-html-language-server'
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
+    end
+    return vim.lsp.rpc.start({ cmd, '--stdio' }, dispatchers)
+  end,
   filetypes = { 'html' },
   root_markers = { 'package.json', '.git' },
   ---@type lspconfig.settings.html

--- a/lsp/jsonls.lua
+++ b/lsp/jsonls.lua
@@ -23,7 +23,16 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'vscode-json-language-server', '--stdio' },
+  cmd = function(dispatchers, config)
+    local cmd = 'vscode-json-language-server'
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
+    end
+    return vim.lsp.rpc.start({ cmd, '--stdio' }, dispatchers)
+  end,
   filetypes = { 'json', 'jsonc' },
   init_options = {
     provideFormatter = true,

--- a/lsp/oxfmt.lua
+++ b/lsp/oxfmt.lua
@@ -17,9 +17,11 @@ local util = require 'lspconfig.util'
 return {
   cmd = function(dispatchers, config)
     local cmd = 'oxfmt'
-    local local_cmd = (config or {}).root_dir and config.root_dir .. '/node_modules/.bin/oxfmt'
-    if local_cmd and vim.fn.executable(local_cmd) == 1 then
-      cmd = local_cmd
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
     end
     return vim.lsp.rpc.start({ cmd, '--lsp' }, dispatchers)
   end,

--- a/lsp/oxlint.lua
+++ b/lsp/oxlint.lua
@@ -32,9 +32,11 @@ end
 return {
   cmd = function(dispatchers, config)
     local cmd = 'oxlint'
-    local local_cmd = (config or {}).root_dir and config.root_dir .. '/node_modules/.bin/oxlint'
-    if local_cmd and vim.fn.executable(local_cmd) == 1 then
-      cmd = local_cmd
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
     end
     return vim.lsp.rpc.start({ cmd, '--lsp' }, dispatchers)
   end,

--- a/lsp/rome.lua
+++ b/lsp/rome.lua
@@ -12,7 +12,16 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'rome', 'lsp-proxy' },
+  cmd = function(dispatchers, config)
+    local cmd = 'rome'
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
+    end
+    return vim.lsp.rpc.start({ cmd, 'lsp-proxy' }, dispatchers)
+  end,
   filetypes = {
     'javascript',
     'javascriptreact',

--- a/lsp/tailwindcss.lua
+++ b/lsp/tailwindcss.lua
@@ -12,7 +12,16 @@ local util = require('lspconfig.util')
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'tailwindcss-language-server', '--stdio' },
+  cmd = function(dispatchers, config)
+    local cmd = 'tailwindcss-language-server'
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
+    end
+    return vim.lsp.rpc.start({ cmd, '--stdio' }, dispatchers)
+  end,
   -- filetypes copied and adjusted from tailwindcss-intellisense
   filetypes = {
     -- html

--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -76,7 +76,16 @@
 ---@type vim.lsp.Config
 return {
   init_options = { hostInfo = 'neovim' },
-  cmd = { 'typescript-language-server', '--stdio' },
+  cmd = function(dispatchers, config)
+    local cmd = 'typescript-language-server'
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
+    end
+    return vim.lsp.rpc.start({ cmd, '--stdio' }, dispatchers)
+  end,
   filetypes = {
     'javascript',
     'javascriptreact',

--- a/lsp/tsgo.lua
+++ b/lsp/tsgo.lua
@@ -63,9 +63,11 @@ return {
   },
   cmd = function(dispatchers, config)
     local cmd = 'tsgo'
-    local local_cmd = (config or {}).root_dir and config.root_dir .. '/node_modules/.bin/tsgo'
-    if local_cmd and vim.fn.executable(local_cmd) == 1 then
-      cmd = local_cmd
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
     end
     return vim.lsp.rpc.start({ cmd, '--lsp', '--stdio' }, dispatchers)
   end,

--- a/lsp/yamlls.lua
+++ b/lsp/yamlls.lua
@@ -61,7 +61,16 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'yaml-language-server', '--stdio' },
+  cmd = function(dispatchers, config)
+    local cmd = 'yaml-language-server'
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
+    end
+    return vim.lsp.rpc.start({ cmd, '--stdio' }, dispatchers)
+  end,
   filetypes = { 'yaml', 'yaml.docker-compose', 'yaml.gitlab', 'yaml.helm-values' },
   root_markers = { '.git' },
   ---@type lspconfig.settings.yamlls


### PR DESCRIPTION
In a similar vein to #3957, this PR allows the use of local `node_modules` executables for some of the most common tools in the JS ecosystem.

Some of the tools already had support for this (`biome`,  `glint`, `oxfmt`, `oxlint` and `tsgo`), so for these the code was just slightly refactored to use the new `lspconfig.utils` function `get_node_modules_executable`.