### PR TITLE
feat: pkl

### DIFF
--- a/lsp/pkl.lua
+++ b/lsp/pkl.lua
@@ -1,0 +1,19 @@
+--- @brief
+---
+--- https://github.com/apple/pkl-lsp
+---
+--- Language server for [Pkl](https://pkl-lang.org/), a configuration language by Apple.
+---
+--- `pkl-lsp` can be installed via Homebrew:
+--- ```sh
+--- brew install pkl
+--- ```
+---
+--- Or downloaded from the [GitHub releases page](https://github.com/apple/pkl/releases).
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'pkl-lsp' },
+  filetypes = { 'pkl', 'pcf' },
+  root_markers = { 'PklProject', '.git' },
+}


### PR DESCRIPTION
### Why
Pkl (https://pkl-lang.org/) is Apple's configuration language with ~1.3k GitHub stars and an official LSP server.

### What
Add a minimal `pkl` config so users can enable it with `vim.lsp.enable('pkl')`.

### Notes
- Prior PR (#3440) was closed because `pkl-lsp` was JAR-only and required a jar in CWD. That's no longer the case — `pkl-lsp` is now a native binary installable via `brew install pkl`, so `cmd = { 'pkl-lsp' }` works out of the box.