### PR TITLE
fix: logic bugs found by AI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+Everything in `lua/lspconfig/*` (except `util.lua`) is frozen legacy code;
+ignore that subtree when looking for bugs or analyzing patterns in the
+codebase.

--- a/lsp/muon.lua
+++ b/lsp/muon.lua
@@ -18,7 +18,7 @@ return {
 
         on_dir(nil)
       else
-        vim.notify(('[muon] cmd failed with code %d: %s\n%s'):format(output.code, cmd, output.stderr))
+        vim.notify(('[muon] cmd failed with code %d: %s\n%s'):format(output.code, vim.inspect(cmd), output.stderr))
       end
     end)
   end,

--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -158,6 +158,7 @@ if vim.fn.has('nvim-0.11.2') == 1 then
       for name in vim.iter(client_names) do
         vim.schedule_wrap(vim.lsp.enable)(name)
       end
+      timer:close()
     end)
   end, {
     desc = 'Restart the given client',


### PR DESCRIPTION
1. `plugin/lspconfig.lua`: LspRestart timer was never closed after firing, leaking a libuv handle on every invocation.
2. `lsp/muon.lua`: Formatting cmd (a list) with %s, producing table: 0x... instead of the command.