### PR TITLE
fix(gdscript): remove nonexistent filetypes

### DIFF
--- a/doc/configs.md
+++ b/doc/configs.md
@@ -4730,7 +4730,7 @@ Default config:
 - `cmd`: [../lsp/gdscript.lua:11](../lsp/gdscript.lua#L11)
 - `filetypes` :
   ```lua
-  { "gd", "gdscript", "gdscript3" }
+  { "gdscript" }
   ```
 - `root_markers` :
   ```lua

--- a/doc/configs.txt
+++ b/doc/configs.txt
@@ -3352,7 +3352,7 @@ Snippet to enable the language server: >lua
 Default config:
 - cmd (use "gF" to view): ../lsp/gdscript.lua:11
 - filetypes: >lua
-  { "gd", "gdscript", "gdscript3" }
+  { "gdscript" }
 - root_markers: >lua
   { "project.godot", ".git" }
 <

--- a/lsp/gdscript.lua
+++ b/lsp/gdscript.lua
@@ -10,6 +10,6 @@ local cmd = vim.lsp.rpc.connect('127.0.0.1', tonumber(port))
 ---@type vim.lsp.Config
 return {
   cmd = cmd,
-  filetypes = { 'gd', 'gdscript', 'gdscript3' },
+  filetypes = { 'gdscript' },
   root_markers = { 'project.godot', '.git' },
 }


### PR DESCRIPTION
Problem:
'gd' and 'gdscript3' are file extentions, not filetypes (as per the result of running `getcompletion('', 'filetype')` command in neovim

Solution:
Remove them, leaving only 'gdscript'