### PR TITLE
feat(groovyls): use groovy-language-server from $PATH

### DIFF
--- a/lsp/groovyls.lua
+++ b/lsp/groovyls.lua
@@ -20,11 +20,14 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = {
-    'java',
-    '-jar',
-    'groovy-language-server-all.jar',
-  },
+  -- When installed via mason
+  cmd = { 'groovy-language-server' },
+  -- If installed/built locally, please provide the correct filepath to Java.
+  -- cmd = {
+  --   'java',
+  --   '-jar',
+  --   'groovy-language-server-all.jar',
+  -- },
   filetypes = { 'groovy' },
   root_markers = { 'Jenkinsfile', '.git' },
 }


### PR DESCRIPTION
I'd say most people will be using mason to install this. Anyway I'm not sure what was there before would work as the path would require the jar to be on your/neovim's path, I think, which won't be the case for something you download manually/or build locally so you'd have to move it there in which case creating a little shell script like mason does is hardly much extra effort.

<img width="1298" height="218" alt="image" src="https://github.com/user-attachments/assets/4c75337f-74fb-49ac-a047-51535bc04a12" />
