### PR TITLE
feat: add panache language server

### DIFF
--- a/lsp/panache.lua
+++ b/lsp/panache.lua
@@ -1,0 +1,18 @@
+---@brief
+---
+--- https://github.com/jolars/panache
+---
+--- A language server, formatter, and linter for Markdown, Quarto, and R Markdown,
+--- built in Rust with a lossless CST parser and support for external formatters
+--- and linters on code blocks.
+---
+--- Install via `cargo install panache`, from the [releases page](https://github.com/jolars/panache/releases),
+--- or via your system package manager (`nixpkgs`, AUR, `pipx install panache-cli`,
+--- `npm install -g @panache-cli/panache`).
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'panache', 'lsp' },
+  filetypes = { 'markdown', 'quarto', 'rmd' },
+  root_markers = { '.panache.toml', 'panache.toml', '_quarto.yml', '_bookdown.yml', '.git' },
+}


### PR DESCRIPTION
Panache is a language server (formatter, and linter) for Markdown, Quarto, and R Markdown. It's built in Rust and uses a lossless CST parser. It supports integrating external formatters and linters. It's packaged at crates.io, AUR, NixOS, NPM, PyPi, and as a VSIX extension at VS Code Marketplace and Open VSX. Binaries are provided directly from the GitHub repo.

Links:

- <https://panache.bz>
- <https://github.com/jolars/panache>