### PR TITLE
fix(slang-server): Properly detect different workspaces in the same git repo

### DIFF
--- a/lsp/slang_server.lua
+++ b/lsp/slang_server.lua
@@ -13,5 +13,5 @@
 return {
   cmd = { 'slang-server' },
   filetypes = { 'systemverilog', 'verilog' },
-  root_markers = { '.git', '.slang' },
+  root_markers = vim.fn.has('nvim-0.11.3') == 1 and { { '.git', '.slang' } } or { '.git', '.slang' },
 }


### PR DESCRIPTION
**Problem** 
Workspace search always converges to the project repo root dir (that has `.git`) regardless of presence of `.slang/` in any of subdirs. This makes it impossible to properly detect individual workspaces in monorepo projects. E.g. see https://github.com/EECS-151/fpga-labs-sp26. Each of `labX/` directories is essentially a separate workspace. Adding `labX/.slang` with workspace config has no effect as `.git` marker is of higher priority and is guaranteed to be found at the repo root, leading to incorrect workspace root resolution.

**Solution**
Whenever possible, give both markers the same priority. So that for multi-workspace repos workspace search will stop at the first `.slang` config rather than at the root `.git`. Nothing has changed for single workspace projects that either have or don't have .slang config at repo root.