### PR TITLE
feat: terraformls enable codelens

### DIFF
--- a/lsp/terraformls.lua
+++ b/lsp/terraformls.lua
@@ -37,4 +37,12 @@ return {
   cmd = { 'terraform-ls', 'serve' },
   filetypes = { 'terraform', 'terraform-vars' },
   root_markers = { '.terraform', '.git' },
+  capabilities = {
+    experimental = {
+      showReferencesCommandId = 'client.showReferences',
+    },
+  },
+  on_attach = function(_, bufnr)
+    vim.lsp.codelens.enable(true, { bufnr = bufnr })
+  end,
 }


### PR DESCRIPTION
I noticed that terraform_ls does support codelens for references but its opt-in. I'm not sure if it should be default enabled or commented out for reference but it would be nice for it to be discoverable from this repo rather than having to dig through docs in terraform repo

<img width="227" height="61" alt="image" src="https://github.com/user-attachments/assets/e6c4eb36-7a3b-4126-9895-a570d11b0aff" />

Thoughts?

Here is the reference https://github.com/hashicorp/terraform-ls/blob/main/docs/language-clients.md?plain=1#L162