### PR TITLE
fix(lua_ls): add lspconfig runtime to lua config

### DIFF
--- a/lsp/lua_ls.lua
+++ b/lsp/lua_ls.lua
@@ -42,6 +42,8 @@
 ---         checkThirdParty = false,
 ---         library = {
 ---           vim.env.VIMRUNTIME,
+---           -- Necessary for LSP Settings Type Annotations
+---           vim.api.nvim_get_runtime_file("lua/lspconfig", false)[1],
 ---           -- Depending on the usage, you might want to add additional paths
 ---           -- here.
 ---           -- '${3rd}/luv/library',

--- a/lsp/lua_ls.lua
+++ b/lsp/lua_ls.lua
@@ -42,7 +42,7 @@
 ---         checkThirdParty = false,
 ---         library = {
 ---           vim.env.VIMRUNTIME,
----           -- Necessary for LSP Settings Type Annotations
+---           -- For LSP Settings Type Annotations: https://github.com/neovim/nvim-lspconfig#lsp-settings-type-annotations
 ---           vim.api.nvim_get_runtime_file("lua/lspconfig", false)[1],
 ---           -- Depending on the usage, you might want to add additional paths
 ---           -- here.


### PR DESCRIPTION
Problem:
The commented config for lua_ls doesn't make type definitions aware to the server

Fix:
Add runtime to library

Checked on Nvim v0.12.1