### PR TITLE
fix(roslyn_ls): remove unnecessary code and recommend maintained plugin for razor

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -68,7 +68,7 @@ local function roslyn_handlers()
     end,
     ['razor/provideDynamicFileInfo'] = function(_, _, _)
       vim.notify(
-        'Razor is not supported.\nPlease use https://github.com/tris203/rzls.nvim',
+        'Razor is not supported.\nPlease use https://github.com/seblyng/roslyn.nvim',
         vim.log.levels.WARN,
         { title = 'roslyn_ls' }
       )

--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -11,10 +11,6 @@
 --   cmd = {
 --     'dotnet',
 --     '<my_folder>/Microsoft.CodeAnalysis.LanguageServer.dll',
---     '--logLevel', -- this property is required by the server
---     'Information',
---     '--extensionLogDirectory', -- this property is required by the server
---     fs.joinpath(uv.os_tmpdir(), 'roslyn_ls/logs'),
 --     '--stdio',
 --   },
 --   ```
@@ -167,10 +163,6 @@ return {
   cmd = {
     vim.fn.executable('Microsoft.CodeAnalysis.LanguageServer') == 1 and 'Microsoft.CodeAnalysis.LanguageServer'
       or 'roslyn-language-server',
-    '--logLevel',
-    'Information',
-    '--extensionLogDirectory',
-    fs.joinpath(uv.os_tmpdir(), 'roslyn_ls/logs'),
     '--stdio',
   },
 

--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -66,23 +66,6 @@ local function roslyn_handlers()
       refresh_diagnostics(client)
       return vim.NIL
     end,
-    ['workspace/_roslyn_projectNeedsRestore'] = function(_, result, ctx)
-      local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
-
-      ---@diagnostic disable-next-line: param-type-mismatch
-      client:request('workspace/_roslyn_restore', result, function(err, response)
-        if err then
-          vim.notify(err.message, vim.log.levels.ERROR, { title = 'roslyn_ls' })
-        end
-        if response then
-          for _, v in ipairs(response) do
-            vim.notify(v.message, vim.log.levels.INFO, { title = 'roslyn_ls' })
-          end
-        end
-      end)
-
-      return vim.NIL
-    end,
     ['razor/provideDynamicFileInfo'] = function(_, _, _)
       vim.notify(
         'Razor is not supported.\nPlease use https://github.com/tris203/rzls.nvim',


### PR DESCRIPTION
I am one of the maintainers of [roslyn.nvim](https://github.com/seblyng/roslyn.nvim). The roslyn server has made some changes that makes some of the code here not needed anymore:

- The arguments to cmd are no longer required
- The `workspace/_roslyn_projectNeedsRestore` handler is removed internally in roslyn

Also, I changed the recommendation to use roslyn.nvim over rzls.nvim for razor support since rzls.nvim has been deprecated for quite some time, and the effort for razor is moved into roslyn.nvim, with the maintainer of that plugin joining me in maintaining roslyn.nvim