### PR TITLE
Enable clangd lsp for c.doxygen / cpp.doxygen

### DIFF
--- a/lsp/clangd.lua
+++ b/lsp/clangd.lua
@@ -64,7 +64,7 @@ end
 ---@type vim.lsp.Config
 return {
   cmd = { 'clangd' },
-  filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda' },
+  filetypes = { 'c', 'c.doxygen', 'cpp', 'cpp.doxygen', 'objc', 'objcpp', 'cuda' },
   root_markers = {
     '.clangd',
     '.clang-tidy',

--- a/lua/lspconfig/configs/clangd.lua
+++ b/lua/lspconfig/configs/clangd.lua
@@ -57,7 +57,7 @@ end
 return {
   default_config = {
     cmd = { 'clangd' },
-    filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'cuda' },
+    filetypes = { 'c', 'c.doxygen', 'cpp', 'cpp.doxygen', 'objc', 'objcpp', 'cuda' },
     root_dir = function(fname)
       return util.root_pattern(
         '.clangd',


### PR DESCRIPTION
This fixes #4458.

One option to get doxygen highlighting in C / C++ files is to append `.doxygen` to the file type (see `:help doxygen`).

This commits add the `c.doxygen` / `cpp.doxygen` filetypes to the list of clangd lsp to be compatible with this approach.

Note that vim help also recommend an alternative approach that doesn't change the filetype, which is to define the variable:

    let g:load_doxygen_syntax=1