### PR TITLE
feat: add shuck language server

### DIFF
--- a/lsp/shuck.lua
+++ b/lsp/shuck.lua
@@ -1,0 +1,17 @@
+---@brief
+---
+--- https://github.com/ewhauser/shuck
+---
+--- `shuck` can be installed via `cargo`:
+--- ```sh
+--- cargo install shuck-cli
+--- ```
+---
+--- A lightning fast shell linter with LSP support for bash, zsh, posix, and mksh dialects.
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'shuck', 'server' },
+  filetypes = { 'bash', 'sh', 'zsh' },
+  root_markers = { '.shuck.toml', '.git' },
+}


### PR DESCRIPTION
## Summary

Adds support for [shuck](https://github.com/ewhauser/shuck), a lightning fast shell linter and language server written in Rust.

shuck provides LSP functionality for shell scripts including:
- Diagnostics / linting for bash, zsh, posix, and mksh dialects
- Auto-detects shell dialect from file extension and shebang line
- Language server started with `shuck server`

## Note on Stars

shuck currently has fewer than 100 GitHub stars. It is a young but actively developed tool with a unique approach to shell scripting (managed interpreters, embedded shell detection, formatter, and LSP all in one). I'm submitting this PR speculatively — happy to leave it as draft until the project gains more traction.

## Install

```sh
cargo install shuck-cli
```

## Configuration

```lua
-- Minimal setup (root_markers and filetypes are set in the config file)
vim.lsp.config('shuck', {})
vim.lsp.enable('shuck')
```