### PR TITLE
notify the user if rustc/cargo are missing instead of throwing an error (v2)

### DIFF
--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -44,8 +44,9 @@ local function get_rustc(opt)
     return command
   elseif opt.notify_on_error then
     vim.notify_once(
-      "[rust_analyzer] `rustc` (Rust compiler) not found. Please make sure it is installed and your PATH or RUSTC environment variables are set up correctly.",
-      vim.log.levels.WARN)
+      '[rust_analyzer] `rustc` (Rust compiler) not found. Please make sure it is installed and your PATH or RUSTC environment variables are set up correctly.',
+      vim.log.levels.WARN
+    )
   end
 end
 
@@ -57,8 +58,10 @@ local function get_cargo(opt)
   if ok then
     return command
   elseif opt.notify_on_error then
-    vim.notify_once("[rust_analyzer] `cargo` (Rust package manager) not found. Please make sure it is installed.",
-      vim.log.levels.WARN)
+    vim.notify_once(
+      '[rust_analyzer] `cargo` (Rust package manager) not found. Please make sure it is installed.',
+      vim.log.levels.WARN
+    )
   end
 end
 

--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -35,34 +35,32 @@ local function reload_workspace(bufnr)
   end
 end
 
----@param opt { notify_on_error: boolean? }
----@return string|nil
-local function get_rustc(opt)
-  local command = os.getenv 'RUSTC' or 'rustc'
-  local ok, _ = pcall(vim.system, { command })
-  if ok then
-    return command
-  elseif opt.notify_on_error then
-    vim.notify_once(
-      '[rust_analyzer] `rustc` (Rust compiler) not found. Please make sure it is installed and your PATH or RUSTC environment variables are set up correctly.',
-      vim.log.levels.WARN
-    )
-  end
-end
+---@param command string
+---@param opt { env_override: string? }?
+---@return boolean
+local function executable_exists(command, opt)
+  opt = opt or {}
+  local env_command = opt.env_override and os.getenv(opt.env_override)
+  local ok = false
+  local error_msg = ''
 
