### PR TITLE
fix(svelte): support svelteserver installed in node_modules

### DIFF
--- a/lsp/svelte.lua
+++ b/lsp/svelte.lua
@@ -6,12 +6,21 @@
 ---
 --- `svelte-language-server` can be installed via `npm`:
 --- ```sh
---- npm install -g svelte-language-server
+--- npm install [-g] svelte-language-server
 --- ```
 
 ---@type vim.lsp.Config
 return {
-  cmd = { 'svelteserver', '--stdio' },
+  cmd = function(dispatchers, config)
+    local cmd = 'svelteserver'
+    if (config or {}).root_dir then
+      local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
+    end
+    return vim.lsp.rpc.start({ cmd, '--stdio' }, dispatchers)
+  end,
   filetypes = { 'svelte' },
   settings = {
     typescript = {


### PR DESCRIPTION
Problem:
Currently the `svelte` configuration expects a globally installed `svelteserver` binary. Meanwhile, other LSP configs support binaries installed as dev dependencies on `node_modules/.bin`.
A global language server makes it harder to have project-scoped version management.

Solution:
Implement a `cmd` finder similar to `oxlint` and `oxfmt` which considers `node_modules/bin` as an additional lookup path as well as the global install

Workaround:
Meanwhile, users can define the `cmd` function on their own
`vim.lsp.config('svelte')` as needed.