### PR TITLE
fix(rust_analyzer): error thrown if rustc is not found

### DIFF
--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -44,7 +44,9 @@ local function default_sysroot_src()
   if not sysroot then
     local rustc = os.getenv 'RUSTC' or 'rustc'
     local ok, system_obj = pcall(vim.system, { rustc, '--print', 'sysroot' }, { text = true })
-    if not ok then return nil end
+    if not ok then
+      return nil
+    end
     local result = system_obj:wait()
 
     local stdout = result.stdout

--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -43,7 +43,9 @@ local function default_sysroot_src()
   local sysroot = vim.tbl_get(vim.lsp.config['rust_analyzer'], 'settings', 'rust-analyzer', 'cargo', 'sysroot')
   if not sysroot then
     local rustc = os.getenv 'RUSTC' or 'rustc'
-    local result = vim.system({ rustc, '--print', 'sysroot' }, { text = true }):wait()
+    local ok, system_obj = pcall(vim.system, { rustc, '--print', 'sysroot' }, { text = true })
+    if not ok then return nil end
+    local result = system_obj:wait()
 
     local stdout = result.stdout
     if result.code == 0 and stdout then


### PR DESCRIPTION
This commit prevents the propagation of an error due to rustc not being found, which can mess up e.g. syntax highlighting via treesitter.