### PR TITLE
feat: armls

### DIFF
--- a/lsp/armls.lua
+++ b/lsp/armls.lua
@@ -1,0 +1,34 @@
+---@brief
+---
+--- https://github.com/arm/armls
+---
+--- ArmLS is a language server for Arm Assembly.
+---
+--- It supports A32 and A64 assembly and provides hover documentation,
+--- completion, diagnostics, document symbols, go-to-definition, and
+--- semantic highlighting.
+---
+--- ArmLS can be installed from the Arm Assembly Support extension on
+--- Open VSX or the Visual Studio Marketplace.
+---
+--- The internal diagnostics engine is currently alpha quality. Arm
+--- recommends disabling some operand diagnostics by default and using
+--- clang-powered diagnostics when appropriate.
+
+---@type vim.lsp.Config
+return {
+  cmd = { 'armls' },
+  filetypes = { 'asm' },
+  settings = {
+    armls = {
+      diagnostics = {
+        enable = true,
+        disableCategories = {
+          'invalidOperand',
+          'tooManyOperands',
+          'tooFewOperands',
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
Adds a configuration for ArmLS, Arm's language server for A32 and A64 Arm Assembly.

ArmLS is developed by Arm and provides features including hover documentation,
completion, diagnostics, go-to-definition, document symbols, and semantic
highlighting.

Tested locally with Neovim using the standalone ArmLS executable. Verified:

- LSP attachment for `asm` buffers
- semantic highlighting
- hover documentation
- instruction diagnostics

The configuration follows Arm's documented Neovim setup, including the
recommended diagnostic defaults.

Although the GitHub armls from ARM doesn't have 100 stars, it is still used by people as there are:

- Nearly 5,000 installs on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Arm.armls)
- More than 10,000 downloads on [Open VSX](https://open-vsx.org/extension/arm/armls)

### Evidence

[ArmLS GitHub](https://github.com/arm/armls)

[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Arm.armls) 