### PR TITLE
fix(kotlin_lsp): Launch with `intellij-server`

### DIFF
--- a/lsp/kotlin_lsp.lua
+++ b/lsp/kotlin_lsp.lua
@@ -11,7 +11,7 @@
 ---@type vim.lsp.Config
 return {
   filetypes = { 'kotlin' },
-  cmd = { 'kotlin-lsp', '--stdio' },
+  cmd = { 'intellij-server', '--stdio' },
   root_markers = {
     'settings.gradle', -- Gradle (multi-project)
     'settings.gradle.kts', -- Gradle (multi-project)


### PR DESCRIPTION
As per https://github.com/Kotlin/kotlin-lsp/commit/75ddb7586e0170ed93912b0be5d67e0a45769ee6, the new name of the launcher is `intellij-server`, not `kotlin-lsp`.

fix https://github.com/neovim/nvim-lspconfig/issues/4411