### PR TITLE
fix(esbonio): update cmd for esbonio v2

### DIFF
--- a/lsp/esbonio.lua
+++ b/lsp/esbonio.lua
@@ -22,7 +22,7 @@
 ---
 --- ```lua
 --- vim.lsp.config('esbonio', {
----   cmd = { '/path/to/virtualenv/bin/python', '-m', 'esbonio' }
+---   cmd = { '/path/to/virtualenv/bin/python', '-m', 'esbonio.server' }
 --- })
 --- ```
 ---
@@ -45,7 +45,7 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'python3', '-m', 'esbonio' },
+  cmd = { 'python3', '-m', 'esbonio.server' },
   filetypes = { 'rst' },
   root_markers = { '.git' },
 }


### PR DESCRIPTION
Esbonio v2 can no longer be started with the top-level esbonio command. Switch to 'esbonio.server' which is compatible with v1 and v2.

See: https://github.com/swyddfa/esbonio/pull/1098

Thanks!