### PR TITLE
fix(oxc): fix oxlint and oxfmt vite plus config search

### DIFF
--- a/lsp/oxfmt.lua
+++ b/lsp/oxfmt.lua
@@ -58,7 +58,8 @@ return {
       { 'oxfmt', 'vite%-plus' },
       fname
     )
-    root_markers = util.root_markers_with_field(root_markers, { 'vite.config.ts' }, 'vite%-plus', fname)
+    -- find vite plus config with fmt field
+    root_markers = util.root_markers_with_fields(root_markers, { 'vite.config.ts' }, { 'vite%-plus', 'fmt:' }, fname)
     on_dir(vim.fs.dirname(vim.fs.find(root_markers, { path = fname, upward = true })[1]))
   end,
 }

--- a/lsp/oxfmt.lua
+++ b/lsp/oxfmt.lua
@@ -59,7 +59,13 @@ return {
       fname
     )
     -- find vite plus config with fmt field
-    root_markers = util.root_markers_with_fields(root_markers, { 'vite.config.ts' }, { 'vite%-plus', 'fmt:' }, fname)
+    root_markers = util.root_markers_with_field(
+      root_markers,
+      { 'vite.config.ts' },
+      { 'vite%-plus', 'fmt:' },
+      fname,
+      'all'
+    )
     on_dir(vim.fs.dirname(vim.fs.find(root_markers, { path = fname, upward = true })[1]))
   end,
 }

--- a/lsp/oxlint.lua
+++ b/lsp/oxlint.lua
@@ -61,7 +61,13 @@ return {
       fname
     )
     -- find vite plus config with lint field
-    root_markers = util.root_markers_with_fields(root_markers, { 'vite.config.ts' }, { 'vite%-plus', 'lint:' }, fname)
+    root_markers = util.root_markers_with_field(
+      root_markers,
+      { 'vite.config.ts' },
+      { 'vite%-plus', 'lint:' },
+      fname,
+      'all'
+    )
     on_dir(vim.fs.dirname(vim.fs.find(root_markers, { path = fname, upward = true })[1]))
   end,
   workspace_required = true,

--- a/lsp/oxlint.lua
+++ b/lsp/oxlint.lua
@@ -60,7 +60,8 @@ return {
       { 'oxlint', 'vite%-plus' },
       fname
     )
-    root_markers = util.root_markers_with_field(root_markers, { 'vite.config.ts' }, 'vite%-plus', fname)
+    -- find vite plus config with lint field
+    root_markers = util.root_markers_with_fields(root_markers, { 'vite.config.ts' }, { 'vite%-plus', 'lint:' }, fname)
     on_dir(vim.fs.dirname(vim.fs.find(root_markers, { path = fname, upward = true })[1]))
   end,
   workspace_required = true,

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -100,7 +100,7 @@ function M.root_markers_with_fields(root_files, new_names, fields, fname)
       to_find = vim
         .iter(to_find)
         :filter(function(s)
-          return line:find(s)
+          return !line:find(s)
         end)
         :totable()
       if #to_find == 0 then

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -76,7 +76,11 @@ function M.root_markers_with_field(root_files, new_names, field, fname, match_mo
           return not line:find(s)
         end)
         :totable()
-      return #to_find == 0
+      if #to_find == 0 then
+        to_find = vim.deepcopy(files)
+        return true
+      end
+      return false
     end
   for _, f in ipairs(found or {}) do
     -- Match the given `field`.
