### PR TITLE
fix(rescript): default parameters do not enable incremental typechecking

### DIFF
--- a/lsp/rescriptls.lua
+++ b/lsp/rescriptls.lua
@@ -48,7 +48,7 @@ return {
 
       allowBuiltInFormatter = true, -- lower latency
       incrementalTypechecking = { -- removes the need for external build process
-        enabled = true,
+        enable = true,
         acrossFiles = true,
       },
       cache = { projectConfig = { enabled = true } }, -- speed up latency dramatically


### PR DESCRIPTION
## Problem
Typechecking in Rescript is not enabled by default

## Root cause
"enabled" is not the correct flag. It should be "enable"

Reference 1 https://github.com/neovim/nvim-lspconfig/blob/a4ed4e761c400849e8c9f8bda33e5083f890268c/lua/lspconfig/types/lsp/rescriptls.lua#L30
Reference 2 https://github.com/rescript-lang/rescript-vscode/blob/2bc69d29ed92e19b14054952bafe9d4af7bd4c4b/server/src/server.ts#L338

## Fix
Rename the flag