### PR TITLE
Fix `overrides` type and prefix `nixd`

### DIFF
--- a/scripts/gen_json_schemas.lua
+++ b/scripts/gen_json_schemas.lua
@@ -126,6 +126,9 @@ local overrides = {
   cssls = {
     translate = true,
   },
+  nixd = {
+    prefix = 'nixd.',
+  },
   zls = {
     prefix = 'zls.',
   },

--- a/scripts/gen_json_schemas.lua
+++ b/scripts/gen_json_schemas.lua
@@ -106,7 +106,11 @@ end
 ---@field translate? boolean
 ---@field prefix? string Prepend this string to each schema property.
 
---- @type table<string, LspSchema>
+---@class LspSchemaOverrides : LspSchema
+---@field package_url? string
+---@field settings_file? boolean
+
+--- @type table<string, LspSchemaOverrides>
 local overrides = {
   lua_ls = {
     translate = true,


### PR DESCRIPTION
https://github.com/neovim/nvim-lspconfig/pull/4405 made me notice that `nixd` lsp was also missing the prefix.

Also fixed the `overrides` type, which doesn't require keys to be set.