### PR TITLE
fix(eslint): convert workspaceFolder.uri to a proper URI

### DIFF
--- a/lsp/eslint.lua
+++ b/lsp/eslint.lua
@@ -194,7 +194,7 @@ return {
     if root_dir then
       config.settings = config.settings or {}
       config.settings.workspaceFolder = {
-        uri = root_dir,
+        uri = vim.uri_from_fname(root_dir),
         name = vim.fn.fnamemodify(root_dir, ':t'),
       }
 


### PR DESCRIPTION
`workspaceFolder.uri` was set to a raw filesystem path, but the LSP spec requires a URI. Use `vim.uri_from_fname(root_dir)` to convert it.