### PR TITLE
fix(golangci_lint_ls): guard against missing `golangci-lint` in `before_init`

### DIFF
--- a/lsp/golangci_lint_ls.lua
+++ b/lsp/golangci_lint_ls.lua
@@ -47,6 +47,11 @@ return {
   before_init = function(_, config)
     -- Add support for golangci-lint V1 (in V2 `--out-format=json` was replaced by
     -- `--output.json.path=stdout`).
+
+    if vim.fn.executable('golangci-lint') ~= 1 then
+      return
+    end
+
     local v1, v2 = false, false
     -- PERF: `golangci-lint version` is very slow (about 0.1 sec) so let's find
     -- version using `go version -m $(which golangci-lint) | grep '^\smod'`.


### PR DESCRIPTION
Problem:
`before_init` errors if `golangci-lint` is not in `$PATH`.

Solution:
Return early when the executable is not available to avoid raising an error.