### PR TITLE
feat(annotations): add gopls schema

### DIFF
--- a/scripts/gen_json_schemas.lua
+++ b/scripts/gen_json_schemas.lua
@@ -16,6 +16,7 @@ local index = {
   eslint = 'https://raw.githubusercontent.com/microsoft/vscode-eslint/main/package.json',
   flow = 'https://raw.githubusercontent.com/flowtype/flow-for-vscode/master/package.json',
   fsautocomplete = 'https://raw.githubusercontent.com/ionide/ionide-vscode-fsharp/main/release/package.json',
+  gopls = 'https://raw.githubusercontent.com/golang/vscode-go/refs/heads/master/extension/package.json',
   grammarly = 'https://raw.githubusercontent.com/znck/grammarly/main/extension/package.json',
   hhvm = 'https://raw.githubusercontent.com/slackhq/vscode-hack/master/package.json',
   hie = 'https://raw.githubusercontent.com/alanz/vscode-hie-server/master/package.json',


### PR DESCRIPTION
Add golang/vscode-go package.json to generate types for gopls

The type for this LSP settings has two top level keys `go` and `gopls`. The `go` key is configured by nesting tables, like:

```lua
---@type lspconfig.settings.gopls
settings = {
  go = {
    addTags = ...,
    alternateTools = ...,
    buildFlags = ...,
    inlayHints = {
        assignVariableTypes = ...,
    },
  },
  gopls = {
    ...
  },
}
```

while the `gopls` key has strings defining the nested structure:

```lua
---@type lspconfig.settings.gopls
settings = {
  go = {
     ...
  },
  gopls = {
    ["build.buildFlags"] = ...,
    ["build.directoryFilters"] = ...,
    ["build.env"] = ...,
  },
}
```

Tested locally