### PR TITLE
fix(util): use vim.uv for fs_stat

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -114,7 +114,7 @@ function M.get_typescript_server_path(root_dir)
   local project_roots = vim.fs.find('node_modules', { path = root_dir, upward = true, limit = math.huge })
   for _, project_root in ipairs(project_roots) do
     local typescript_path = project_root .. '/typescript'
-    local stat = vim.loop.fs_stat(typescript_path)
+    local stat = vim.uv.fs_stat(typescript_path)
     if stat and stat.type == 'directory' then
       return typescript_path .. '/lib'
     end


### PR DESCRIPTION
Problem:

`get_typescript_server_path()` uses the deprecated [`vim.loop` alias](https://neovim.io/doc/user/deprecated/#deprecated-0.10).

Solution:

Use `vim.uv.fs_stat()`, matching the other filesystem calls in `util.lua`.

Testing:

- `nix develop -c make test` (9 tests passed)
- `stylua --check lua/lspconfig/util.lua`
