### PR TITLE
fix(vhdl_ls): require workspace

### DIFF
--- a/lsp/vhdl_ls.lua
+++ b/lsp/vhdl_ls.lua
@@ -35,4 +35,5 @@ return {
     'vhdl_ls.toml',
     '.vhdl_ls.toml',
   },
+  workspace_required = true,
 }


### PR DESCRIPTION
Problem:
vhdl_ls rejects initialization without a rootUri. Opening a VHDL file
outside a project starts a client with `root_dir = nil` that emits three
errors and produces no diagnostics:

```
LSP[vhdl_ls] Cannot load workspace: Initialize request is missing rootUri parameter.
LSP[vhdl_ls] Error loading vhdl_ls.toml: Workspace root configuration file not set
LSP[vhdl_ls] Opening file /tmp/vhdl-noconfig/e.vhd that is not part of the project
```

Solution:
Set `workspace_required` so the client only starts when a `vhdl_ls.toml`
or `.vhdl_ls.toml` is found.

Verified on Nvim 0.12.4, vhdl_ls 0.88.0:

Without a `vhdl_ls.toml`:
- before: client starts, `root_dir = nil`, three errors, 0 diagnostics
- after: no client starts, no errors

With a `vhdl_ls.toml` present:
- unchanged: client attaches, `root_dir = /tmp/vhdl-ws`, diagnostics reported