### PR TITLE
feat: agentscript

### DIFF
--- a/lsp/agentscript.lua
+++ b/lsp/agentscript.lua
@@ -1,0 +1,20 @@
+---@brief
+---
+--- https://github.com/salesforce/agentscript
+---
+--- Language server for Agent Script, Salesforce's open agent specification
+--- language for `*.agent` files. Install with
+--- `npm install -g @sf-agentscript/lsp-server`.
+---
+--- Neovim does not detect the `agentscript` filetype by default:
+---
+--- ```lua
+--- vim.filetype.add({ extension = { agent = 'agentscript' } })
+--- ```
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'agentscript-lsp', '--stdio' },
+  filetypes = { 'agentscript' },
+  root_markers = { 'package.json', '.git' },
+}


### PR DESCRIPTION
Adds support for **Agent Script**, Salesforce's open agent specification
language ([salesforce/agentscript](https://github.com/salesforce/agentscript),
Apache 2.0).

**Why now:** Salesforce open sourced the complete Agent Script toolchain —
parser, compiler, LSP server, VS Code extension — and made the language
generally available in July 2026. As of the week of **July 13, 2026** the
legacy Agentforce Builder was retired: the "New Agent" button in Setup only
opens the new Agent Script-based Agentforce Builder
([release note](https://help.salesforce.com/s/articleView?id=005232662&language=en_US&type=1)).
Every Agentforce customer authoring agents going forward is writing `.agent`
files, and the Salesforce + Neovim community already maintains dedicated
tooling (e.g. [sf.nvim](https://github.com/xixiaofinland/sf.nvim)).

**Server:** [`@sf-agentscript/lsp-server`](https://www.npmjs.com/package/@sf-agentscript/lsp-server)
(`npm install -g @sf-agentscript/lsp-server`) ships the `agentscript-lsp`
executable; `agentscript-lsp --stdio` provides diagnostics, completions,
hover, go-to-definition, references, rename, document symbols, code actions
and semantic tokens.

**Popularity criteria:** the server repository has 250+ stars within a week of
launch, and Agent Script is the mandated authoring format for Salesforce
Agentforce (see above).

**Filetype:** Neovim core does not yet detect `.agent`; the docstring shows the
`vim.filetype.add` one-liner (upstream registers only the `.agent` extension,
language id `agentscript`).

**Naming:** the config, server and filetype are all named `agentscript` — the
exact language id upstream's VS Code extension registers. No competing
convention exists anywhere as of 2026-07-22: GitHub Linguist has no entry for
`.agent`/Agent Script, and neither Helix's `languages.toml` nor Neovim core's
`filetype.lua` mention it, so upstream's own id is the only precedent. This
also fits CONTRIBUTING's guidance (unique server name, nothing to
dash-convert).

**Known caveat:** the currently published `@sf-agentscript/lsp-server@2.2.30`
crashes at import due to an upstream dependency-pin mistake
(`agentforce-dialect@2.13.4` needs `@sf-agentscript/language` ≥ 2.8.4 but pins
2.5.4) — reported upstream at salesforce/agentscript#73. Installing with an npm
`overrides` fix works today, and this config is correct regardless: it runs
whatever `agentscript-lsp` resolves on `$PATH`.

Verified locally on Neovim 0.12.2 (Windows): server attaches on `.agent`
buffers, publishes parse errors and semantic lints (e.g. unused-variable).
