### PR TITLE
feat(harper_ls): add tex filetype

### DIFF
--- a/lsp/harper_ls.lua
+++ b/lsp/harper_ls.lua
@@ -37,6 +37,7 @@ return {
     'ruby',
     'rust',
     'swift',
+    'tex',
     'toml',
     'typescript',
     'typescriptreact',


### PR DESCRIPTION
`harper-ls` supports (since https://github.com/Automattic/harper/pull/2689, see https://github.com/Automattic/harper/issues/56) `TeX` and derivative languages. This PR includes that support in the package spec for the language server.