### PR TITLE
docs(emmylua_ls): fix config example

### DIFF
--- a/lsp/emmylua_ls.lua
+++ b/lsp/emmylua_ls.lua
@@ -32,18 +32,20 @@
 ---     end
 ---   end,
 ---   settings = {
----     -- Tell the server which Lua you're using (usually LuaJIT, for Neovim).
----     runtime = { version = 'LuaJIT' },
----     diagnostics = { globals = { 'vim' } },
----     -- Make the server aware of Neovim runtime files.
----     workspace = {
----       library = {
----         vim.env.VIMRUNTIME,
----         -- For LSP Settings Type Annotations: https://github.com/neovim/nvim-lspconfig#lsp-settings-type-annotations
----         vim.api.nvim_get_runtime_file('lua/lspconfig', false)[1],
+---     emmylua = {
+---       -- Tell the server which Lua you're using (usually LuaJIT, for Neovim).
+---       runtime = { version = 'LuaJIT' },
+---       diagnostics = { globals = { 'vim' } },
+---       -- Make the server aware of Neovim runtime files.
+---       workspace = {
+---         library = {
+---           vim.env.VIMRUNTIME,
+---           -- For LSP Settings Type Annotations: https://github.com/neovim/nvim-lspconfig#lsp-settings-type-annotations
+---           vim.api.nvim_get_runtime_file('lua/lspconfig', false)[1],
+---         },
+---         -- Or pull in all of 'runtimepath'. May be slower! https://github.com/neovim/nvim-lspconfig/issues/3189
+---         -- library = vim.api.nvim_get_runtime_file('', true),
 ---       },
----       -- Or pull in all of 'runtimepath'. May be slower! https://github.com/neovim/nvim-lspconfig/issues/3189
----       -- library = vim.api.nvim_get_runtime_file('', true),
 ---     },
 ---   },
 --- })


### PR DESCRIPTION
### Problem:

Example nvim `emmylua_ls` config included in 423941612b6be3a2824b9e2cb50150950d56e42a does not pass settings to the LSP due to missing `emmylua` wrapper table.

To reproduce:

```lua
vim.pack.add({ "https://github.com/neovim/nvim-lspconfig" })
vim.lsp.config("emmylua_ls", {
  on_init = function(client)
    -- If the workspace has its own emmylua_ls/lua_ls config file, defer to it.
    if client.workspace_folders then
      local path = client.workspace_folders[1].name
      if
        path ~= vim.fn.stdpath("config")
        and (vim.uv.fs_stat(path .. "/.emmyrc.json") or vim.uv.fs_stat(path .. "/.luarc.json"))
      then
        client.config.settings = {}
      end
    end
  end,
  settings = {
    -- Tell the server which Lua you're using (usually LuaJIT, for Neovim).
    runtime = { version = "LuaJIT" },
    diagnostics = { globals = { "vim" } },
    -- Make the server aware of Neovim runtime files.
    workspace = {
      library = {
        vim.env.VIMRUNTIME,
        -- For LSP Settings Type Annotations: https://github.com/neovim/nvim-lspconfig#lsp-settings-type-annotations
        vim.api.nvim_get_runtime_file("lua/lspconfig", false)[1],
      },
      -- Or pull in all of 'runtimepath'. May be slower! https://github.com/neovim/nvim-lspconfig/issues/3189
      -- library = vim.api.nvim_get_runtime_file('', true),
    },
  },
})
vim.lsp.enable("emmylua_ls")
```

### Solution:

Pass config through `emmylua` table