### PR TITLE
fix(julials): fix the default setup

### DIFF
--- a/lsp/julials.lua
+++ b/lsp/julials.lua
@@ -1,13 +1,13 @@
 ---@brief
 ---
---- https://github.com/julia-vscode/julia-vscode
+--- https://github.com/julia-vscode/LanguageServer.jl/
 ---
---- LanguageServer.jl, SymbolServer.jl and StaticLint.jl can be installed with `julia` and `Pkg`:
+--- LanguageServer.jl can be installed with `julia` and `Pkg`:
 --- ```sh
---- julia --project=~/.julia/environments/nvim-lspconfig -e 'using Pkg; Pkg.add("LanguageServer"); Pkg.add("SymbolServer"); Pkg.add("StaticLint")'
+--- julia --project=~/.julia/environments/nvim-lspconfig -e 'using Pkg; Pkg.add("LanguageServer")'
 --- ```
 --- where `~/.julia/environments/nvim-lspconfig` is the location where
---- the default configuration expects LanguageServer.jl, SymbolServer.jl and StaticLint.jl to be installed.
+--- the default configuration expects LanguageServer.jl to be installed.
 ---
 --- To update an existing install, use the following command:
 --- ```sh
@@ -96,30 +96,10 @@ local cmd = {
         "environments", "nvim-lspconfig"
     )
     pushfirst!(LOAD_PATH, ls_install_path)
-    using LanguageServer, SymbolServer, StaticLint
+    using LanguageServer
     popfirst!(LOAD_PATH)
-    depot_path = get(ENV, "JULIA_DEPOT_PATH", "")
-    project_path = let
-        dirname(something(
-            ## 1. Finds an explicitly set project (JULIA_PROJECT)
-            Base.load_path_expand((
-                p = get(ENV, "JULIA_PROJECT", nothing);
-                p === nothing ? nothing : isempty(p) ? nothing : p
-            )),
-            ## 2. Look for a Project.toml file in the current working directory,
-            ##    or parent directories, with $HOME as an upper boundary
-            Base.current_project(),
-            ## 3. First entry in the load path
-            get(Base.load_path(), 1, nothing),
-            ## 4. Fallback to default global environment,
-            ##    this is more or less unreachable
-            Base.load_path_expand("@v#.#"),
-        ))
-    end
-    @info "Running language server" VERSION pwd() project_path depot_path
-    server = LanguageServer.LanguageServerInstance(stdin, stdout, project_path, depot_path)
-    server.runlinter = true
-    run(server)
+    @info "Running language server" VERSION pwd()
+    LanguageServer.runserver()
   ]],
 }
 


### PR DESCRIPTION
This patch updates the julials config:
 - Drop explicit installation and loading of SymbolServer and StaticLint
   (these are/were dependencies of LanguageServer and it was never
   required to load them at this top level anyway).
 - Drop the project path handling. This is only used for standalone
   files now, and the LanguageServer itself makes a good job of
   determining it.
 - Use LanguageServer.runserver() to start the server instead of the
   internal run(LanguageServerInstance(...)) path. The latter is broken
   since
   https://github.com/julia-vscode/LanguageServer.jl/commit/eb9eb72a10467dd951f605090ca3f144c74cecee
   (see e.g.
   https://github.com/julia-vscode/LanguageServer.jl/issues/1408)
   because of updated arguments to the LanguageServerInstance default
   constructor.