### PR TITLE
fix(roslyn_ls): update diagnostics on project/solution initialization

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -51,14 +51,21 @@ end
 
 ---@param client vim.lsp.Client
 local function refresh_diagnostics(client)
-  for buf, _ in pairs(vim.lsp.get_client_by_id(client.id).attached_buffers) do
+  local capabilities = vim
+    .iter(client.dynamic_capabilities.capabilities.diagnosticProvider)
+    :map(function(cap)
+      return cap.registerOptions.identifier
+    end)
+    :totable()
+
+  for buf, _ in pairs(client.attached_buffers) do
     if vim.api.nvim_buf_is_loaded(buf) then
-      client:request(
-        vim.lsp.protocol.Methods.textDocument_diagnostic,
-        { textDocument = vim.lsp.util.make_text_document_params(buf) },
-        nil,
-        buf
-      )
+      for _, cap in pairs(capabilities) do
+        client:request(vim.lsp.protocol.Methods.textDocument_diagnostic, {
+          identifier = cap,
+          textDocument = vim.lsp.util.make_text_document_params(buf),
+        }, nil, buf)
+      end
     end
   end
 end


### PR DESCRIPTION
Problem:
When a solution or a project gets loaded, diagnostics do not update correctly.

Solution:
Change refresh_diagnostics function. Instead of performing one `client:request`, call `client:request` for every capability registered by roslyn for diagnosticProvider.

Rationale:
I've taken the idea from the `roslyn.nvim` plugin, that for neovim non-nightly uses `vim.lsp.diagnostic._refresh()`  function to update diagnostics in the `workspace/projectInitializationComplete` handler. The function uses `Client:_provider_foreach` to call client:request for each capability registered for the `textDocument/diagnostic` LSP method. This approach succeeds to update diagnostics after initialization. 

I decided against using an underscore-prefixed function, so I directly iterate through registered capabilites. A question I have is: would using `vim.lsp.diagnostic._refresh()` have been fine? 

NOT tested on nightly. 