### PR TITLE
feat: laravel_lsp

### DIFF
--- a/lsp/laravel_lsp.lua
+++ b/lsp/laravel_lsp.lua
@@ -1,0 +1,25 @@
+---@brief
+---
+--- https://github.com/laravel/lsp
+---
+--- Laravel LSP provides framework-aware editor features for Laravel applications.
+---
+--- Install Laravel LSP globally with Composer:
+---
+--- ```sh
+--- composer global require laravel/lsp
+--- ```
+---
+--- Ensure Composer's global bin directory is on `$PATH`.
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'laravel-lsp' },
+  filetypes = { 'php', 'blade' },
+  root_dir = function(bufnr, on_dir)
+    local root = vim.fs.root(bufnr, 'artisan')
+    if root then
+      on_dir(root)
+    end
+  end,
+}


### PR DESCRIPTION
## Summary

- add a configuration for the official Laravel language server
- enable PHP and Blade files
- start the server only when an `artisan` project root is found

## Motivation

Laravel maintains a separate language server at `laravel/lsp`. The existing `laravel_ls` configuration targets the unrelated `laravel-ls/laravel-ls` project, so users of the official server currently need to define a custom Neovim configuration.

## Impact

Users can enable the official server with:

```lua
vim.lsp.enable('laravel_lsp')
```

Non-Laravel PHP projects are unaffected because the configuration requires an `artisan` root marker.

## Validation

- `stylua --check lsp/laravel_lsp.lua`
- headless Neovim config loading and root callback assertions
- `bash .github/ci/lint.sh origin/master HEAD`
- `git diff --check`

The full Vusted and EmmyLua checks were not run because `vusted` and `emmylua_check` are not installed locally.
