### PR TITLE
fix(ast_grep): attach to shell buffers

### DIFF
--- a/lsp/ast_grep.lua
+++ b/lsp/ast_grep.lua
@@ -37,6 +37,7 @@ return {
     'ruby',
     'rust',
     'scala',
+    'sh',
     'solidity',
     'swift',
     'typescript',


### PR DESCRIPTION
**Problem:**

`ast_grep` never attaches to shell scripts. `filetypes` lists `bash`, but Nvim's filetype detection never produces `bash` — shell files are `sh` regardless of extension, name, or shebang:

```lua
vim.filetype.match({ filename = 'a.sh' })    --> sh
vim.filetype.match({ filename = 'a.bash' })  --> sh
vim.filetype.match({ filename = 'a.ksh' })   --> sh
vim.filetype.match({ filename = '.bashrc' })  --> sh
vim.filetype.match({ filename = 'PKGBUILD' }) --> sh
```

This is by construction rather than an oversight in detection. `runtime/lua/vim/filetype.lua` maps the `.bash` extension to `detect.bash`, which is `sh_with('bash')`, and `sh()` in `runtime/lua/vim/filetype/detect.lua` ends with:

```lua
return M.shell(path, contents, 'sh'), on_detect
```

The shell variant survives only as `b:is_bash` / `b:is_kornshell` / `b:is_sh`, never as the filetype. So no buffer is ever filetype `bash`.

Checked on a stock `nvim --clean` (v0.12.4), not a configured setup.

**Where it came from:**

`bash` is one of [ast-grep's language ids](https://ast-grep.github.io/reference/languages.html), not an Nvim filetype. The list was imported from that reference in #4106. #4253 caught part of the fallout from that import — *"`csharp` is not a valid filetype in neovim. csharp files are of filetype `cs`."* — and also dropped `javascript.jsx` / `typescript.tsx`, but `bash` was missed.

It slipped through because, unlike `csharp`, `bash` **is** a valid filetype name, so it raises no `Unknown filetype` warning in `:checkhealth vim.lsp`. It is simply never assigned, and ast-grep's shell rules never reach the editor.

**Solution:**

Add `sh`. I kept `bash` rather than replacing it, since it is a valid filetype a user could set manually — happy to drop it if you'd prefer the #4253 treatment.

**Verified:** with `sh` added, `ast_grep` attaches to a `.sh` buffer and reports diagnostics from the project's rules:

```
before:  filetype=sh  clients=bashls,copilot
after:   filetype=sh  clients=ast_grep,bashls,copilot
         DIAG line=197 src=ast-grep code=prefer-long-form-flags
```

`make lint` and `make test` were run against this branch:

- `stylua --check .` — clean.
- `emmylua_check .` — reports `2 errors, 580 warnings, 7 hints`, identical to an unmodified `master` checkout, so nothing here is new. The one warning in `lsp/ast_grep.lua` (`Type 'vim.lsp.Config' not found`) is likewise pre-existing.
- `vusted ./test` — 9/9 pass.
