### PR TITLE
feat: pyfun

### DIFF
--- a/lsp/pyfun.lua
+++ b/lsp/pyfun.lua
@@ -1,0 +1,19 @@
+---@brief
+---
+--- https://github.com/simontreanor/Pyfun
+---
+--- Language server for Pyfun, an F#-inspired, functional-first language that
+--- compiles to readable Python.
+---
+--- The `pyfun` binary ships with the compiler and can be installed via pip:
+---
+--- ```sh
+--- pip install pyfun-lang
+--- ```
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'pyfun', 'lsp' },
+  filetypes = { 'pyfun' },
+  root_markers = { '.git' },
+}


### PR DESCRIPTION
Adds a config for the [Pyfun](https://github.com/simontreanor/Pyfun) language server. Pyfun is an F#-inspired, functional-first language that compiles to readable Python. The `pyfun` binary bundles the language server (`pyfun lsp`, stdio) and installs with `pip install pyfun-lang`; the config activates on the `pyfun` filetype with `.git` as the root marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)