### PR TITLE
fix(tsc): unable to find tsgo

### DIFF
--- a/lsp/tsc.lua
+++ b/lsp/tsc.lua
@@ -73,22 +73,37 @@ return {
     },
   },
   cmd = function(dispatchers, config)
-    local cmd = 'tsc'
-    local bins = { 'tsc', 'tsgo' }
-    for _, bin in ipairs(bins) do
-      if (config or {}).root_dir then
-        local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', bin)
-        if vim.fn.executable(local_cmd) == 1 then
-          cmd = local_cmd
-          break
+    local bins = { 'tsgo', 'tsc' }
+
+    local local_cmds = (config and config.root_dir)
+        and vim
+          .iter(bins)
+          :map(function(bin)
+            return vim.fs.joinpath(config.root_dir, 'node_modules/.bin', bin)
+          end)
+          :totable()
+      or {}
+
+    local cmd = vim
+      .iter({ local_cmds, bins })
+      :flatten()
+      :filter(function(cmd)
+        return vim.fn.executable(cmd) == 1
+      end)
+      :filter(function(cmd)
+        if cmd:match('tsc$') then
+          local result = vim.system({ cmd, '--version' }, { text = true }):wait()
+          if result.code ~= 0 then
+            return false
+          end
+          local ver = vim.version.parse(result.stdout)
+          return ver and ver.major >= 7 or false
         end
-      end
-      if vim.fn.executable(bin) == 1 then
-        cmd = bin
-        break
-      end
-    end
-    return vim.lsp.rpc.start({ cmd, '--lsp', '--stdio' }, dispatchers)
+        return true
+      end)
+      :next()
+
+    return cmd and vim.lsp.rpc.start({ cmd, '--lsp', '--stdio' }, dispatchers)
   end,
   filetypes = {
     'javascript',

--- a/lsp/tsc.lua
+++ b/lsp/tsc.lua
@@ -46,6 +46,18 @@
 --- If DENO ROOT is found, and it's longer than or equal to PROJECT ROOT, then this is a Deno file, and we abort.
 --- Otherwise, attach at PROJECT ROOT, or the cwd if not found.
 
+local function validate_tsc_version(cmd_path)
+  local result = vim.system({ cmd_path, '--version' }, { text = true }):wait()
+
+  if result.code ~= 0 then
+    return false
+  end
+
+  local version = vim.version.parse(result.stdout)
+
+  return version and version.major >= 7 or false
+end
+
 ---@type vim.lsp.Config
 return {
   settings = {
@@ -73,37 +85,34 @@ return {
     },
   },
   cmd = function(dispatchers, config)
+    local cmd = 'tsc'
     local bins = { 'tsgo', 'tsc' }
-
-    local local_cmds = (config and config.root_dir)
-        and vim
-          .iter(bins)
-          :map(function(bin)
-            return vim.fs.joinpath(config.root_dir, 'node_modules/.bin', bin)
-          end)
-          :totable()
-      or {}
-
-    local cmd = vim
-      .iter({ local_cmds, bins })
-      :flatten()
-      :filter(function(cmd)
-        return vim.fn.executable(cmd) == 1
-      end)
-      :filter(function(cmd)
-        if cmd:match('tsc$') then
-          local result = vim.system({ cmd, '--version' }, { text = true }):wait()
-          if result.code ~= 0 then
-            return false
+    for _, bin in ipairs(bins) do
+      if (config or {}).root_dir then
+        local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', bin)
+        if vim.fn.executable(local_cmd) == 1 then
+          if cmd:match('tsc$') then
+            local ok = validate_tsc_version(local_cmd)
+            if not ok then
+              break
+            end
           end
-          local ver = vim.version.parse(result.stdout)
-          return ver and ver.major >= 7 or false
+          cmd = local_cmd
+          break
         end
-        return true
-      end)
-      :next()
-
-    return cmd and vim.lsp.rpc.start({ cmd, '--lsp', '--stdio' }, dispatchers)
+      end
+      if vim.fn.executable(bin) == 1 then
+        if cmd:match('tsc$') then
+          local ok = validate_tsc_version(local_cmd)
+          if not ok then
+            break
+          end
+        end
+        cmd = bin
+        break
+      end
+    end
+    return vim.lsp.rpc.start({ cmd, '--lsp', '--stdio' }, dispatchers)
   end,
   filetypes = {
     'javascript',


### PR DESCRIPTION
In the code, tsc is searched first, followed by tsgo. For large code repositories that use tsgo but have difficulty upgrading the tsc version, they may match a tsc version that does not support LSP. Therefore, it is necessary to prioritize searching for tsgo and confirm the tsc version