@@ -88,9 +92,6 @@ function M.root_markers_with_field(root_files, new_names, field, fname, match_mo
       end
     end
     file:close()
-    if #to_find ~= #fields then
-      to_find = vim.deepcopy(fields)
-    end
   end
 
   return root_files

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -93,8 +93,8 @@ function M.root_markers_with_fields(root_files, new_names, fields, fname)
   local found = vim.fs.find(new_names, { path = path, upward = true, type = 'file' })
 
   for _, f in ipairs(found or {}) do
-    -- Match the given `field`.
     local file = assert(io.open(f, 'r'))
+    -- Match all the given `fields`.
     local to_find = vim.deepcopy(fields)
     for line in file:lines() do
       to_find = vim

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -57,58 +57,40 @@ end
 --- @param new_names string[] Potential root-marker filenames (e.g. `{ 'package.json', 'package.json5' }`) to inspect for the given `field`.
 --- @param field string | string[] Field(s) to search for in the given `new_names` files.
 --- @param fname string Full path of the current buffer name to start searching upwards from.
-function M.root_markers_with_field(root_files, new_names, field, fname)
+--- @param match_mode? 'all' | 'any' Match mode - all or any field passed as `field`
+function M.root_markers_with_field(root_files, new_names, field, fname, match_mode)
   local path = vim.fn.fnamemodify(fname, ':h')
   local found = vim.fs.find(new_names, { path = path, upward = true, type = 'file' })
   local fields = type(field) == 'string' and { field } or field
-
-  for _, f in ipairs(found or {}) do
-    -- Match the given `field`.
-    local file = assert(io.open(f, 'r'))
-    for line in file:lines() do
-      if vim.iter(fields):any(function(s)
-        return line:find(s)
-      end) then
-        root_files[#root_files + 1] = vim.fs.basename(f)
-        break
+  local to_find = vim.deepcopy(fields)
+  local matcher = (match_mode or 'any') == 'any'
+      and function(line)
+        return vim.iter(fields):any(function(s)
+          return line:find(s)
+        end)
       end
-    end
-    file:close()
-  end
-
-  return root_files
-end
-
---- Appends `new_names` to `root_files` if all `fields` are found in any such file in any ancestor of `fname`.
----
---- NOTE: this does a "breadth-first" search, so is broken for multi-project workspaces:
---- https://github.com/neovim/nvim-lspconfig/issues/3818#issuecomment-2848836794
----
---- @param root_files string[] List of root-marker files to append to.
---- @param new_names string[] Potential root-marker filenames (e.g. `{ 'package.json', 'package.json5' }`) to inspect for the given `field`.
---- @param fields string[] Fields to search for in the given `new_names` files.
---- @param fname string Full path of the current buffer name to start searching upwards from.
-function M.root_markers_with_fields(root_files, new_names, fields, fname)
-  local path = vim.fn.fnamemodify(fname, ':h')
-  local found = vim.fs.find(new_names, { path = path, upward = true, type = 'file' })
-
-  for _, f in ipairs(found or {}) do
-    local file = assert(io.open(f, 'r'))
-    -- Match all the given `fields`.
-    local to_find = vim.deepcopy(fields)
-    for line in file:lines() do
+    or function(line)
       to_find = vim
         .iter(to_find)
         :filter(function(s)
           return not line:find(s)
         end)
         :totable()
-      if #to_find == 0 then
+      return #to_find == 0
+    end
+  for _, f in ipairs(found or {}) do
+    -- Match the given `field`.
+    local file = assert(io.open(f, 'r'))
+    for line in file:lines() do
+      if matcher(line) then
         root_files[#root_files + 1] = vim.fs.basename(f)
         break
       end
     end
     file:close()
+    if #to_find ~= #fields then
+      to_find = vim.deepcopy(fields)
+    end
   end
 
   return root_files

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -79,6 +79,41 @@ function M.root_markers_with_field(root_files, new_names, field, fname)
   return root_files
 end
 
+--- Appends `new_names` to `root_files` if all `fields` are found in any such file in any ancestor of `fname`.
+---
+--- NOTE: this does a "breadth-first" search, so is broken for multi-project workspaces:
+--- https://github.com/neovim/nvim-lspconfig/issues/3818#issuecomment-2848836794
+---
+--- @param root_files string[] List of root-marker files to append to.
+--- @param new_names string[] Potential root-marker filenames (e.g. `{ 'package.json', 'package.json5' }`) to inspect for the given `field`.
+--- @param fields string[] Fields to search for in the given `new_names` files.
+--- @param fname string Full path of the current buffer name to start searching upwards from.
+function M.root_markers_with_fields(root_files, new_names, fields, fname)
+  local path = vim.fn.fnamemodify(fname, ':h')
+  local found = vim.fs.find(new_names, { path = path, upward = true, type = 'file' })
+
+  for _, f in ipairs(found or {}) do
+    -- Match the given `field`.
+    local file = assert(io.open(f, 'r'))
+    local to_find = vim.deepcopy(fields)
+    for line in file:lines() do
+      to_find = vim
+        .iter(to_find)
+        :filter(function(s)
+          return line:find(s)
+        end)
+        :totable()
+      if #to_find == 0 then
+        root_files[#root_files + 1] = vim.fs.basename(f)
+        break
+      end
+    end
+    file:close()
+  end
+
+  return root_files
+end
+
 function M.insert_package_json(root_files, field, fname)
   return M.root_markers_with_field(root_files, { 'package.json', 'package.json5' }, field, fname)
 end

--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -100,7 +100,7 @@ function M.root_markers_with_fields(root_files, new_names, fields, fname)
       to_find = vim
         .iter(to_find)
         :filter(function(s)
-          return !line:find(s)
+          return not line:find(s)
         end)
         :totable()
       if #to_find == 0 then


### PR DESCRIPTION
Adds additional check for `fmt`/`lint` fields in `vite.config.ts`, fix #4432 