### PR TITLE
feat(powershell_es): add other applicable file types

### DIFF
--- a/lsp/powershell_es.lua
+++ b/lsp/powershell_es.lua
@@ -51,6 +51,6 @@ return {
 
     return vim.lsp.rpc.start(cmd, dispatchers)
   end,
-  filetypes = { 'ps1' },
+  filetypes = { 'ps1', 'psd1', 'psm1', 'psrc', 'pssc' },
   root_markers = { 'PSScriptAnalyzerSettings.psd1', '.git' },
 }


### PR DESCRIPTION
These are involved with module development and remoting session configuration. List derived from `microsoft/vscode` at `vscode/extensions/powershell/package.json`

https://github.com/microsoft/vscode/blob/d0d2ff7777fa25ec4ac37692bfb88db302e9552f/extensions/powershell/package.json#L16-L22

MS Docs on file types.
[psd1](https://learn.microsoft.com/en-us/powershell/scripting/developer/module/understanding-a-windows-powershell-module?view=powershell-7.6#module-manifests)
[psm1](https://learn.microsoft.com/en-us/powershell/scripting/developer/module/understanding-a-windows-powershell-module?view=powershell-7.6#module-manifests)
[pssc](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_session_configuration_files?view=powershell-7.6#long-description)
[psrc](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/new-psrolecapabilityfile?view=powershell-7.6#example-1-create-a-blank-role-capability-file)

Upon using `code file.ft` , the PowerShell extension does enable too.

Lastly, I am intentionally excluding `ps1xml` ( types and formatting ) and `cdxml` ( cmdlet definitions ) as those are purely `xml` and are better handled with appropriate tooling. 
