### PR TITLE
fix(util): replace undefined variable

### DIFF
--- a/lua/lspconfig/util.lua
+++ b/lua/lspconfig/util.lua
@@ -77,7 +77,7 @@ function M.root_markers_with_field(root_files, new_names, field, fname, match_mo
         end)
         :totable()
       if #to_find == 0 then
-        to_find = vim.deepcopy(files)
+        to_find = vim.deepcopy(fields)
         return true
       end
       return false


### PR DESCRIPTION
Problem:
`root_markers_with_field` function uses undefined variable `files`.

Solution:
Replace `files` with `fields`.