### PR TITLE
fix(flow): resolve project-local binary before npx fallback

### DIFF
--- a/lsp/flow.lua
+++ b/lsp/flow.lua
@@ -15,13 +15,21 @@
 ---@type vim.lsp.Config
 return {
   cmd = function(dispatchers)
-    local cmd = nil
+    local cmd
     if vim.fn.executable('flow') == 1 then
       cmd = { 'flow', 'lsp' }
     else
-      cmd = { 'npx', '--no-install', 'flow', 'lsp' }
+      -- Try project-local binary before falling back to npx
+      local file_dir = vim.fn.expand('%:p:h')
+      local config = vim.fn.findfile('.flowconfig', file_dir .. ';')
+      local root_dir = config ~= '' and vim.fn.fnamemodify(config, ':p:h') or vim.fn.getcwd()
+      local flow_bin = root_dir .. '/node_modules/.bin/flow'
+      if vim.fn.executable(flow_bin) == 1 then
+        cmd = { flow_bin, 'lsp' }
+      else
+        cmd = { 'npx', '--no-install', 'flow', 'lsp' }
+      end
     end
-
     return vim.lsp.rpc.start(cmd, dispatchers)
   end,
   filetypes = { 'javascript', 'javascriptreact' },

--- a/lsp/flow.lua
+++ b/lsp/flow.lua
@@ -14,17 +14,13 @@
 
 ---@type vim.lsp.Config
 return {
-  cmd = function(dispatchers)
+  cmd = function(dispatchers, config)
     local cmd
     if vim.fn.executable('flow') == 1 then
       cmd = { 'flow', 'lsp' }
     else
-      -- Try project-local binary before falling back to npx
-      local file_dir = vim.fn.expand('%:p:h')
-      local config = vim.fn.findfile('.flowconfig', file_dir .. ';')
-      local root_dir = config ~= '' and vim.fn.fnamemodify(config, ':p:h') or vim.fn.getcwd()
-      local flow_bin = root_dir .. '/node_modules/.bin/flow'
-      if vim.fn.executable(flow_bin) == 1 then
+      local flow_bin = (config or {}).root_dir and vim.fs.joinpath(config.root_dir, 'node_modules/.bin/flow')
+      if flow_bin and vim.fn.executable(flow_bin) == 1 then
         cmd = { flow_bin, 'lsp' }
       else
         cmd = { 'npx', '--no-install', 'flow', 'lsp' }


### PR DESCRIPTION
## Problem

When Flow is installed as a project-local dependency (the most common setup), `vim.fn.executable('flow')` returns 0 because `flow` is not inglobal PATH. 

The config then falls back directly to `npx --no-install flow lsp`, never using the project-local binary directly.

If Neovim is launched outside the project tree, it will never reach the project's `node_modules/.bin`.

## Solution

Insert a project-local binary check between the existing global check and the npx fallback:

1. Global `flow` binary — unchanged, existing users unaffected
2. Project-local `<root_dir>/node_modules/.bin/flow` ← new intermediate step
3. `npx --no-install flow lsp` — unchanged fallback

The project root is taken from `config.root_dir`, which Neovim resolves from the existing `root_markers = { '.flowconfig' }`, and the binary path is built with `vim.fs.joinpath` to match the pattern used in other configs (e.g. jsonls).

Users with a global `flow` installation see no behavior change.

For users without a global `flow`, project-local resolution is now explicit rather than delegated to npx's cwd-based resolution.

## Testing

Tested against projects that install `flow-bin` as a local devDependency with no global `flow` in PATH (e.g., [facebook/react](https://github.com/facebook/react)).