### PR TITLE
fix(ruff_lsp): deprecate `ruff_lsp` in favour of `ruff`

### DIFF
--- a/lsp/ruff.lua
+++ b/lsp/ruff.lua
@@ -10,7 +10,7 @@
 ---
 --- **Available in Ruff `v0.4.5` in beta and stabilized in Ruff `v0.5.3`.**
 ---
---- This is the new built-in language server written in Rust. It supports the same feature set as `ruff-lsp`, but with superior performance and no installation required. Note that the `ruff-lsp` server will continue to be maintained until further notice.
+--- This is the new built-in language server written in Rust. It supports the same feature set as `ruff-lsp`, but with superior performance and no separate installation required.
 ---
 --- Server settings can be provided via:
 ---

--- a/lsp/ruff_lsp.lua
+++ b/lsp/ruff_lsp.lua
@@ -2,7 +2,7 @@
 ---
 --- https://github.com/astral-sh/ruff-lsp
 ---
---- WARN: `ruff-lsp` is now deprecated, LSP functionality is now built into `ruff` itslef, consider setting up `ruff` instead.
+--- WARN: `ruff-lsp` is now deprecated, LSP functionality is now built into `ruff` itself, consider setting up `ruff` instead.
 ---
 --- A Language Server Protocol implementation for Ruff, an extremely fast Python linter and code transformation tool, written in Rust. It can be installed via pip.
 ---

--- a/lsp/ruff_lsp.lua
+++ b/lsp/ruff_lsp.lua
@@ -2,6 +2,8 @@
 ---
 --- https://github.com/astral-sh/ruff-lsp
 ---
+--- WARN: `ruff-lsp` is now deprecated, LSP functionality is now built into `ruff` itslef, consider setting up `ruff` instead.
+---
 --- A Language Server Protocol implementation for Ruff, an extremely fast Python linter and code transformation tool, written in Rust. It can be installed via pip.
 ---
 --- ```sh
@@ -28,4 +30,7 @@ return {
   root_markers = { 'pyproject.toml', 'ruff.toml', '.git' },
   ---@type lspconfig.settings.ruff_lsp
   settings = {},
+  on_init = function()
+    vim.deprecate('ruff_lsp', 'ruff', '3.0.0', 'nvim-lspconfig', false)
+  end,
 }

--- a/lsp/ruff_lsp.lua
+++ b/lsp/ruff_lsp.lua
@@ -2,7 +2,7 @@
 ---
 --- https://github.com/astral-sh/ruff-lsp
 ---
---- WARN: `ruff-lsp` is now deprecated, LSP functionality is now built into `ruff` itself, consider setting up `ruff` instead.
+--- WARNING: `ruff-lsp` is now deprecated, LSP functionality is now built into `ruff` itself, consider setting up `ruff` instead.
 ---
 --- A Language Server Protocol implementation for Ruff, an extremely fast Python linter and code transformation tool, written in Rust. It can be installed via pip.
 ---


### PR DESCRIPTION
The `ruff-lsp` project was archived a while back, the lsp is now built into the `ruff` project itself. This PR does the following:

1. Add a warning comment into the docs of `ruff_lsp` config
2. Add a `vim.deprecate` call to the `ruff_lsp` config (suggesting that it will be dropped in `v3.0.0` release)
3. Modify `ruff` config documentation to reflect that `ruff_lsp` isn't maintained anymore

Closes #4461