### PR TITLE
fix(ast_grep): stop reuse_client from spawning duplicate lsp client

### DIFF
--- a/lsp/ast_grep.lua
+++ b/lsp/ast_grep.lua
@@ -13,8 +13,8 @@ return {
   cmd = { 'ast-grep', 'lsp' },
   workspace_required = true,
   reuse_client = function(client, config)
-    config.cmd_cwd = config.root_dir
-    return client.name == config.name and client.config.cmd_cwd == config.cmd_cwd
+    return client.name == config.name
+      and client.config.root_dir == config.root_dir
   end,
   filetypes = { -- https://ast-grep.github.io/reference/languages.html
     'bash',

--- a/lsp/ast_grep.lua
+++ b/lsp/ast_grep.lua
@@ -13,8 +13,7 @@ return {
   cmd = { 'ast-grep', 'lsp' },
   workspace_required = true,
   reuse_client = function(client, config)
-    return client.name == config.name
-      and client.config.root_dir == config.root_dir
+    return client.name == config.name and client.config.root_dir == config.root_dir
   end,
   filetypes = { -- https://ast-grep.github.io/reference/languages.html
     'bash',


### PR DESCRIPTION
Problem:
Old config set config.cmd_cwd = config.root_dir inside reuse_client itself. On the first client's initial start, reuse_client is never invoked (nothing exists yet to compare against), so cmd_cwd is never set on it. On the second start attempt, the comparison client.config.cmd_cwd == config.cmd_cwd evaluates nil == <string>, which fails, and a second client spawns.

Solution:
Change reuse_client key-value pair to

  reuse_client = function(client, config)
    return client.name == config.name
      and client.config.root_dir == config.root_dir
  end,

Now the first spawned client is reused. Only one lua_ls client was ever spawned. Only the `reuse_client` section looked fishy to me.

Testing:
Tested only with my Lua based Neovim configuration. I was unable to figure out what the old config was trying to do. So more testing might be needed with other languages.