### PR TITLE
feat: Update TypeScript version in installation instructions

### DIFF
--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -33,6 +33,9 @@
 --- }
 --- ```
 ---
+--- If you also have a `deno.json` or a `deno.jsonc` in your project, the `ts_ls` may not start (depending where the
+--- deno.json is)
+---
 --- Use the `:LspTypescriptSourceAction` command to see "whole file" ("source") code-actions such as:
 --- - organize imports
 --- - remove unused code

--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -9,7 +9,8 @@
 ---
 --- `typescript-language-server` depends on `typescript`. Both packages can be installed via `npm`:
 --- ```sh
---- npm install -g typescript typescript-language-server
+--- npm install -g typescript@<version> typescript-language-server
+--- # if you are using `ts_ls` you will need to install a `typescript` version < 7 for now
 --- ```
 ---
 --- To configure typescript language server, add a

--- a/lsp/ts_ls.lua
+++ b/lsp/ts_ls.lua
@@ -9,8 +9,8 @@
 ---
 --- `typescript-language-server` depends on `typescript`. Both packages can be installed via `npm`:
 --- ```sh
---- npm install -g typescript@<version> typescript-language-server
 --- # if you are using `ts_ls` you will need to install a `typescript` version < 7 for now
+--- npm install -g typescript@<version> typescript-language-server
 --- ```
 ---
 --- To configure typescript language server, add a


### PR DESCRIPTION
Looking at the README from https://www.npmjs.com/package/typescript-language-server

typescript-language-server needs for typescript@6
tsc needs typescript@7