### PR TITLE
corrected roslyn_ls.lua call to .iter to take a table as expected

### DIFF
--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -52,7 +52,7 @@ end
 ---@param client vim.lsp.Client
 local function refresh_diagnostics(client)
   local capabilities = vim
-    .iter({client.dynamic_capabilities.capabilities.diagnosticProvider})
+    .iter(client.dynamic_capabilities.capabilities.diagnosticProvider or {})
     :map(function(cap)
       return cap.registerOptions.identifier
     end)

--- a/lsp/roslyn_ls.lua
+++ b/lsp/roslyn_ls.lua
@@ -52,7 +52,7 @@ end
 ---@param client vim.lsp.Client
 local function refresh_diagnostics(client)
   local capabilities = vim
-    .iter(client.dynamic_capabilities.capabilities.diagnosticProvider)
+    .iter({client.dynamic_capabilities.capabilities.diagnosticProvider})
     :map(function(cap)
       return cap.registerOptions.identifier
     end)


### PR DESCRIPTION
neovim kept giving me an annoying error every time i edited a .cs file. reading the traceback i saw wherein the call was improperly invoked. hope this is helpful