### PR TITLE
fix(oxc): allow oxfmt and oxlint to run in single-file mode

### DIFF
--- a/lsp/oxfmt.lua
+++ b/lsp/oxfmt.lua
@@ -47,7 +47,6 @@ return {
     'markdown',
     'svelte',
   },
-  workspace_required = true,
   root_dir = function(bufnr, on_dir)
     local fname = vim.api.nvim_buf_get_name(bufnr)
 

--- a/lsp/oxlint.lua
+++ b/lsp/oxlint.lua
@@ -70,7 +70,6 @@ return {
     )
     on_dir(vim.fs.dirname(vim.fs.find(root_markers, { path = fname, upward = true })[1]))
   end,
-  workspace_required = true,
   on_attach = function(client, bufnr)
     vim.api.nvim_buf_create_user_command(bufnr, 'LspOxlintFixAll', function()
       client:exec_cmd({


### PR DESCRIPTION
## Problem
The `oxlint` and `oxfmt` servers don't get started if a root directory can't be determined.

I think the change which added these servers (originally they were both in `oxc-language-server`)
https://github.com/neovim/nvim-lspconfig/pull/3586 either cargo culted `single_file_support = true` from the `biome` config or there was no single-file support at the time (I only started using `oxfmt` today). Either way, single-file mode is explictly supported now: https://github.com/oxc-project/oxc/blob/f7be7cc5d3011203da2d824be18d6980adc786ba/crates/oxc_language_server/src/backend.rs?plain=1#L141.

## Solution
Remove `workspace_required = true` from the `oxlint` and `oxfmt` configs. 

I've tested `oxfmt` in single-file mode on a HTML, JS, TS, and markdown file. I've tested `oxlint` in single-mode on a JS file.