### PR TITLE
feat: wolfram_lsp

### DIFF
--- a/lsp/wolfram_lsp.lua
+++ b/lsp/wolfram_lsp.lua
@@ -1,0 +1,45 @@
+---@brief
+---
+--- https://github.com/WolframResearch/LSPServer
+---
+--- LSPServer is an official lsp server for Mathematica.
+---
+--- Installation:
+--- The LSPServer paclet and its dependencies are included in Mathematica or
+--- Wolfram Engine installation in recent versions (13.0 and later).
+---
+--- If your Mathematica or Wolfram Engine installation is old and LSPServer is
+--- not included, you can install it manually in a Mathematica environment:
+--- ```mma
+--- PacletInstall["CodeParser"]
+--- PacletInstall["CodeInspector"]
+--- PacletInstall["CodeFormatter"]
+--- PacletInstall["LSPServer"]
+--- ```
+
+---@type vim.lsp.Config
+return {
+  -- CMD is borrowed from official vscode extension:
+  -- https://github.com/WolframResearch/vscode-wolfram
+  cmd = {
+    'WolframKernel',
+    '-noinit',
+    '-noprompt',
+    '-nopaclet',
+    '-noicon',
+    '-nostartuppaclets',
+    '-run',
+    'Needs["LSPServer`"];LSPServer`StartServer[]',
+  },
+  filetypes = { 'mma' },
+  root_markers = { '.git' },
+  init_options = {
+    -- The semantic tokens support needs to be explicitly enabled.
+    -- Otherwise, there would be errors during lsp initialization such as:
+    --   "attempt to index field 'semanticTokensProvider' (a userdata value)"
+    --
+    -- Option found in:
+    -- https://github.com/WolframResearch/LSPServer/blob/cecb4b310270d39fb7ba05564e5d5ae89d27802d/LSPServer/Kernel/LSPServer.wl#L926
+    semanticTokens = true,
+  },
+}


### PR DESCRIPTION
Official LSP for Mathematica or Wolfram Engine.
https://github.com/WolframResearch/LSPServer

The repo above does not have many stars. Probably due to that the lsp is built in Mathematica already, so not so many people went to this repo to check it out. The popularity can be confirmed from Wolfram's official [VSCode](https://github.com/WolframResearch/vscode-wolfram) [extension](https://marketplace.visualstudio.com/items?itemName=WolframResearch.wolfram).

Some points about the setup:
- I have added an init option to enable semantic tokens, as a solution to an error I get if it is not enabled:
  ```
  vim.schedule callback: /usr/share/nvim/runtime/lua/vim/lsp/semantic_tokens.lua:425: /usr/share/nvim/runtime/lua/vim/lsp/semantic_tokens.lua:86: attempt to index field 'semanticTokensProvider' (a userdata value)
  stack traceback:
  	[builtin#36]: at 0x7f2673d93c70
  	/usr/share/nvim/runtime/lua/vim/lsp/semantic_tokens.lua:425: in function 'handler'
  	/usr/share/nvim/runtime/lua/vim/lsp/client.lua:743: in function 'fn'
  	[string "vim/_core/editor"]:273: in function <[string "vim/_core/editor"]:272>
  ```
  The `semanticTokensProvider` won't be initialized if `semanticTokens` is false. (see [here](https://github.com/WolframResearch/LSPServer/blob/cecb4b310270d39fb7ba05564e5d5ae89d27802d/LSPServer/Kernel/LSPServer.wl#L926), [here](https://github.com/WolframResearch/LSPServer/blob/cecb4b310270d39fb7ba05564e5d5ae89d27802d/LSPServer/Kernel/LSPServer.wl#L1090) and [here](https://github.com/WolframResearch/LSPServer/blob/cecb4b310270d39fb7ba05564e5d5ae89d27802d/LSPServer/Kernel/LSPServer.wl#L1142))
- The executable is set to be "WolframKernel", since that is one of the executables that get installed by the installer. Also, That is the executable's basename searched for by [the official VSCode extension](https://github.com/WolframResearch/vscode-wolfram/blob/c864d4d7bebf0df7310710e090541f88eac8070f/src/extension/find-kernel.ts#L26).