### PR TITLE
fix(vhdl_ls): drop .vhdl_ls.toml root marker

### DIFF
--- a/lsp/vhdl_ls.lua
+++ b/lsp/vhdl_ls.lua
@@ -33,7 +33,6 @@ return {
   filetypes = { 'vhd', 'vhdl' },
   root_markers = {
     'vhdl_ls.toml',
-    '.vhdl_ls.toml',
   },
   workspace_required = true,
 }


### PR DESCRIPTION
Closes #4503.

Problem:

`.vhdl_ls.toml` is listed in `root_markers`, but vhdl_ls only reads that file
from the user's home directory, never from a project directory:

```rust
// vhdl_lang/src/config.rs
/// Load configuration file from home folder
fn load_home_config(&mut self, messages: &mut dyn MessageHandler) {
    if let Some(home_dir) = dirs::home_dir() {
        let file_name = home_dir.join(".vhdl_ls.toml");
```

With `~/.vhdl_ls.toml` present and no project `vhdl_ls.toml` anywhere in the
ancestry, `root_dir` resolves to `$HOME` for any VHDL file underneath it.
Projects with their own `vhdl_ls.toml` are unaffected, since it takes priority.

Solution:

Remove `.vhdl_ls.toml` from `root_markers`.

How to verify:

Using the reproduction in #4503, pointing `LSPCONFIG_FORK` at a checkout before
and after this change:

| target | before | after |
| --- | --- | --- |
| `flat/counter.vhd` (no project config) | `root_dir = .../home` | no client attached |
| `proj/counter.vhd` (has `vhdl_ls.toml`) | `root_dir = .../home/proj` | `root_dir = .../home/proj` |

Adding `print(vim.inspect(vim.lsp.config['vhdl_ls'].root_markers))` to that
probe confirms which checkout is loaded. The
`Library mapping is unknown ... workspace root path` warning from the server
appears only in the before/no-project case.

Note:

`$HOME` has been reachable as a root since #2504, but only became the only
remaining path to a server for global-config users after #4494 set
`workspace_required = true`. This removes that path, so anyone relying solely
on `~/.vhdl_ls.toml` will no longer get an attach.

The marker was added with the config in #2504 by @fmaggi and carried into
`lsp/vhdl_ls.lua` unchanged by the 0.11 migration in #3659 — flagging per
@justinmk's comment on #4503.

Happy to open a separate PR adding a lower-priority `.git` fallback if you want
`vhdl_ls` to match the other HDL configs on that point.