### PR TITLE
Update npm registry command for GitLab LSP

### DIFF
--- a/lsp/gitlab_duo.lua
+++ b/lsp/gitlab_duo.lua
@@ -315,7 +315,7 @@ end
 return {
   cmd = {
     'npx',
-    '--registry=https://gitlab.com/api/v4/packages/npm/',
+    '--@gitlab-org:registry=https://gitlab.com/api/v4/packages/npm/',
     '@gitlab-org/gitlab-lsp',
     '--stdio',
   },


### PR DESCRIPTION
Make registry path more specific to the main package to make npx command more reliable

Upstream issue: https://gitlab.com/gitlab-org/editor-extensions/gitlab-lsp/-/work_items/2371