### PR TITLE
fix(emmylua_ls): move settings under emmylua section

### DIFF
--- a/lsp/emmylua_ls.lua
+++ b/lsp/emmylua_ls.lua
@@ -73,7 +73,9 @@ return {
     or vim.list_extend(vim.list_extend(root_markers1, root_markers2), { '.git' }),
   workspace_required = false,
   settings = {
-    codeLens = { enable = true },
-    hint = { enable = true },
+    emmylua = {
+      codeLens = { enable = true },
+      hint = { enable = true },
+    },
   },
 }


### PR DESCRIPTION
# Problem
EmmyLua requests configuration from the "emmylua" section, but the current configuration doesn't expose the settings under that section.

Example request and response:
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "workspace/configuration",
  "params": {
    "items": [
      {
        "scopeUri": "file:///Users/marcus/.dotfiles",
        "section": "emmylua"
      }
    ]
  }
}
```
```json
{
  "result": [
    null
  ],
  "id": 1,
  "jsonrpc": "2.0"
}
```

# Solution
Move the settings under the "emmylua" section.

After these changes:
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "workspace/configuration",
  "params": {
    "items": [
      {
        "scopeUri": "file:///Users/marcus/.dotfiles",
        "section": "emmylua"
      }
    ]
  }
}
```
```json
{
  "result": [
    {
      "hint": {
        "enable": true
      },
      "codeLens": {
        "enable": true
      }
    }
  ],
  "id": 1,
  "jsonrpc": "2.0"
}
```