### PR TITLE
feat(pyright): disable tagged hints by default

### DIFF
--- a/lsp/basedpyright.lua
+++ b/lsp/basedpyright.lua
@@ -3,6 +3,9 @@
 --- https://detachhead.github.io/basedpyright
 ---
 --- `basedpyright`, a static type checker and language server for python
+---
+--- Tagged hints are disabled by default. See Pyright for more details.
+--- Set `basedpyright.disableTaggedHints = false` to re-enable.
 
 local function set_python_path(command)
   local path = command.args
@@ -45,6 +48,7 @@ return {
         -- Because it will override per-project configurations like `pyproject.toml`.
         -- If left unset, its default value is `true`, and it can be correctly overridden by project config files.
       },
+      disableTaggedHints = true,
     },
   },
   on_attach = function(client, bufnr)

--- a/lsp/pyright.lua
+++ b/lsp/pyright.lua
@@ -3,6 +3,17 @@
 --- https://github.com/microsoft/pyright
 ---
 --- `pyright`, a static type checker and language server for python
+---
+--- Pyright marks unreachable, unreferenced and deprecated code with hint
+--- diagnostics. Nvim correctly reports them as regular diagnostics, but they
+--- are usually too noisy (https://github.com/neovim/neovim/issues/30444), so
+--- they are disabled by default. To re-enable:
+---
+--- ```lua
+--- vim.lsp.config('pyright', {
+---   settings = { pyright = { disableTaggedHints = false } },
+--- })
+--- ```
 
 local function set_python_path(command)
   local path = command.args
@@ -36,6 +47,9 @@ return {
   },
   ---@type lspconfig.settings.pyright
   settings = {
+    pyright = {
+      disableTaggedHints = true,
+    },
     python = {
       analysis = {
         autoSearchPaths = true,


### PR DESCRIPTION
The current behavior makes Pyright almost unusable in large Python projects due to the immense amount of diagnostics. Spent some time going down the rabbit hole on this ;) I hope this PR creates a better default experience for others.

Close  #3314.

---
Problem:
Pyright marks unreachable, unreferenced and deprecated code with hint
diagnostics. Nvim correctly reports them as regular diagnostics, but
they are usually too noisy (c.f., neovim/neovim#30444).

Solution:
Disable it by default in pyright and basedpyright for a better default
user experience.
