### PR TITLE
feat: terragrunt-ls

### DIFF
--- a/lsp/terragrunt_ls.lua
+++ b/lsp/terragrunt_ls.lua
@@ -1,0 +1,12 @@
+---@brief
+---
+--- https://github.com/gruntwork-io/terragrunt-ls
+---
+--- `terragrunt-ls`, a language server for Terragrunt configuration files.
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'terragrunt-ls' },
+  filetypes = { 'hcl' },
+  root_markers = { 'terragrunt.hcl', '.git' },
+}


### PR DESCRIPTION
Adds config for `terragrunt-ls`, a language server for Terragrunt configuration
files (terragrunt.hcl, terragrunt.stack.hcl, terragrunt.values.hcl).

Terragrunt is an IaC orchestration tool maintained by
[Gruntwork](https://www.gruntwork.io/) with a large established user base. The
server is under active development and provides hover, go-to-definition,
completion, references, rename, and formatting for Terragrunt configs.
