### PR TITLE
refactor: move legacy-only code below version check

### DIFF
--- a/plugin/lspconfig.lua
+++ b/plugin/lspconfig.lua
@@ -12,64 +12,6 @@ if vim.fn.has('nvim-0.11') == 0 then
 end
 
 local api, lsp = vim.api, vim.lsp
-local util
-
-local completion_sort = function(items)
-  table.sort(items)
-  return items
-end
-
-local lsp_complete_configured_servers = function(arg)
-  return completion_sort(vim.tbl_filter(function(s)
-    return s:sub(1, #arg) == arg
-  end, util.available_servers()))
-end
-
-local lsp_get_active_clients = function(arg)
-  local clients = vim.tbl_map(function(client)
-    return ('%s'):format(client.name)
-  end, util.get_managed_clients())
-
-  return completion_sort(vim.tbl_filter(function(s)
-    return s:sub(1, #arg) == arg
-  end, clients))
-end
-
----@return vim.lsp.Client[] clients
-local get_clients_from_cmd_args = function(arg)
-  local result = {}
-  local managed_clients = util.get_managed_clients()
-  local clients = {}
-  for _, client in pairs(managed_clients) do
-    clients[client.name] = client
-  end
-
-  local err_msg = ''
-  arg = arg:gsub('[%a-_]+', function(name)
-    if clients[name] then
-      return clients[name].id
-    end
-    err_msg = err_msg .. ('config "%s" not found\n'):format(name)
-    return ''
-  end)
-  for id in (arg or ''):gmatch '(%d+)' do
-    local client = lsp.get_client_by_id(assert(tonumber(id)))
-    if client == nil then
-      err_msg = err_msg .. ('client id "%s" not found\n'):format(id)
-    end
-    result[#result + 1] = client
-  end
-
-  if err_msg ~= '' then
-    vim.notify(('nvim-lspconfig:\n%s'):format(err_msg:sub(1, -2)), vim.log.levels.WARN)
-    return result
-  end
-
-  if #result == 0 then
-    return managed_clients
-  end
-  return result
-end
 
 -- Called from plugin/lspconfig.vim because it requires knowing that the last
 -- script in scriptnames to be executed is lspconfig.
@@ -202,7 +144,64 @@ if vim.fn.has('nvim-0.11.2') == 1 then
   return
 end
 
-util = require('lspconfig.util')
+local util = require('lspconfig.util')
+
+local completion_sort = function(items)
+  table.sort(items)
+  return items
+end
+
+local lsp_complete_configured_servers = function(arg)
+  return completion_sort(vim.tbl_filter(function(s)
+    return s:sub(1, #arg) == arg
+  end, util.available_servers()))
+end
+
+local lsp_get_active_clients = function(arg)
+  local clients = vim.tbl_map(function(client)
+    return ('%s'):format(client.name)
+  end, util.get_managed_clients())
+
+  return completion_sort(vim.tbl_filter(function(s)
+    return s:sub(1, #arg) == arg
+  end, clients))
+end
+
+---@return vim.lsp.Client[] clients
+local get_clients_from_cmd_args = function(arg)
+  local result = {}
+  local managed_clients = util.get_managed_clients()
+  local clients = {}
+  for _, client in pairs(managed_clients) do
+    clients[client.name] = client
+  end
+
+  local err_msg = ''
+  arg = arg:gsub('[%a-_]+', function(name)
+    if clients[name] then
+      return clients[name].id
+    end
+    err_msg = err_msg .. ('config "%s" not found\n'):format(name)
+    return ''
+  end)
+  for id in (arg or ''):gmatch '(%d+)' do
+    local client = lsp.get_client_by_id(assert(tonumber(id)))
+    if client == nil then
+      err_msg = err_msg .. ('client id "%s" not found\n'):format(id)
+    end
+    result[#result + 1] = client
+  end
+
+  if err_msg ~= '' then
+    vim.notify(('nvim-lspconfig:\n%s'):format(err_msg:sub(1, -2)), vim.log.levels.WARN)
+    return result
+  end
+
+  if #result == 0 then
+    return managed_clients
+  end
+  return result
+end
 
 api.nvim_create_user_command('LspStart', function(info)
   local server_name = string.len(info.args) > 0 and info.args or nil


### PR DESCRIPTION
## Problem

`completion_sort`, `lsp_complete_configured_servers`, `lsp_get_active_clients` and `get_clients_from_cmd_args` are only used by the commands registered for Neovim older than 0.11.2, but they are defined above the version check. On newer versions they are created and never used, and `util` has to be forward-declared as a local so those closures can capture it before it is assigned.

## Solution

Move them below the version check, next to the commands that use them.