### PR TITLE
feat: spade_ls

### DIFF
--- a/lsp/spade_ls.lua
+++ b/lsp/spade_ls.lua
@@ -1,0 +1,18 @@
+--@brief
+--
+-- https://gitlab.com/spade-lang/spade/-/tree/main/spade-language-server
+--
+-- Spade language server.
+--
+-- `spade-language-server` can be installed by following the instructions
+-- [here](https://docs.spade-lang.org/typst/editor_setup.html)
+--
+-- The default `cmd` assumes that `spade-language-server` binary can be
+-- found in `$PATH`.
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'lua-language-server' },
+  filetypes = { 'spade' },
+  root_markers = { 'swim.toml' },
+}


### PR DESCRIPTION
## Description

Adding an LSP configuration for `spade-language-server`, the LSP implementation for the [spade hardware description language](https://spade-lang.org/).

## Inclusion Criteria

- **Github Stars:** Spade is not on GitHub[^1], it is split across [GitLab](https://gitlab.com/spade-lang/spade) and [Codeberg](https://codeberg.org/spade-lang), with 104 stars on GitLab.
- **Active Use:** Recently Spade has celebrated its [18th major release](https://blog.spade-lang.org/v0-18-0/), its [discord server](https://discord.gg/YtXbeamxEX) has roughly 400 members, and has been the subject of publications, talks, guest lectures, and more.

## Implementation Notes

The configuration is pretty simple as only a minimal setup is needed.

[^1]: Technically there is a mirror on GitHub, but it is not advertised anywhere at all