### PR TITLE
Check `client.name` in `ast_grep.lua` and `ruby_lsp.lua`

### DIFF
--- a/lsp/ast_grep.lua
+++ b/lsp/ast_grep.lua
@@ -14,7 +14,7 @@ return {
   workspace_required = true,
   reuse_client = function(client, config)
     config.cmd_cwd = config.root_dir
-    return client.config.cmd_cwd == config.cmd_cwd
+    return client.name == config.name and client.config.cmd_cwd == config.cmd_cwd
   end,
   filetypes = { -- https://ast-grep.github.io/reference/languages.html
     'bash',

--- a/lsp/ruby_lsp.lua
+++ b/lsp/ruby_lsp.lua
@@ -28,6 +28,6 @@ return {
   },
   reuse_client = function(client, config)
     config.cmd_cwd = config.root_dir
-    return client.config.cmd_cwd == config.cmd_cwd
+    return client.name == config.name and client.config.cmd_cwd == config.cmd_cwd
   end,
 }


### PR DESCRIPTION
Fixes #4407

Checks the client name against the config name, fixing issue where the wrong lsp client could be reused.

Also noticed #4132 removes the client arg, we'd want to make sure it sticks around :)