### PR TITLE
docs(docker-language-server): fix typo

### DIFF
--- a/lsp/docker_language_server.lua
+++ b/lsp/docker_language_server.lua
@@ -2,7 +2,7 @@
 ---
 --- https://github.com/docker/docker-language-server
 ---
---- `docker-langserver-server` can be installed via `go`:
+--- `docker-language-server` can be installed via `go`:
 --- ```sh
 --- go install github.com/docker/docker-language-server/cmd/docker-language-server@latest
 --- ```


### PR DESCRIPTION
`docker-langserver-server` should be `docker-language-server`
