### PR TITLE
fix(tsc): skip binaries that do not support --lsp

### DIFF
--- a/lsp/tsc.lua
+++ b/lsp/tsc.lua
@@ -52,6 +52,7 @@
 
 local bin_cache = {} ---@type table<string, string>
 
+--- Checks if the given tsc/tsgo cmd supports the "--lsp" arg.
 ---@param bin string
 ---@return boolean
 local function supports_lsp(bin)
@@ -60,9 +61,9 @@ local function supports_lsp(bin)
   end
 
   local out = vim.system({ bin, '--version' }, { text = true }):wait()
-  local major = tonumber((out.stdout or ''):match('(%d+)%.'))
+  local version = vim.version.parse(out.stdout or '')
 
-  return out.code == 0 and major ~= nil and major >= 7
+  return out.code == 0 and version ~= nil and version.major >= 7
 end
 
 ---@type vim.lsp.Config

--- a/lsp/tsc.lua
+++ b/lsp/tsc.lua
@@ -8,6 +8,10 @@
 ---
 --- `tsc` can be installed via npm `npm install typescript`.
 ---
+--- The language server (`--lsp`) is only available in the native compiler, TypeScript 7.0
+--- and newer. An older binary in `node_modules/.bin` is skipped in favour of one on `$PATH`
+--- that does support it; if no candidate qualifies, the server does not attach.
+---
 --- ### Monorepo support
 ---
 --- `tsc` supports monorepos by default. It will automatically find the `tsconfig.json` or `jsconfig.json` corresponding to the package you are working on.
@@ -46,6 +50,21 @@
 --- If DENO ROOT is found, and it's longer than or equal to PROJECT ROOT, then this is a Deno file, and we abort.
 --- Otherwise, attach at PROJECT ROOT, or the cwd if not found.
 
+local bin_cache = {} ---@type table<string, string>
+
+---@param bin string
+---@return boolean
+local function supports_lsp(bin)
+  if vim.fn.executable(bin) ~= 1 then
+    return false
+  end
+
+  local out = vim.system({ bin, '--version' }, { text = true }):wait()
+  local major = tonumber((out.stdout or ''):match('(%d+)%.'))
+
+  return out.code == 0 and major ~= nil and major >= 7
+end
+
 ---@type vim.lsp.Config
 return {
   settings = {
@@ -73,21 +92,7 @@ return {
     },
   },
   cmd = function(dispatchers, config)
-    local cmd = 'tsc'
-    local bins = { 'tsc', 'tsgo' }
-    for _, bin in ipairs(bins) do
-      if (config or {}).root_dir then
-        local local_cmd = vim.fs.joinpath(config.root_dir, 'node_modules/.bin', bin)
-        if vim.fn.executable(local_cmd) == 1 then
-          cmd = local_cmd
-          break
-        end
-      end
-      if vim.fn.executable(bin) == 1 then
-        cmd = bin
-        break
-      end
-    end
+    local cmd = bin_cache[(config or {}).root_dir] or 'tsc'
     return vim.lsp.rpc.start({ cmd, '--lsp', '--stdio' }, dispatchers)
   end,
   filetypes = {
@@ -119,6 +124,26 @@ return {
     end
     -- project is standard TS, not deno
     -- We fallback to the current working directory if no project root is found
-    on_dir(project_root or vim.fn.getcwd())
+    local root = project_root or vim.fn.getcwd()
+
+    if bin_cache[root] then
+      return on_dir(root)
+    end
+
+    local bins = {}
+
+    for _, bin in ipairs({ 'tsc', 'tsgo' }) do
+      bins[#bins + 1] = vim.fs.joinpath(root, 'node_modules/.bin', bin)
+      bins[#bins + 1] = bin
+    end
+
+    for _, bin in ipairs(bins) do
+      if supports_lsp(bin) then
+        bin_cache[root] = bin
+        return on_dir(root)
+      end
+    end
+
+    vim.notify('tsc: no binary supporting `--lsp` found (requires TypeScript 7.0+)', vim.log.levels.WARN)
   end,
 }


### PR DESCRIPTION
Fixes #4504.

`lsp/tsc.lua` picked its binary in `cmd` using `vim.fn.executable()` alone, preferring
`node_modules/.bin`. But `--lsp` only exists in the native compiler, TypeScript 7.0 and
newer, so in any project still pinned to TypeScript 5.x/6.x the project-local binary won the
lookup, got spawned with a flag it does not understand, and died — even when a 7.0+ `tsc`
was sitting on `$PATH`.

Resolution moves to `root_dir`, which probes `--version` and takes the first candidate
reporting major >= 7. The existing preference order is preserved (project-local before
`$PATH`, `tsc` before `tsgo`). The result is cached per project root and `cmd` becomes a
lookup into that cache, so the probe runs once per root rather than on every client start,
and `cmd` cannot disagree with the binary `root_dir` already accepted. When no candidate
qualifies the server does not attach and warns instead of failing to spawn.

### Verification

Nvim v0.12.4, in a project with `node_modules/.bin/tsc` at `Version 5.9.3` and
`tsc` `Version 7.0.2` on `$PATH`.

Before:

```
NOTIFY: Client tsc quit with exit code 1 and signal 0.
clients=0
```

After:

```
clients=1
ATTACHED tsc root=/home/dan/Projects/Personal-Angular
```

`stylua --check .` and `.github/ci/lint.sh` pass.