### PR TITLE
fix(verible): add verible.filelist as root marker

### DIFF
--- a/lsp/verible.lua
+++ b/lsp/verible.lua
@@ -13,5 +13,5 @@
 return {
   cmd = { 'verible-verilog-ls' },
   filetypes = { 'systemverilog', 'verilog' },
-  root_markers = { '.git' },
+  root_markers = { 'verible.filelist', '.git' },
 }


### PR DESCRIPTION
`verible-verilog-ls`'s README documents `verible.filelist` as the marker used to determine the project root (https://github.com/chipsalliance/verible/blob/master/verible/verilog/tools/ls/README.md#project-root). `lsp/verible.lua` only has `.git`, so in any project where `verible.filelist` isn't co-located with `.git`, `root_dir` resolves to the wrong (ancestor) directory.

  Verified locally: with only `.git` as a marker, `root_dir` resolved to a `.git` ancestor above the actual project directory. Adding `verible.filelist` ahead of `.git` fixes this, confirmed both directions (before/after) via `vim.lsp.get_clients()[1].root_dir`.

  Note: I also tested whether this alone restores cross-file go-to-definition and could not get it working even with a correct root_dir — that appears to be a separate issue in `verible-verilog-ls` itself (possibly related to chipsalliance/verible#2290), not something in this config. This PR is scoped only to root_dir resolution, which is independently correct per the upstream docs and consistent with how vhdl_ls.lua/ghdl_ls.lua/svlangserver.lua already prioritize their markers.