----@param opt { notify_on_error: boolean? }
----@return string|nil
-local function get_cargo(opt)
-  local command = 'cargo'
-  local ok, _ = pcall(vim.system, { command })
-  if ok then
-    return command
-  elseif opt.notify_on_error then
-    vim.notify_once(
-      '[rust_analyzer] `cargo` (Rust package manager) not found. Please make sure it is installed.',
-      vim.log.levels.WARN
+  if env_command then
+    ok = vim.fn.executable(env_command) == 1
+    error_msg = ('%s not found. Please make sure the environment variable %s points to the %s executable or unset it.'):format(
+      command,
+      opt.env_override,
+      command
     )
+  else
+    ok = vim.fn.executable(command) == 1
+    error_msg = ('%s not found. Please make sure it is installed.'):format(command)
   end
+
+  if not ok then
+    vim.notify_once(('[rust_analyzer] %s'):format(error_msg), vim.log.levels.WARN)
+  end
+
+  return ok
 end
 
 local function user_sysroot_src()
@@ -72,10 +70,7 @@ end
 local function default_sysroot_src()
   local sysroot = vim.tbl_get(vim.lsp.config['rust_analyzer'], 'settings', 'rust-analyzer', 'cargo', 'sysroot')
   if not sysroot then
-    local rustc = get_rustc({ notify_on_error = true })
-    if not rustc then
-      return
-    end
+    local rustc = os.getenv 'RUSTC' or 'rustc'
     local result = vim.system({ rustc, '--print', 'sysroot' }, { text = true }):wait()
 
     local stdout = result.stdout
@@ -119,13 +114,7 @@ return {
   cmd = { 'rust-analyzer' },
   filetypes = { 'rust' },
   root_dir = function(bufnr, on_dir)
-    local rustc = get_rustc({ notify_on_error = true })
-    if not rustc then
-      return
-    end
-
-    local cargo = get_cargo({ notify_on_error = true })
-    if not cargo then
+    if not executable_exists('rustc', { env_override = 'RUSTC' }) or not executable_exists('cargo') then
       return
     end
 
@@ -148,7 +137,7 @@ return {
     end
 
     local cmd = {
-      cargo,
+      'cargo',
       'metadata',
       '--no-deps',
       '--format-version',
@@ -212,12 +201,7 @@ return {
     ---@param command table{ title: string, command: string, arguments: any[] }
     vim.lsp.commands['rust-analyzer.runSingle'] = function(command)
       local r = command.arguments[1]
-      local cargo = get_cargo({ notify_on_error = true })
-      if not cargo then
-        return
-      end
-
-      local cmd = { cargo, unpack(r.args.cargoArgs) }
+      local cmd = { 'cargo', unpack(r.args.cargoArgs) }
       if r.args.executableArgs and #r.args.executableArgs > 0 then
         vim.list_extend(cmd, { '--', unpack(r.args.executableArgs) })
       end

--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -46,14 +46,14 @@ local function executable_exists(command, opt)
 
   if env_command then
     ok = vim.fn.executable(env_command) == 1
-    error_msg = ('%s not found. Please make sure the environment variable %s points to the %s executable or unset it.'):format(
+    error_msg = ('%s not found. Ensure the environment variable %s points to the %s executable or unset it.'):format(
       command,
       opt.env_override,
       command
     )
   else
     ok = vim.fn.executable(command) == 1
-    error_msg = ('%s not found. Please make sure it is installed.'):format(command)
+    error_msg = ('%s not found.'):format(command)
   end
 
   if not ok then

--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -36,31 +36,15 @@ local function reload_workspace(bufnr)
 end
 
 ---@param command string
----@param opt { env_override: string? }?
 ---@return boolean
-local function executable_exists(command, opt)
-  opt = opt or {}
-  local env_command = opt.env_override and os.getenv(opt.env_override)
-  local ok = false
-  local error_msg = ''
+local function executable_exists(command)
+  local exists = vim.fn.executable(command) == 1
 
-  if env_command then
-    ok = vim.fn.executable(env_command) == 1
-    error_msg = ('%s not found. Ensure the environment variable %s points to the %s executable or unset it.'):format(
-      command,
-      opt.env_override,
-      command
-    )
-  else
-    ok = vim.fn.executable(command) == 1
-    error_msg = ('%s not found.'):format(command)
+  if not exists then
+    vim.notify_once(('[rust_analyzer] %s not found.'):format(command), vim.log.levels.WARN)
   end
 
-  if not ok then
-    vim.notify_once(('[rust_analyzer] %s'):format(error_msg), vim.log.levels.WARN)
-  end
-
-  return ok
+  return exists
 end
 
 local function user_sysroot_src()
@@ -70,20 +54,12 @@ end
 local function default_sysroot_src()
   local sysroot = vim.tbl_get(vim.lsp.config['rust_analyzer'], 'settings', 'rust-analyzer', 'cargo', 'sysroot')
   if not sysroot then
-    local rustc = os.getenv 'RUSTC' or 'rustc'
-    local result = vim.system({ rustc, '--print', 'sysroot' }, { text = true }):wait()
+    local result = vim
+      .system({ 'cargo', '-Z', 'unstable-options', 'rustc', '--print', 'sysroot' }, { text = true })
+      :wait()
 
-    local stdout = result.stdout
-    if result.code == 0 and stdout then
-      if string.sub(stdout, #stdout) == '\n' then
-        if #stdout > 1 then
-          sysroot = string.sub(stdout, 1, #stdout - 1)
-        else
-          sysroot = ''
-        end
-      else
-        sysroot = stdout
-      end
+    if result.code == 0 and result.stdout then
+      sysroot = vim.trim(result.stdout)
     end
   end
 
@@ -114,7 +90,7 @@ return {
   cmd = { 'rust-analyzer' },
   filetypes = { 'rust' },
   root_dir = function(bufnr, on_dir)
-    if not executable_exists('rustc', { env_override = 'RUSTC' }) or not executable_exists('cargo') then
+    if not executable_exists('cargo') then
       return
     end
 

--- a/lsp/rust_analyzer.lua
+++ b/lsp/rust_analyzer.lua
@@ -35,6 +35,33 @@ local function reload_workspace(bufnr)
   end
 end
 
+---@param opt { notify_on_error: boolean? }
+---@return string|nil
+local function get_rustc(opt)
+  local command = os.getenv 'RUSTC' or 'rustc'
+  local ok, _ = pcall(vim.system, { command })
+  if ok then
+    return command
+  elseif opt.notify_on_error then
+    vim.notify_once(
+      "[rust_analyzer] `rustc` (Rust compiler) not found. Please make sure it is installed and your PATH or RUSTC environment variables are set up correctly.",
+      vim.log.levels.WARN)
+  end
+end
+
+---@param opt { notify_on_error: boolean? }
+---@return string|nil
+local function get_cargo(opt)
+  local command = 'cargo'
+  local ok, _ = pcall(vim.system, { command })
+  if ok then
+    return command
+  elseif opt.notify_on_error then
+    vim.notify_once("[rust_analyzer] `cargo` (Rust package manager) not found. Please make sure it is installed.",
+      vim.log.levels.WARN)
+  end
+end
+
 local function user_sysroot_src()
   return vim.tbl_get(vim.lsp.config['rust_analyzer'], 'settings', 'rust-analyzer', 'cargo', 'sysrootSrc')
 end
@@ -42,7 +69,10 @@ end
 local function default_sysroot_src()
   local sysroot = vim.tbl_get(vim.lsp.config['rust_analyzer'], 'settings', 'rust-analyzer', 'cargo', 'sysroot')
   if not sysroot then
-    local rustc = os.getenv 'RUSTC' or 'rustc'
+    local rustc = get_rustc({ notify_on_error = true })
+    if not rustc then
+      return
+    end
     local result = vim.system({ rustc, '--print', 'sysroot' }, { text = true }):wait()
 
     local stdout = result.stdout
@@ -86,6 +116,16 @@ return {
   cmd = { 'rust-analyzer' },
   filetypes = { 'rust' },
   root_dir = function(bufnr, on_dir)
+    local rustc = get_rustc({ notify_on_error = true })
+    if not rustc then
+      return
+    end
+
+    local cargo = get_cargo({ notify_on_error = true })
+    if not cargo then
+      return
+    end
+
     local fname = vim.api.nvim_buf_get_name(bufnr)
     local reused_dir = is_library(fname)
     if reused_dir then
@@ -105,7 +145,7 @@ return {
     end
 
     local cmd = {
-      'cargo',
+      cargo,
       'metadata',
       '--no-deps',
       '--format-version',
@@ -169,7 +209,12 @@ return {
     ---@param command table{ title: string, command: string, arguments: any[] }
     vim.lsp.commands['rust-analyzer.runSingle'] = function(command)
       local r = command.arguments[1]
-      local cmd = { 'cargo', unpack(r.args.cargoArgs) }
+      local cargo = get_cargo({ notify_on_error = true })
+      if not cargo then
+        return
+      end
+
+      local cmd = { cargo, unpack(r.args.cargoArgs) }
       if r.args.executableArgs and #r.args.executableArgs > 0 then
         vim.list_extend(cmd, { '--', unpack(r.args.executableArgs) })
       end


### PR DESCRIPTION
Fixes https://github.com/neovim/nvim-lspconfig/issues/4465

This is a revised version of https://github.com/neovim/nvim-lspconfig/pull/4464
- we define `get_rustc` and `get_cargo` functions to check if the rust compiler and the rust package manager cargo are available
- checks are performed on lsp initialization and also before spawning the respective processes
- it displays a warning  if rustc or cargo cannot be found, so the user stays informed
- it only displays the warning once to not be annoying in case the user intentionally does not have rustc/cargo installed (but rust_analyzer exists in the PATH) (thanks to @idbrii)