### PR TITLE
fix(spade_ls): correct default binary name

### DIFF
--- a/lsp/spade_ls.lua
+++ b/lsp/spade_ls.lua
@@ -12,7 +12,7 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'lua-language-server' },
+  cmd = { 'spade-language-server' },
   filetypes = { 'spade' },
   root_markers = { 'swim.toml' },
 }


### PR DESCRIPTION
As [defined](https://gitlab.com/spade-lang/spade/-/blob/main/spade-language-server/Cargo.toml?ref_type=heads#L2), the name of the executable is `spade-language-server` by default.