### PR TITLE
feat: ctags_lsp

### DIFF
--- a/lsp/ctags_lsp.lua
+++ b/lsp/ctags_lsp.lua
@@ -1,0 +1,28 @@
+---@brief
+---
+--- https://github.com/netmute/ctags-lsp
+---
+--- A simple LSP server wrapping universal-ctags. Provides completion,
+--- go-to-definition, and document/workspace symbols. Useful as a generic
+--- symbol provider for languages without a dedicated language server, or
+--- as a fallback alongside other LSPs.
+---
+--- Requires `universal-ctags` to be installed and available in `$PATH`.
+--- Pre-built binaries are at https://github.com/netmute/ctags-lsp/releases
+--- (Homebrew: `brew install netmute/tap/ctags-lsp`).
+---
+--- The server is generic and does not declare default `filetypes`. Configure
+--- the languages you want it to attach to:
+---
+--- ```lua
+--- vim.lsp.config('ctags_lsp', {
+---   filetypes = { 'lua', 'ruby', 'go' },
+--- })
+--- vim.lsp.enable('ctags_lsp')
+--- ```
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'ctags-lsp' },
+  root_markers = { 'tags', '.tags', '.git' },
+}


### PR DESCRIPTION
## Adds a config for `ctags_lsp`

This adds a server config for [ctags-lsp](https://github.com/netmute/ctags-lsp),
a small LSP server wrapping `universal-ctags`. It provides code completion,
go-to-definition, and document/workspace symbols.

### Use case

ctags-lsp is generic — it isn't tied to a single language. Useful as:

- a fallback symbol provider for languages without a dedicated language server,
- a complement to a primary LSP when working in a tags-indexed codebase,
- a low-overhead option in environments where heavier LSPs are impractical.

### Criteria

- **GitHub stars**: <https://github.com/netmute/ctags-lsp> has **138 stars** as of writing — exceeds the 100-star threshold.
- **Active user base for the targeted "language"**: the underlying tool, [universal-ctags](https://github.com/universal-ctags/ctags) (~7k stars), is widely used across virtually every programming language. Many editors, IDEs, and CLI workflows already produce or consume ctags. ctags-lsp brings that established workflow into the LSP ecosystem.
- **Maintenance**: the upstream repo has 19 releases, latest v0.11.0 (January 2026).

### Notes

No default `filetypes` — left for users to configure, matching the
convention used by other generic servers (e.g. `typos_lsp`).