### PR TITLE
fix(ols): reuse existing client when opening libraries

### DIFF
--- a/lsp/ols.lua
+++ b/lsp/ols.lua
@@ -6,12 +6,51 @@
 
 local util = require 'lspconfig.util'
 
+---@return string?
+local function default_odin_root()
+  -- https://odin-lang.org/docs/install/#release-requirements--notes
+  local odin_root = os.getenv('ODIN_ROOT')
+  if odin_root ~= nil and odin_root ~= '' then
+    return vim.fs.normalize(odin_root)
+  end
+
+  -- https://github.com/odin-lang/Odin/wiki/Compiler-Flags
+  local result = vim.system({ 'odin', 'root' }, { text = true }):wait()
+  if result.code == 0 and result.stdout ~= nil then
+    local stdout = vim.trim(result.stdout)
+    return stdout ~= '' and vim.fs.normalize(stdout) or nil
+  end
+end
+
+---@param fname string
+---@return string?
+local function is_library(fname)
+  local odin_root = default_odin_root()
+  if odin_root == nil then
+    return nil
+  end
+
+  fname = vim.fs.normalize(fname)
+  for _, lib in ipairs({ 'base', 'core', 'vendor' }) do
+    if vim.fs.relpath(vim.fs.joinpath(odin_root, lib), fname) ~= nil then
+      local clients = vim.lsp.get_clients({ name = 'ols' })
+      return #clients > 0 and clients[#clients].config.root_dir or nil
+    end
+  end
+end
+
 ---@type vim.lsp.Config
 return {
   cmd = { 'ols' },
   filetypes = { 'odin' },
   root_dir = function(bufnr, on_dir)
     local fname = vim.api.nvim_buf_get_name(bufnr)
+    local reused_dir = is_library(fname)
+    if reused_dir then
+      on_dir(reused_dir)
+      return
+    end
+
     on_dir(util.root_pattern('ols.json', '.git', '*.odin')(fname))
   end,
 }


### PR DESCRIPTION
Problem: When going to the definition of a library function, a new ols client is created.

Solution: Detect if the file is a library. If so, re-use a pre-existing client.

----------------

Similar to the current rust-analyzer logic: https://github.com/neovim/nvim-lspconfig/blob/1c0d8f70dbc8827263eedc3cf7021ceba0f68689/lsp/rust_analyzer.lua#L65

Comments have links to odin's documentation.