### PR TITLE
feat: ms_terraform_lsp

### DIFF
--- a/lsp/ms_terraform_lsp.lua
+++ b/lsp/ms_terraform_lsp.lua
@@ -1,0 +1,20 @@
+---@brief
+---
+--- https://github.com/Azure/ms-terraform-lsp
+---
+--- Microsoft Terraform Providers Language Server. Provides completion, hover
+--- documentation and schema validation for the `azapi`, `azurerm` and `msgraph`
+--- providers, and for Azure Verified Modules.
+---
+--- Only covers Microsoft providers, so it is intended to run alongside
+--- [terraformls](#terraformls).
+---
+--- Download a released binary from
+--- https://github.com/Azure/ms-terraform-lsp/releases.
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'ms-terraform-lsp', 'serve' },
+  filetypes = { 'terraform' },
+  root_markers = { '.terraform', '.git' },
+}


### PR DESCRIPTION
Adds a config for <https://github.com/Azure/ms-terraform-lsp>, Microsoft's language server for the `azapi`, `azurerm` and `msgraph` Terraform providers.

The gap it fills is `azapi_resource`: the provider schema exposes `body` as `dynamic`, so `terraform-ls` has nothing to complete inside it. This server has the Azure resource schemas embedded, so it completes property names and values there, with hover docs and diagnostics. It only covers Microsoft providers, so it runs alongside `terraformls`.

The server repo has few stars. It may be because its only documented client is Microsoft's Azure Terraform VS Code extension, which ships the binary inside the extension package, so users have little reason to visit the repo. The `azapi` provider it targets has 250M+ Terraform Registry downloads.

Tested locally with both servers attached: type and API version completion, completion and hover inside `body`, `diagnostics` on unknown properties.
