### PR TITLE
docs(emmylua_ls): remove irrelevant issue link

### DIFF
--- a/lsp/emmylua_ls.lua
+++ b/lsp/emmylua_ls.lua
@@ -43,7 +43,7 @@
 ---           -- For LSP Settings Type Annotations: https://github.com/neovim/nvim-lspconfig#lsp-settings-type-annotations
 ---           vim.api.nvim_get_runtime_file('lua/lspconfig', false)[1],
 ---         },
----         -- Or pull in all of 'runtimepath'. May be slower! https://github.com/neovim/nvim-lspconfig/issues/3189
+---         -- Or pull in all of 'runtimepath'. May be slower!
 ---         -- library = vim.api.nvim_get_runtime_file('', true),
 ---       },
 ---     },


### PR DESCRIPTION
emmylua_ls [deduplicates all workspace files](https://github.com/EmmyLuaLs/emmylua-analyzer-rust/blob/e3d5adece807c6acf9b90fbba391cf4502f13808/crates/emmylua_code_analysis/src/vfs/collect_workspace_files.rs#L385-L405) before analysing them. Therefore, using the recommended `workspace.library = vim.api.nvim_get_runtime_file("", true)` will not result in erroneous duplicate field warnings as discussed
in #3189.